### PR TITLE
docs(KIN-001): publish planning docs (PRD, SPECS, ARCHITECTURE, COMPLIANCE)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,35 @@
+# Documentation Kinhale
+
+> **Index de la documentation publique du projet Kinhale**
+> Version : 0.1.0 — Date : 2026-04-19
+> Licence : AGPL v3
+
+Bienvenue dans la documentation de **Kinhale**, une application multi-plateforme (web + iOS + Android) open source sous licence AGPL v3 qui permet aux aidants d'un enfant asthmatique de coordonner, tracer et partager les prises de pompes de fond et de secours. Architecture local-first avec partage E2EE zero-knowledge : les données de santé restent chiffrées sur les appareils des utilisateurs.
+
+Cette page liste les documents de cadrage publiques du projet. Le guide général (conventions, structure monorepo, commandes) est dans le fichier `CLAUDE.md` à la racine du dépôt.
+
+## Documents de cadrage
+
+| Document | Description | Chemin |
+|---|---|---|
+| **PRD** (Product Requirements Document) | Vision produit, personas, parcours utilisateurs J1-J7, périmètre fonctionnel v1.0 / v1.1 / v2.0, métriques de succès (OKR) et critères de sortie. | [`product/PRD.md`](./product/PRD.md) |
+| **SPECS** (Spécifications fonctionnelles) | Modèle de données logique, règles métier RM1-RM28, workflows W1-W12, écrans E1-E13, contrats API REST + WebSocket, exigences non fonctionnelles, critères d'acceptation globaux. | [`product/SPECS.md`](./product/SPECS.md) |
+| **ARCHITECTURE** (Architecture technique) | Vision local-first + E2EE zero-knowledge, stack technique (React Native, Next.js, Fastify, PostgreSQL, libsodium, MLS, Automerge), infrastructure AWS ca-central-1, conventions de code, Gitflow, roadmap technique v1.0 (13 semaines). | [`architecture/ARCHITECTURE.md`](./architecture/ARCHITECTURE.md) |
+| **COMPLIANCE** (Cadre de conformité) | Classification des données, cadre réglementaire multi-juridictions (Loi 25, PIPEDA, RGPD, COPPA), principes privacy by design, consentement, hébergement et chiffrement, gouvernance, risques conformité. | [`product/COMPLIANCE.md`](./product/COMPLIANCE.md) |
+
+## À propos de ces documents
+
+- **Public cible** : contributeurs et contributrices, opérateurs d'instances self-hostées, partenaires cliniques et toute personne souhaitant comprendre le projet en profondeur.
+- **Versionnement** : ces documents sont versionnés avec le code source ; toute modification structurante doit passer par une PR et être reflétée dans le changelog du dépôt.
+- **Architecture Decision Records (ADRs)** : les décisions techniques structurantes sont consignées dans `architecture/adr/` (à créer au Sprint 0).
+- **Documentation utilisateur et self-hosting** : voir `user/` (à venir).
+- **Guide de contribution / Gitflow** : voir `contributing/` (à venir).
+
+## Contact
+
+- **Mainteneur principal** : Martial Kaljob — `martial@wonupshop.com`
+- **Sécurité** : signaler toute vulnérabilité à `security@kinhale.health` (voir `SECURITY.md` à venir).
+
+---
+
+*Index publié le 2026-04-19 sous licence AGPL v3.*

--- a/docs/architecture/ARCHITECTURE.md
+++ b/docs/architecture/ARCHITECTURE.md
@@ -1,0 +1,460 @@
+# Architecture technique — Kinhale v1.0
+
+> **Document d'architecture technique**
+> Version : 0.1.0 — Date : 2026-04-19
+> Licence : AGPL v3
+> Description courte : vision local-first + E2EE zero-knowledge, stack technique (React Native, Next.js, Fastify, PostgreSQL, libsodium, MLS, Automerge), infrastructure AWS ca-central-1, conventions et roadmap technique v1.0.
+
+---
+
+## 1. Vision technique globale
+
+Kinhale est une application **local-first, zero-knowledge**. Les données de santé d'un enfant asthmatique (plans, prises, symptômes, rapports) **ne quittent jamais en clair** les appareils des aidants autorisés du foyer. Le backend opéré par Kamez n'est **pas un stockage santé** : c'est un **relais opaque** qui transporte des blobs chiffrés de bout en bout entre les devices d'un même foyer, plus un petit service de comptes et de routage.
+
+```
+                               ┌────────────────────────────────────────┐
+                               │         Services tiers opaques         │
+                               │  APNs / FCM (push titre générique)     │
+                               │  Postmark/SES (magic link, rapport*)   │
+                               │  S3 ca-central-1 (blobs chiffrés)      │
+                               └──────────▲─────────────────────────────┘
+                                          │ TLS 1.3
+                                          │ Aucune donnée santé en clair
+                                          │
+┌─────────────────┐                ┌──────┴──────────────┐                ┌─────────────────┐
+│  Device parent  │                │  Relais Kinhale     │                │  Device aidant  │
+│  (iOS/Android)  │◄──WSS E2EE────►│  (AWS ca-central-1) │◄──WSS E2EE────►│  (garderie,     │
+│                 │                │                     │                │   co-parent…)   │
+│  - SQLite chiff │                │  - Fastify + WS     │                │                 │
+│  - Keychain     │                │  - PostgreSQL       │                │  - SQLite chiff │
+│  - CRDT doc     │                │    (métadonnées)    │                │  - Keychain/KS  │
+│  - Clés X25519  │                │  - S3 blobs opaques │                │  - CRDT doc     │
+│  - Recovery seed│                │  - Redis pub/sub    │                │  - Clés groupe  │
+└────────┬────────┘                │  - Auth magic link  │                └────────┬────────┘
+         │                         │  - Routage mailbox  │                         │
+         │                         └─────────────────────┘                         │
+         │                                                                         │
+         └────────────────── Sync directe LAN (Bonjour/mDNS, v1.1+) ──────────────┘
+
+*Les rapports quittent le device seulement si le parent choisit l'envoi e-mail ; dans ce cas
+ l'e-mail transite chiffré via le fournisseur — payload santé attaché en PDF non-chiffré
+ côté fournisseur. À privilégier : téléchargement local + remise en main propre.
+```
+
+**Invariants architecturaux** :
+
+1. **Aucune donnée santé en clair côté relais** — ni en base, ni dans les logs, ni dans les payloads push, ni dans les metrics Sentry.
+2. **Clé privée par device**, jamais transmise. Authentification des messages par signature Ed25519.
+3. **Clés de groupe par foyer**, distribuées via un protocole d'échange authentifié (MLS ou Double Ratchet), **rotées** à chaque révocation d'aidant.
+4. **Local-first** : chaque device porte une copie complète du document CRDT de son foyer. L'app est fonctionnelle hors-ligne (saisie, lecture 30+ jours, rapport PDF client-side).
+5. **Relais sans état métier santé** : une restauration depuis backup DB du relais ne permet **pas** de reconstruire les données santé d'un foyer, seulement son routage.
+
+---
+
+## 2. Stack technique retenue
+
+### 2.1. Frontend (web + iOS + Android)
+
+**Recommandation : React Native 0.74+ via Expo SDK 52 (bare workflow avec EAS Build) + React Native Web + Next.js 15 pour le wrap SEO-landing.**
+
+| Brique | Choix | Version cible Sprint 0 | Justification |
+|---|---|---|---|
+| Framework cross-platform | **React Native** (bare workflow, EAS Build) | RN 0.74+ / Expo SDK 52+ | Écosystème JS partagé avec le backend TS, librairies crypto (libsodium, noble) matures, portage web natif via React Native Web. Flutter écarté car écosystème crypto Dart moins mature et perte du partage TS/JS avec le backend. Bare workflow (pas Managed) pour intégrer `react-native-libsodium`, `op-sqlite` et modules natifs sensibles. |
+| Wrap web | **Next.js 15 (App Router)** + React Native Web | 15.x | SEO pour la landing + PWA installable pour l'app. SSR utile pour `/privacy`, `/download`, contenus statiques. L'écran app lui-même reste une SPA React Native Web. |
+| State | **Zustand** (état UI local) + **TanStack Query v5** (état réseau / sync) | 5.x / 4.x | Plus léger que Redux Toolkit, aligné avec le caractère événementiel du CRDT. RTK Query écarté car la "source de vérité" est le document CRDT local, pas un cache HTTP. Le CRDT lui-même (Automerge) est la vraie source d'état métier. |
+| Navigation | **React Navigation 7** (native stack + tabs) | 7.x | Standard RN, prend en charge deep links (invitations QR). |
+| Style / design system | **Tamagui** (tokens + variants compilés) | 1.x | Compile-time sur web et natif, aligné avec WCAG (contrast helpers), tokens de couleur mutualisés. Alternative StyleSheet conservée si Tamagui ralentit le build (fallback). |
+| i18n | **i18next + react-i18next** | 23.x | Structure namespace JSON, pluralisation ICU, détection OS. |
+| Accessibilité | APIs RN (`accessibilityRole`, `accessibilityLabel`), audits axe + Lighthouse sur web | — | Voir §7. |
+| Crypto client | **libsodium-wrappers** (web) + **react-native-libsodium** (mobile) | 0.7+ / 1.x | Audité, mêmes primitives que côté backend. Alternative TweetNaCl écartée (moins de primitives, pas d'Argon2id natif). |
+| Stockage local | **op-sqlite** (mobile, bindings SQLCipher) + **IndexedDB** chiffré applicatif (web) | — | op-sqlite plus rapide que expo-sqlite, support SQLCipher natif. |
+| CRDT | **Automerge 2** | 2.2+ | Voir §2.4. |
+| Tests | Jest (unit) + React Native Testing Library + **Maestro** (e2e mobile) + **Playwright** (e2e web) | — | Maestro plus stable qu'e Detox en 2026. |
+
+**Fallback si Sprint 0 invalide Tamagui** : StyleSheet natif + tokens exposés via un petit wrapper `@kinhale/ui`. Coût : légère perte de productivité, acceptée.
+
+### 2.2. Backend (relais zero-knowledge + comptes)
+
+**Recommandation : TypeScript (Node.js 20 LTS) + Fastify 5, mono-service.**
+
+| Brique | Choix | Version cible | Justification |
+|---|---|---|---|
+| Langage / runtime | **TypeScript 5.4+ / Node.js 20 LTS** | — | Cohérence avec le front, vitesse de dev, bibliothèque libsodium identique. Go écarté pour la v1 : gain de perf non justifié à 100-5000 foyers, perte de partage de code (types CRDT, contrats WS). À réévaluer post-v2 si le relais atteint 10 k connexions WS concurrentes. |
+| Framework API | **Fastify 5** | 5.x | Plus performant qu'Express, plugins bien maintenus, schema JSON natif (validation entrée/sortie). NestJS écarté : la surface fonctionnelle du relais est trop mince pour justifier le coût structurel de NestJS. |
+| Temps réel | **Fastify + ws** (WebSocket) + fallback long-poll | — | Socket.io écarté : on n'a pas besoin de rooms/namespaces complexes, on gère nos mailboxes directement. |
+| Pub/sub inter-nœuds | **Redis 7** (AWS ElastiCache) | 7.x | Nécessaire dès qu'on a ≥ 2 nodes WS pour router un message vers la bonne instance. |
+| Base de données métadonnées | **PostgreSQL 16** (AWS RDS multi-AZ) | 16 | **Aucune donnée santé.** Stocke : comptes, devices enregistrés avec clés publiques, mailboxes, métadonnées de messages (timestamp, taille, expiration), invitations, logs d'audit pseudonymisés, consentements. |
+| ORM | **Drizzle ORM** (ou Kysely) | — | Drizzle : types TS natifs, migrations SQL lisibles, pas de magie. Prisma écarté car trop lourd pour le périmètre + génération de client incompatible avec monorepo strict. |
+| Stockage blobs chiffrés | **S3 (ca-central-1)** avec SSE-KMS + lifecycle 90 j | — | Les blobs sont déjà chiffrés côté client ; SSE-KMS en défense en profondeur. Rétention 90 jours par défaut (le device télécharge et ack les messages ; après ack ils sont purgés). |
+| Auth | **Magic link** (JWT courts 15 min + refresh 14 j) + **passkeys WebAuthn** optionnels | — | Pas de mot de passe réutilisable. MFA TOTP optionnelle pour Admin. |
+| Push | **APNs (HTTP/2)** + **FCM v1 API** | — | Payload générique "Nouvelle activité dans votre foyer", jamais de contenu santé. |
+| Email | **Postmark** (transactionnel, DPA signé) | — | Deux usages : magic link + alertes dose manquée en fallback. Jamais de contenu santé dans le corps. SES Canada envisagé si data residency Canada exigée — à trancher Sprint 0. |
+| Observabilité | **CloudWatch Logs + Metrics** + **Sentry** (avec `beforeSend` scrubbing agressif) + **OpenTelemetry** (traces) | — | Sentry reçoit des erreurs JS sans payload métier. Whitelist explicite des champs loggés. |
+
+**Fallback si AWS Native jugé trop lourd en Sprint 0** : **Supabase** (Postgres managé + Auth + Storage) pour le relais. Trade-off : moins de contrôle fin sur les DPA, dépendance plateforme. Réservé au plan B si le délai devient critique. **Recommandation finale : AWS natif** pour la crédibilité long terme et la maîtrise des DPA.
+
+### 2.3. Cryptographie
+
+**Primitives retenues (libsodium partout)** :
+
+| Usage | Algorithme | Librairie |
+|---|---|---|
+| Signature d'événements, authentification device | **Ed25519** | libsodium `crypto_sign_*` |
+| Échange de clés 1:1 | **X25519** | libsodium `crypto_kx_*` |
+| Chiffrement symétrique authentifié (blobs) | **XChaCha20-Poly1305** | libsodium `crypto_secretbox_*` / `aead_xchacha20poly1305_ietf_*` |
+| Dérivation depuis recovery seed | **Argon2id** (m=64 Mio, t=3, p=1) | libsodium `crypto_pwhash` |
+| Génération d'identifiants opaques | `randombytes_buf` 256 bits | libsodium |
+
+**Protocole de groupe (foyer)** :
+
+**Recommandation : MLS (Messaging Layer Security, RFC 9420) via `openmls` (Rust, wrappé en bindings) OU `mls-ts` si la maturité se confirme en Sprint 0.**
+
+MLS est la cible moderne : groupes dynamiques, rotation de clés post-compromission, forward secrecy, standard IETF. Pour Kinhale, un foyer = un groupe MLS, chaque device = un membre, la rotation lors d'une révocation d'aidant est native.
+
+**Fallback si la maturité mobile de MLS est insuffisante à kickoff (bindings React Native non stables, audit externe défavorable)** : **Signal Protocol simplifié** — Double Ratchet 1-to-1 par paire de devices, avec re-keying manuel du groupe à chaque ajout/révocation. Coût UX : léger impact sur les latences d'invitation (< 2 s vs < 500 ms avec MLS).
+
+> **Décision Sprint 0 obligatoire** : PoC MLS sur iOS + Android + Web avec 3 devices + 1 révocation, validé par un auditeur crypto externe avant verrouillage. Si PoC échoue : fallback Double Ratchet, documenté dans un ADR.
+
+**Recovery seed (BIP39, 24 mots, 256 bits d'entropie)** :
+- Générée au premier lancement, **affichée une seule fois**, confirmée mot-à-mot par l'utilisateur.
+- Stockée **uniquement** sur le device (Keychain/Keystore) et en sauvegarde hors-ligne par l'utilisateur (papier, gestionnaire de mots de passe).
+- Permet de : dériver la clé privée du device, déchiffrer le backup cloud opt-in, restaurer sur nouveau device.
+- Jamais transmise au relais — **ligne rouge**.
+
+**Stockage local chiffré** :
+- **iOS** : Keychain Services (via `expo-secure-store`) pour les clés privées ; `op-sqlite` avec clé dérivée Argon2id pour la base SQLite.
+- **Android** : Android Keystore (AES-GCM hardware-backed) pour les clés privées ; `op-sqlite` avec SQLCipher.
+- **Web** : clés privées en IndexedDB chiffrée applicative (XChaCha20-Poly1305, clé dérivée de la passphrase utilisateur déverrouillée en mémoire pour la session). WebCrypto `CryptoKey` non-extractible utilisé pour les opérations runtime.
+
+**Sauvegarde cloud opt-in** :
+- Archive JSON complète chiffrée (XChaCha20-Poly1305, clé dérivée Argon2id depuis la recovery seed).
+- Destinations : iCloud Key-Value / Google Drive App Folder / fichier local exportable.
+- Le relais ne voit **jamais** cette archive.
+
+### 2.4. Synchronisation local-first
+
+**Recommandation : Automerge 2 (format binaire `save`/`load`/`getChanges`).**
+
+| Critère | Automerge 2 | Yjs | Verdict |
+|---|---|---|---|
+| Maturité format binaire | Stable (2.x) | Stable | Égal |
+| Complexité d'un schéma "santé" (listes imbriquées, events append-only avec méta) | Excellente (types riches, JSON-like) | Bonne (mais Y.Map/Y.Array plus bas niveau) | **Automerge** |
+| Incremental sync | `getChanges(since)` efficace | `Y.encodeStateAsUpdate()` | Égal |
+| Binding React Native | `@automerge/automerge` pur JS + WASM (fonctionne RN 0.74+) | `yjs` idem | Égal |
+| Communauté crypto / privacy | Historique fort (Ink & Switch, local-first) | Forte (collaboratif temps réel) | **Automerge** (aligné avec la posture produit) |
+
+**Modèle d'événement** :
+- Un document Automerge par foyer. Contient : liste append-only d'événements signés (`DoseAdministered`, `SymptomReported`, `PumpReplaced`, `PlanUpdated`, `CaregiverInvited`, `CaregiverRevoked`).
+- Chaque événement est **signé Ed25519** par le device émetteur avant insertion dans le doc CRDT.
+- Les entités dérivées (pompes actives, plan en cours, historique) sont **des projections calculées** à la lecture, jamais stockées en tant qu'état concurrent.
+
+**Sync via relais** :
+- Chaque device publie dans sa "mailbox de foyer" les deltas Automerge (`getChanges(since)`), chiffrés avec la clé de groupe MLS.
+- Le relais stocke ces blobs chiffrés dans S3, indexés par `mailbox_id` (= identifiant opaque du groupe MLS) + horodatage + hash.
+- Les autres devices du foyer récupèrent les blobs via WebSocket, les déchiffrent, appliquent `Automerge.applyChanges`.
+- Le relais **n'a jamais la clé de groupe** et ne peut donc pas lire les deltas.
+
+**Résolution de conflits** :
+- Automerge garantit déterminisme → même état final sur tous les devices.
+- Les rares conflits métier sémantiques (ex : deux aidants enregistrent une même prise à 5 s d'écart) sont signalés comme `is_disputed` et remontent dans l'UI pour action humaine (**RM6** des specs).
+
+### 2.5. Infrastructure
+
+**Hébergement : AWS `ca-central-1` (Montréal).**
+
+| Service | Rôle | Dimensionnement v1.0 |
+|---|---|---|
+| **AWS ECS Fargate** | Runtime API Fastify + WS | 2 tasks 0.5 vCPU / 1 Gio RAM, autoscaling sur CPU > 70 % |
+| **Application Load Balancer** | TLS termination, routage `/api` et `/ws` | 1 ALB, listener 443 |
+| **RDS PostgreSQL 16** | Métadonnées | db.t4g.small Multi-AZ, 20 Gio gp3, backups 14 j |
+| **ElastiCache Redis 7** | Pub/sub WS + rate limiting | cache.t4g.micro, 1 node (v1 mono-AZ acceptable) |
+| **S3** | Blobs chiffrés + assets web statiques | Buckets dédiés blobs (lifecycle 90 j) + web |
+| **CloudFront** | CDN web statique + PWA | 1 distribution, certificat ACM |
+| **Route 53** | DNS | Zone hébergée |
+| **Secrets Manager** | Secrets backend (DB url, JWT secrets, APNs key, FCM key) | Rotation 90 j |
+| **KMS** | Clés SSE-S3, SSE-RDS, chiffrement Secrets Manager | 3 CMK, rotation annuelle |
+| **CloudWatch** | Logs + metrics + alarmes | 30 j retention logs app, 90 j logs audit |
+| **AWS WAF** | Rate limiting + OWASP Top 10 rules | Attaché à l'ALB |
+
+**Infra-as-code : AWS CDK (TypeScript)**, cohérence langage repo. Terraform écarté pour limiter le nombre de langages dans la CI.
+
+**Environnements** :
+- `local` : docker-compose (Postgres 16, Redis 7, MinIO pour S3, Mailpit pour email).
+- `dev` : déploiement automatique sur push `develop`.
+- `staging` : déploiement automatique sur merge `release/*`.
+- `prod` : déploiement manuel sur merge `main`, après tag semver.
+
+### 2.6. DevOps / CI/CD
+
+**Monorepo : Turborepo.**
+
+Nx écarté : surcouche plus lourde, moins de valeur sur un monorepo de taille moyenne. Turborepo est suffisant, excellent cache distant (Vercel Remote Cache ou Nx Cloud selon Sprint 0).
+
+**Structure monorepo** :
+
+```
+kinhale/
+├── apps/
+│   ├── mobile/             # React Native (iOS + Android), Expo bare
+│   ├── web/                # Next.js 15 (App Router) + React Native Web
+│   └── api/                # Fastify backend (relais + auth)
+├── packages/
+│   ├── crypto/             # Wrappers libsodium multi-plateforme, primitives MLS
+│   ├── sync/               # Moteur Automerge + protocole mailbox + signature events
+│   ├── domain/             # Entités métier, règles RM1-RM28, types partagés
+│   ├── ui/                 # Design system (Tamagui), tokens, composants RN/RNW
+│   ├── i18n/               # i18next config + locales fr/en
+│   ├── eslint-config/      # ESLint partagé
+│   ├── tsconfig/           # tsconfig.base.json partagé
+│   └── test-utils/         # Helpers de test (fixtures, crypto test vectors)
+├── infra/
+│   ├── cdk/                # AWS CDK stacks
+│   └── docker/             # docker-compose local
+├── docs/
+│   ├── product/            # PRD, specs, compliance (publics)
+│   ├── architecture/       # ADRs + ce document
+│   ├── contributing/       # Guide contributeur, Gitflow
+│   └── user/               # Documentation utilisateur (self-hosting, FAQ)
+├── .github/
+│   └── workflows/          # CI/CD
+├── CLAUDE.md
+├── README.md
+├── LICENSE                 # AGPL v3
+├── package.json
+├── pnpm-workspace.yaml
+├── turbo.json
+└── tsconfig.json
+```
+
+**Package manager : pnpm** (workspaces rapides, store centralisé, strict hoisting).
+
+**CI/CD : GitHub Actions**.
+
+Pipelines :
+- `ci.yml` : déclenché sur toute PR. Étapes : install → lint → typecheck → test unitaire → build.
+- `e2e.yml` : déclenché sur PR ciblant `develop` et `main`. Playwright (web) + Maestro (mobile, via émulateur iOS/Android hébergé sur runner macOS).
+- `release.yml` : déclenché sur tag `v*`. Build + publication TestFlight + Play Internal Testing + déploiement CDN web + déploiement API.
+- `sca.yml` : Snyk + Dependabot + Renovate (quotidien).
+- `sast.yml` : Semgrep (règles OWASP + custom crypto).
+- `dast.yml` : OWASP ZAP baseline scan sur staging (hebdomadaire).
+
+**Release management** :
+- Semver strict (MAJOR.MINOR.PATCH).
+- Tag à chaque merge `release/*` → `main`.
+- Changelog conventionnel (`@changesets/cli`).
+- Builds iOS/Android publiés TestFlight / Play Internal à chaque release candidate.
+
+---
+
+## 3. Conventions de code
+
+### 3.1. TypeScript
+
+- `"strict": true`, `"noUncheckedIndexedAccess": true`, `"exactOptionalPropertyTypes": true`.
+- Pas de `any` implicite. `// @ts-ignore` interdit sans commentaire `// @ts-expect-error <raison>` + ticket associé.
+- Préférer les types discriminés aux unions `string | null` pour les états.
+
+### 3.2. Linting / Formatting
+
+- **ESLint** flat config (`eslint.config.mjs`), `@typescript-eslint`, `eslint-plugin-react`, `eslint-plugin-react-native`, `eslint-plugin-security`, `eslint-plugin-sonarjs`.
+- **Prettier** uniforme (config `@kinhale/prettier-config`).
+- Règle custom : interdire `console.log` hors `packages/test-utils` (on utilise un logger pseudonymisé qui strippe les champs santé).
+
+### 3.3. Commits et PR
+
+- **Conventional commits** (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `security`).
+- `commitlint` + `husky` bloquent les commits non conformes.
+- Template PR obligatoire (`/.github/pull_request_template.md`) : description, risques, tests ajoutés, impact crypto, impact i18n, impact a11y, captures.
+
+### 3.4. Tests
+
+| Niveau | Outil | Cible couverture |
+|---|---|---|
+| Unit backend | **Vitest** | 80 % lignes, 90 % sur `packages/crypto`, `packages/sync`, `packages/domain` |
+| Unit mobile / web | **Jest** + React Native Testing Library | 75 % lignes |
+| E2E mobile | **Maestro** | Parcours J1-J7 des specs |
+| E2E web | **Playwright** | Parcours J1-J7 des specs |
+| Crypto (test vectors) | Vitest + RFC vectors | 100 % des primitives |
+| Chaos / sync | Vitest custom (simule N devices, partitions réseau, réconciliations) | 3 scénarios documentés |
+
+---
+
+## 4. Méthodologie Git — Gitflow
+
+### 4.1. Branches
+
+| Branche | Rôle | Parent | Cible merge |
+|---|---|---|---|
+| `main` | Production. Protégée. Tag semver après chaque release. | — | — |
+| `develop` | Intégration continue. Protégée. Toutes les features convergent ici. | — | — |
+| `feature/<ticket-id>-<kebab-case>` | Nouvelle fonctionnalité (ex : `feature/KIN-142-invite-caregiver-qr`). | `develop` | `develop` |
+| `release/vX.Y.Z` | Stabilisation d'une version : bugfixes, docs, aucun nouveau scope. | `develop` | `main` **et** `develop` |
+| `hotfix/<ticket-id>-<kebab-case>` | Correctif urgent prod. | `main` | `main` **et** `develop` |
+| `support/vX.Y.x` | Maintenance long terme d'une branche antérieure (post-v1.0 si besoin). | tag `main` | `support/*` |
+
+### 4.2. Règles de protection
+
+- **Aucun commit direct** sur `main` ni `develop` (branch protection GitHub).
+- **Au moins 1 review** approuvée avant merge.
+- **CI verte obligatoire** (lint + typecheck + test + build).
+- **Linear history** forcée sur `main` (`require linear history`).
+- **Signatures commits** GPG/SSH exigées (vérif activée).
+- **Merge via squash** sur `feature/*` → `develop`, merge-commit sur `release/*` → `main` (préserve la traçabilité).
+- **PRs couvrant > 400 lignes modifiées** : justification écrite ou découpage.
+
+### 4.3. Workflow de release
+
+1. Quand `develop` est stable et contient le scope cible, créer `release/vX.Y.Z`.
+2. Bugfixes + bump version + changelog sur la branche release.
+3. Merge `release/vX.Y.Z` → `main`, tag `vX.Y.Z`, déclenche `release.yml`.
+4. Merge `release/vX.Y.Z` → `develop` pour récupérer les bugfixes.
+5. Suppression de la branche release.
+
+### 4.4. Workflow de hotfix
+
+1. Créer `hotfix/<ticket>-<desc>` depuis `main`.
+2. Fix + test + bump patch.
+3. Merge → `main` + tag `vX.Y.Z+1`.
+4. Merge → `develop`.
+
+---
+
+## 5. Sécurité & durcissement
+
+Référence intégrale : `../product/COMPLIANCE.md`. Synthèse opérationnelle :
+
+- **Chiffrement E2EE par défaut** sur toutes les données santé (aucune exception).
+- **Payload push opaque** : `{title: "Kinhale", body: "Nouvelle activité"}`. Jamais de prénom enfant, jamais de symptôme, jamais de type de pompe.
+- **Scrubbing Sentry agressif** via `beforeSend` : whitelist de clés autorisées, rejet de tout objet contenant un champ parmi `{firstName, symptoms, doseId, pumpName, notes}`.
+- **SCA** : Snyk + Dependabot + Renovate (quotidien).
+- **SAST** : Semgrep (OWASP ruleset + custom crypto : détection de `Math.random`, `crypto-js`, constantes de temps non-constant).
+- **DAST** : OWASP ZAP baseline hebdomadaire sur staging.
+- **Pen-test externe** avant lancement public.
+- **Audit crypto externe** : cabinet indépendant, revue du design MLS/Double Ratchet + implémentation.
+- **Détection root/jailbreak** : warning UX, pas de blocage (maintient l'accessibilité pour parents non techniques).
+- **Rate limiting API** : 100 req/min par IP + 30 req/min par compte sur endpoints sensibles (invite, revoke, magic link request).
+- **Protections** : CSRF (SameSite=Strict + double submit cookie côté web), XSS (Content-Security-Policy strict, no `unsafe-inline`), SSRF (allow-list outbound), clickjacking (`X-Frame-Options: DENY`).
+- **Certificate pinning mobile** : ancre publique Let's Encrypt + backup pin, rotation trimestrielle.
+- **Secrets** : AWS Secrets Manager, rotation 90 j, jamais dans le repo (hook gitleaks pré-commit + CI).
+
+---
+
+## 6. Internationalisation (i18n)
+
+### 6.1. Langues v1.0
+
+**FR (Canada, défaut)** et **EN** à la sortie. Structure prête pour **ES** et **DE** en v1.1+ (clés déjà namespacées).
+
+### 6.2. Structure
+
+```
+packages/i18n/
+├── src/
+│   ├── index.ts              # export du client i18next configuré
+│   ├── detector.ts           # détection OS + override paramètres utilisateur
+│   └── formatters.ts         # dates, heures, nombres via Intl
+└── locales/
+    ├── fr/
+    │   ├── common.json
+    │   ├── onboarding.json
+    │   ├── doses.json
+    │   ├── reminders.json
+    │   ├── reports.json
+    │   ├── caregivers.json
+    │   ├── errors.json
+    │   └── legal.json
+    └── en/
+        └── (même structure)
+```
+
+### 6.3. Règles
+
+- **Aucune chaîne hardcodée** en code applicatif (règle ESLint `i18next/no-literal-string` activée sur `apps/`).
+- Clés en **kebab-case**, namespace explicite (`doses:record-dose-button`).
+- **ICU MessageFormat** pour pluriels (`{count, plural, one {# prise} other {# prises}}`).
+- **Détection** : OS → `i18next-browser-languagedetector` (web) / `expo-localization` (mobile). Override utilisateur persisté.
+- **Formatage** : `Intl.DateTimeFormat`, `Intl.NumberFormat`, avec fallback `date-fns` locales pour formats relatifs (« il y a 3 h »).
+- **Expansion EN → FR** : design prévoit +30 % de largeur (FR verbeux). Tests snapshot visuels sur les deux locales.
+- **Gestion des clés manquantes** : fallback EN, log warn-level (sans remonter à Sentry en prod).
+
+---
+
+## 7. Accessibilité WCAG 2.1 AA
+
+### 7.1. Exigences structurantes
+
+| Critère WCAG | Mise en œuvre Kinhale |
+|---|---|
+| 1.4.3 Contrast (Minimum) | Tokens couleur Tamagui validés par Lighthouse + axe ; ratio ≥ 4.5:1 pour texte, 3:1 pour composants UI. |
+| 1.4.4 Resize text | Support Dynamic Type iOS + `fontScale` Android + tailles em sur web. Aucune coupe au-delà de 200 %. |
+| 1.4.11 Non-text contrast | Boutons et focus visibles avec ratio ≥ 3:1. |
+| 2.1.1 Keyboard | Navigation clavier complète web (Tab, Shift+Tab, Enter, Escape). Focus trap dans les modales. |
+| 2.4.3 Focus order | Ordre DOM aligné sur ordre visuel, testé. |
+| 2.4.7 Focus visible | Anneau de focus custom 2 px contrasté. |
+| 2.5.5 Target size | Tous les touch targets ≥ 44×44 pt. |
+| 3.1.2 Language of parts | Attribut `lang` ajusté dynamiquement. |
+| 4.1.2 Name, Role, Value | `accessibilityRole`, `accessibilityLabel`, `accessibilityState` systématiques sur composants interactifs. |
+
+### 7.2. Code couleur doublé d'une sémantique non-visuelle
+
+Chaque couleur porte **aussi un pictogramme + un texte alternatif** :
+- Bleu/vert "fond" → icône shield + label "Traitement de fond".
+- Rouge/orange "secours" → icône bolt + label "Secours".
+- Jaune/ambre "alerte" → icône warning + label "Attention".
+- Gris "historique passif" → icône clock + label "Dose manquée" ou "Passée".
+
+### 7.3. Tests
+
+- **axe-core** en CI sur Playwright (web, échec si critiques HAUTS).
+- **Lighthouse** CI : score a11y ≥ 95.
+- **Manuels** : VoiceOver (iOS) + TalkBack (Android) + NVDA (Windows) sur parcours J1, J2, J3, J5 à chaque release candidate.
+
+---
+
+## 8. Décisions à trancher en Sprint 0 (ADRs)
+
+| # | Décision | Option recommandée | Alternative (fallback) | Critère de choix |
+|---|---|---|---|---|
+| D1 | React Native workflow | **Bare + EAS Build** | Managed | Les modules crypto natifs (`react-native-libsodium`, `op-sqlite`) imposent bare. Confirmer compatibilité Expo SDK 52. |
+| D2 | Moteur CRDT | **Automerge 2** | Yjs | Bench local de sync 10 devices × 1000 events : latence médiane < 100 ms. |
+| D3 | Protocole de groupe | **MLS (openmls)** | Double Ratchet par paires | PoC 3 devices + 1 révocation sur iOS + Android + Web. Validation crypto externe préliminaire. |
+| D4 | Hébergement relais | **AWS natif (CDK)** | Supabase | Confirmer DPA AWS signé + région ca-central-1 active. |
+| D5 | Monorepo tooling | **Turborepo** | Nx | Bench cache remote sur le repo initial. |
+| D6 | Wrap web | **Next.js 15 + RN Web** | Vite SPA pure | SEO landing + PWA installable : Next.js gagne. Vérifier que RN Web + Next.js App Router compile sans friction. |
+| D7 | Design system | **Tamagui** | StyleSheet + tokens custom | Bench de build iOS/Android < 5 min. Si Tamagui ralentit, fallback. |
+| D8 | Email transactionnel | **Postmark** | SES ca-central-1 | Trancher sur la clause de data residency Canada. |
+
+**Livrable Sprint 0** : **8 ADRs signés** (Architecture Decision Records) couvrant D1-D8, dans `docs/architecture/adr/`.
+
+---
+
+## 9. Points à confirmer avec la revue sécurité avant Sprint 1
+
+1. **Protocole de groupe** : validation du choix MLS vs Double Ratchet, y compris posture en cas d'ajout simultané de deux aidants.
+2. **Schéma de recovery seed** : 12 vs 24 mots, politique de dérivation Argon2id (paramètres m/t/p cibles acceptables).
+3. **Modèle de menace** : validation de la surface attaquante (device compromis, relais compromis, employé opérateur malveillant, autorité judiciaire).
+4. **Stratégie de certificate pinning** : ancre + backup, procédure de rotation d'urgence.
+5. **Politique de logs** : whitelist explicite des champs loggés côté backend, procédure de scrubbing Sentry, audit des 10 premiers loggers du repo à la revue.
+6. **Détection root/jailbreak** : warning-only vs blocage paramétrable.
+7. **Procédure d'audit crypto externe** : scope (design + implémentation), choix du cabinet.
+
+---
+
+## 10. Roadmap technique v1.0 (13 semaines)
+
+Focus technique. Le découpage sprint par sprint donne une vision claire de la progression.
+
+| Sprint | Semaines | Livrables techniques clés |
+|---|---|---|
+| **Sprint 0** | S0 (1 sem) | ADRs D1-D8 signés ; POC MLS + Automerge 3 devices ; CI/CD minimale verte ; docker-compose local ; skeleton monorepo Turborepo ; design tokens Tamagui ; kickoff juriste + auditeur crypto. |
+| **Sprint 1** | S1-S2 | Backend auth magic link + devices + mailboxes ; génération clé X25519/Ed25519 device ; recovery seed BIP39 (génération, confirmation, restauration sur 2e device) ; stockage local chiffré Keychain/Keystore/IndexedDB ; onboarding J1 < 2 min. |
+| **Sprint 2** | S3-S4 | Modèle domaine Enfant/Pompe/Plan ; invitation aidant QR+PIN + échange MLS ; révocation avec rotation de clé de groupe ; design system composants de base ; i18n FR/EN wired. |
+| **Sprint 3** | S5-S6 | Saisie prise fond/secours (J2, J3) ; stockage Automerge local chiffré ; idempotence offline ; file de sortie chiffrée ; rattrapage 24 h ; voiding. |
+| **Sprint 4** | S7-S8 | Sync E2EE via relais (WS + S3 blobs) ; APNs + FCM avec payload opaque ; rappels planifiés (push + local + e-mail fallback) ; détection dose manquée (J4). |
+| **Sprint 5** | S9-S10 | Notifications croisées multi-aidants ; mode offline complet 30 j ; résolution CRDT conflits (J7) ; 2 rôles aidants finalisés ; tests chaos (partitions réseau, multi-device). |
+| **Sprint 6** | S11-S12 | Rapport PDF client-side (1-2 pages) + CSV ; conformité (consentement, droits, export, suppression) ; audit crypto externe + retest ; pen-test externe + retest ; validation pneumo-pédiatre ; publication dépôt public AGPL v3 ; guide self-hosting ; dépôt TestFlight + Play Internal + soumission App Store / Play Store. |
+| **Semaine 13** | S13 | Slack : Apple Review + Go-live + annonce open source. |
+
+---
+
+*Fin de l'architecture technique Kinhale v1.0 — document publié sous AGPL v3.*

--- a/docs/product/COMPLIANCE.md
+++ b/docs/product/COMPLIANCE.md
@@ -1,0 +1,327 @@
+# Cadre de conformité — Kinhale v1.0
+
+> **Document de cadre réglementaire et conformité**
+> Version : 0.1.0 — Date : 2026-04-19
+> Licence : AGPL v3
+> Description courte : classification des données, cadre réglementaire (Loi 25, PIPEDA, RGPD, COPPA), principes privacy by design, consentement, hébergement, gouvernance et risques conformité pour la v1.0 de Kinhale.
+
+---
+
+## Préambule
+
+Kinhale manipule **les données les plus sensibles qui existent** : des données de santé concernant un **mineur**. Cette combinaison fait basculer le projet dans la catégorie réglementaire la plus contraignante dans toutes les juridictions visées (Québec, Canada fédéral, Union européenne, États-Unis). Le statut **non dispositif médical** (journal + rappel + partage, sans recommandation thérapeutique) reste la ligne rouge structurante : toute dérive replace le produit dans un régime de certification CE / Santé Canada incompatible avec le délai v1.0.
+
+Le présent cadre hiérarchise les exigences **bloquantes pour le lancement v1.0** (ne peut pas sortir sans) des exigences v1.1 / v2.0 (améliorations post-lancement acceptables).
+
+---
+
+## 1. Classification des données
+
+### 1.1. Types de données collectées en v1.0
+
+| Catégorie | Données | Classification RGPD / Loi 25 |
+|---|---|---|
+| **Identité enfant** | Prénom, âge ou année de naissance, éventuel surnom | Donnée identifiante **+ mineur** |
+| **Santé enfant** | Nom de la pompe de fond, posologie prescrite, nom de la pompe de secours, horodatages de prises, symptômes (toux, sifflement, essoufflement…), circonstances (effort, allergène, infection, nuit), commentaires libres | **Données de santé sensibles (art. 9 RGPD / renseignement de santé Loi 25)** |
+| **Identité aidants** | E-mail, prénom, rôle (Admin / Contributeur / Contributeur restreint), appareil, consentement horodaté | Donnée identifiante |
+| **Métadonnées techniques** | Identifiant foyer, identifiants appareil (token push APNs/FCM), logs d'audit (connexions, exports, invitations), crash reports | Donnée technique + pseudonyme |
+| **Données dérivées** | Compteur de doses, niveau estimé de la pompe, statuts « dose manquée », historique agrégé | Donnée de santé (dérivée) |
+
+**Hors-périmètre explicite (jamais collecté v1)** : géolocalisation par défaut, biométrie, données bancaires, photos/vidéos, messagerie avec professionnel, ordonnances scannées.
+
+### 1.2. Cartographie data-flow
+
+```
+[Saisie par aidant sur device]
+   ├─ Stockage local chiffré (Keychain iOS / Android Keystore / IndexedDB chiffré web)
+   └─ File d'attente de sync (si hors-ligne)
+        ↓ TLS 1.3, charge utile E2EE (relais ne voit que des blobs chiffrés)
+[Backend Canada — ca-central-1]
+   ├─ Base de métadonnées chiffrée au repos (AES-256) — AUCUNE donnée santé
+   ├─ Stockage blobs chiffrés (S3, lifecycle 90 j)
+   ├─ Audit log (qui a lu/écrit/exporté quoi, horodaté, pseudonymisé)
+   ├─ Backups chiffrés (rétention définie §5)
+   └─ Diffusion temps réel aux autres aidants du foyer (WebSocket) — blobs opaques
+        ↓ push token
+[APNs / FCM] — notification minimale, aucun contenu santé dans le payload
+        ↓ optionnel
+[Export PDF / CSV généré côté client → téléchargé par l'aidant → remis au médecin en local]
+        ↓
+[Suppression en self-service] → purge complète sous 30 jours
+```
+
+**Principe clé** : aucune donnée de santé ne transite en clair par un service tiers. Les serveurs de Kinhale eux-mêmes ne voient **jamais** les données santé en clair (architecture E2EE zero-knowledge — voir `../architecture/ARCHITECTURE.md`). APNs/FCM reçoivent uniquement un identifiant opaque + un titre générique type « Rappel ».
+
+### 1.3. Flux transfrontières
+
+- **Par défaut** : données résidentes au Canada (ca-central-1) sous forme de métadonnées chiffrées et de blobs chiffrés opaques.
+- **Exception structurelle** : APNs (Apple, US) et FCM (Google, US) pour les notifications push — **aucun contenu santé** dans le payload, uniquement un identifiant opaque et un titre générique.
+- **Exception à venir** : Postmark / SES ou équivalent pour les e-mails transactionnels (magic link, rapports envoyés) — fournisseur à choisir parmi ceux offrant une région de traitement Canada ou UE + DPA signé.
+
+---
+
+## 2. Cadre réglementaire applicable
+
+### 2.1. Loi 25 (Québec) — **applicable par défaut** (hébergement Canada + fondateur québécois)
+
+**Exigences structurantes v1.0 (bloquantes)** :
+
+- **Responsable de la protection des renseignements personnels (RPRP)** : nomination obligatoire. Nom et coordonnées publiés dans la politique de confidentialité et sur une page `/privacy-officer`.
+- **Évaluation des facteurs relatifs à la vie privée (ÉFVP)** : document formel obligatoire avant mise en production (équivalent DPIA RGPD). Livrable concret : un fichier `EFVP-v1.0.md` versionné, revu annuellement.
+- **Registre des incidents de confidentialité** : tenir un journal horodaté de tout incident, même sans notification. Template à livrer.
+- **Droits renforcés** : accès, rectification, effacement, **portabilité** (exports CSV + PDF déjà prévus dans le PRD — conforme), retrait du consentement.
+- **Consentement explicite et granulaire** : cases non pré-cochées, distinction données obligatoires (identité enfant, prises) vs optionnelles (e-mail pour rapports, crash reports anonymisés).
+- **Notification à la Commission d'accès à l'information (CAI)** en cas d'incident présentant un **risque de préjudice sérieux** : délai « dans les meilleurs délais », notification à la personne concernée également.
+- **Minimisation** : ne collecter que le strict nécessaire. **Action technique** : la date de naissance complète n'est pas nécessaire, l'année suffit pour la posologie.
+
+### 2.2. PIPEDA (Canada fédéral)
+
+- Consentement éclairé (couvert par 2.1).
+- Accès, correction, retrait (couvert par 2.1).
+- Notification d'atteinte au **Commissariat à la protection de la vie privée du Canada** si risque réel de préjudice grave, et aux personnes concernées.
+- Responsabilité de bout en bout y compris pour les sous-traitants (AWS, Postmark, APNs, FCM) → **DPA (Data Processing Agreement) signés avec chacun**.
+
+### 2.3. RGPD (UE) — **applicable dès qu'un utilisateur européen utilise l'app**
+
+Le code étant open source et l'instance officielle accessible mondialement, un utilisateur français peut s'inscrire dès J1. Le RGPD s'applique alors à l'instance officielle Kinhale.
+
+- **Base légale** : **art. 6.1.a (consentement)** combiné à **art. 9.2.a (consentement explicite pour données de santé)**. Pas de base légale « intérêt légitime » possible sur données de santé d'un mineur.
+- **Consentement parental (art. 8)** : vérifier que le consentant est bien le titulaire de l'autorité parentale. **Action technique** : case dédiée « Je déclare être le parent ou le titulaire de l'autorité parentale de [prénom enfant] », horodatée, version CGU/PC capturée.
+- **DPIA / AIPD obligatoire** : données de santé + mineur + traitement à grande échelle potentiel → seuil de risque élevé atteint (art. 35 RGPD). **Livrable bloquant v1.0**.
+- **Droits** : accès, rectification, effacement, **portabilité (art. 20)**, opposition (art. 21), limitation (art. 18). Délai de réponse **≤ 1 mois** (extensible 2 mois si complexité).
+- **DPO (Délégué à la Protection des Données)** : **non strictement obligatoire** (l'opérateur n'est pas une autorité publique et le traitement ne rentre pas formellement dans les seuils art. 37), mais **fortement recommandé** vu la sensibilité. Option possible : **DPO externe mutualisé** à temps partiel.
+- **Transferts hors UE** : les utilisateurs UE verront leurs données hébergées au Canada. Le Canada bénéficie d'une **décision d'adéquation partielle** de la Commission européenne (pour le secteur privé couvert par PIPEDA). Cette adéquation couvre l'instance officielle **à condition que PIPEDA soit respectée** — ce qui est le cas. **Action v1.0** : documenter explicitement dans la politique de confidentialité que l'hébergement est au Canada sous décision d'adéquation. **Pour APNs/FCM/Postmark (US)** : ajouter des **clauses contractuelles types (SCC) + mesures supplémentaires** (aucun contenu santé dans les payloads, chiffrement bout-en-bout des e-mails sensibles).
+- **Registre des activités de traitement (art. 30)** : obligatoire. Livrable concret : un fichier `RAT-v1.0.md` versionné.
+- **Notification d'incident** : **72h** à l'autorité de contrôle compétente (CNIL pour la France) en cas de risque pour les personnes concernées.
+
+### 2.4. COPPA (US) — applicable si utilisateurs US <13 ans
+
+Dès lors que l'instance officielle est accessible depuis les US et que le produit cible explicitement les enfants, COPPA peut s'appliquer.
+
+- **Consentement parental vérifiable renforcé** : pas uniquement une case à cocher, mais une méthode vérifiable (credit card auth, signature numérique, e-mail double opt-in avec lettre d'information). **Action v1.0** : double opt-in par e-mail suffit pour une interprétation conservatrice.
+- **Collecte minimale** : COPPA est encore plus strict que le RGPD sur le principe de minimisation pour les moins de 13 ans. Le périmètre actuel est compatible.
+- **Politique de confidentialité dédiée** : section spécifique « Children's Privacy » obligatoire, divulgation claire des données collectées et des destinataires.
+- **Safe Harbor** : adhérer à un programme COPPA Safe Harbor (ex : kidSAFE, iKeepSafe) n'est pas obligatoire mais renforce la crédibilité si traction US.
+
+**Recommandation v1.0** : traiter COPPA comme **v1.1 bloquant pour le marché US**. En v1.0, afficher un disclaimer d'inscription pour les utilisateurs US (« Ce service s'adresse aux familles résidant au Canada et dans l'UE ; l'inscription depuis les US n'est pas encore formellement supportée »).
+
+### 2.5. HIPAA (US)
+
+**Hors champ v1.0**. L'opérateur n'est ni un *Covered Entity* ni un *Business Associate* au sens HIPAA (pas de relation contractuelle avec un assureur santé, hôpital, ou professionnel de santé américain). À rouvrir en **v2.0** si partenariat clinique US (portail pro B2B).
+
+---
+
+## 3. Principes transverses — Privacy by Design & by Default
+
+| Principe | Action technique v1.0 | Criticité |
+|---|---|---|
+| Minimisation | Année de naissance (pas DDN complète), symptômes via grille pré-définie (pas de texte libre obligatoire), e-mail uniquement pour magic link + rapports | **Bloquant** |
+| Chiffrement au repos | AES-256 sur disques DB + backups + logs + stockage local device | **Bloquant** |
+| Chiffrement en transit | TLS 1.3 partout, HSTS, pinning optionnel sur mobile | **Bloquant** |
+| E2EE zero-knowledge | Données santé chiffrées de bout en bout entre devices ; relais ne voit jamais le contenu en clair | **Bloquant** |
+| Pseudonymisation | Identifiant enfant = UUID opaque en base, prénom jamais en base relais, jamais dans les logs techniques | **Bloquant** |
+| Séparation logique par foyer | Multi-tenant strict : chaque requête backend filtre par `household_id` du token ; tests automatisés anti-IDOR | **Bloquant** |
+| Rétention limitée | **5 ans post-dernière activité** du foyer pour l'historique médical, puis purge automatique. Alternative : l'utilisateur peut demander une purge anticipée à tout moment. | **Bloquant** |
+| Suppression de compte | Bouton « Supprimer mon foyer » en self-service, purge complète sous **30 jours max** (délai technique pour purge des backups rotatifs) | **Bloquant** |
+| Audit trail | Log horodaté de tout accès/export/modification sur données sensibles, rétention 1 an, accès réservé RPRP | **Bloquant** |
+| Pseudonymisation dans les notifications push | Payload APNs/FCM = `{title: "Kinhale", body: "Nouvelle activité"}`, aucun contenu santé | **Bloquant** |
+
+---
+
+## 4. Consentement
+
+### 4.1. Qui consent
+
+- **Parent titulaire de l'autorité parentale** — déclaration explicite à la création du foyer.
+- **Aidant secondaire invité** (co-parent, grand-parent, garderie) : consent pour **ses propres données** (e-mail, rôle, horodatages de ses saisies) lors de l'acceptation de l'invitation. **Ne consent pas** pour l'enfant — mandat implicite du parent référent dans le cadre de l'administration des soins, sans partage de données hors périmètre du foyer.
+
+### 4.2. Comment
+
+- **Écran dédié à la création du foyer**, pas un simple « J'accepte les CGU ».
+- **Cases non pré-cochées** — séparation claire entre :
+  - **Obligatoire** : traitement des données de santé de l'enfant pour l'usage de l'app (art. 9.2.a RGPD).
+  - **Optionnel** : crash reports anonymisés pour améliorer le service, envoi d'un e-mail de rappel en cas de dose manquée, inscription à une future newsletter produit.
+- **Granularité** : chaque finalité a sa propre case.
+
+### 4.3. Preuve et traçabilité
+
+- Horodatage du consentement (ISO 8601, UTC).
+- Version des CGU et de la politique de confidentialité (hash SHA-256) acceptée, stockée en base.
+- IP + user-agent conservés pour la preuve (24 mois max).
+- **Action technique** : table `consent_log` en base, jamais purgée même en cas de suppression du foyer (conservée en pseudonyme pour preuve légale).
+
+### 4.4. Retrait du consentement
+
+- Possible à tout moment depuis les paramètres du foyer.
+- Retrait = suppression effective sous 30 jours (sauf obligations légales de conservation, aucune connue en v1).
+- Les aidants secondaires peuvent quitter le foyer, leurs saisies passées restent attribuées (pseudonymisées si compte supprimé).
+
+---
+
+## 5. Hébergement & infrastructure
+
+### 5.1. Région principale
+
+- **Canada — ca-central-1 (AWS Montréal)**. Justification : Loi 25 + PIPEDA + proximité du fondateur + décision d'adéquation UE applicable.
+- **Souveraineté des données** : aucune réplication automatique hors Canada en v1.0.
+
+### 5.2. Multi-région (v2+)
+
+- Déploiement UE (eu-west-1 ou eu-central-1) si traction européenne > 1 000 foyers — évite les débats sur l'adéquation, améliore la latence.
+- Pas de déploiement US en v1 / v1.1 tant que COPPA n'est pas traité formellement.
+
+### 5.3. Chiffrement
+
+- **Disques** : chiffrement natif EBS avec clés gérées par KMS.
+- **Base de données** : chiffrement au repos (AES-256) + TLS en transit. **À noter** : dans le modèle E2EE zero-knowledge retenu, la base ne contient **pas** de données santé en clair (voir `../architecture/ARCHITECTURE.md`).
+- **Backups** : chiffrés, rétention **30 jours** pour snapshots journaliers + **1 an** pour snapshots mensuels. Test de restauration **trimestriel**.
+- **Logs** : chiffrés, anonymisés côté application (aucun prénom enfant, aucun symptôme en clair dans les logs).
+
+### 5.4. Gestion des clés (KMS)
+
+- Rotation annuelle des clés de chiffrement applicatif.
+- Séparation des rôles : aucun développeur n'a accès simultané aux clés et aux données.
+- Clés root dans un HSM managé (AWS KMS avec CMK).
+- **Clés santé (E2EE)** : détenues exclusivement par les devices des aidants du foyer. Le relais ne possède **aucune clé** permettant de déchiffrer les données santé.
+
+### 5.5. Journalisation
+
+| Type de log | Quoi | Rétention | Accès |
+|---|---|---|---|
+| Audit sécurité | Connexions, échecs d'auth, exports, invitations, suppressions | 12 mois | RPRP + équipe sécurité |
+| Technique | Erreurs, latences, santé infra (sans PII) | 90 jours | Équipe dev |
+| Accès données sensibles | Toute lecture/écriture sur mailbox de foyer (métadonnées uniquement, jamais le contenu chiffré déchiffré) | 12 mois | RPRP |
+| Consentement | Horodatage + version CGU acceptée | Indéfini (preuve) | RPRP |
+
+---
+
+## 6. Cas spécial open source
+
+- **Code public** → **aucun secret hardcodé**. Secrets via variables d'environnement + gestionnaire (AWS Secrets Manager, ou équivalent). Hook pré-commit + scan CI (gitleaks).
+- **Audit continu des dépendances** : SCA (Software Composition Analysis) obligatoire en CI (Dependabot + Snyk ou équivalent).
+- **Licence retenue** : **AGPL v3** — protège contre le fork commercial propriétaire (tout hébergeur d'une version modifiée doit publier son code). Cohérente avec l'esprit « outil de santé public, non capturé par un éditeur commercial ».
+- **Documentation de self-hosting** : clause explicite dans le README et les CGU de l'instance officielle : *« Kamez héberge l'instance officielle de Kinhale. Toute instance tierce auto-hébergée est sous la responsabilité exclusive de son opérateur. Kamez ne peut être tenu responsable d'une mauvaise configuration de sécurité ou d'un non-respect des obligations réglementaires par un opérateur tiers. »*
+- **Instance officielle = Responsable du traitement (controller)**. Clairement affiché dans la politique de confidentialité et l'onboarding.
+
+---
+
+## 7. Politique de confidentialité & CGU — plan de rédaction
+
+Livrables v1.0 bloquants : **politique de confidentialité**, **CGU**, **mentions légales**, **section COPPA-ready** (activable v1.1).
+
+Sections minimales obligatoires :
+
+1. **Identité du responsable de traitement** — raison sociale, adresse, e-mail RPRP.
+2. **Finalités du traitement** — suivi santé enfant, coordination aidants, rappels, génération de rapports, amélioration du service (opt-in).
+3. **Données collectées** — liste exhaustive (cf. §1.1).
+4. **Base légale** — art. 6.1.a + art. 9.2.a RGPD / consentement explicite Loi 25.
+5. **Destinataires** — aucun tiers en v1 ; sous-traitants techniques (AWS, Postmark, APNs/FCM) listés nommément.
+6. **Durée de conservation** — 5 ans post-dernière activité, 30 jours max après suppression.
+7. **Droits utilisateurs** — accès, rectification, effacement, portabilité, opposition, limitation ; modalités d'exercice (e-mail RPRP + bouton in-app).
+8. **Mesures de sécurité** — chiffrement, pseudonymisation, E2EE, audit (synthèse).
+9. **Transferts internationaux** — Canada (décision d'adéquation UE) + exceptions push/e-mail avec SCC.
+10. **Modifications de la politique** — notification in-app + e-mail, nouveau consentement requis si changement substantiel.
+11. **Contact RPRP / DPO** — e-mail dédié, délai de réponse 30 jours.
+12. **Section enfants / COPPA** (v1.1 si ouverture US).
+
+**Recommandation forte** : faire réviser la rédaction par un **juriste externe spécialisé protection des données santé**.
+
+---
+
+## 8. Mesures de sécurité exigibles
+
+Alignement avec **OWASP MASVS** (mobile), **OWASP ASVS** niveau 2 (web/backend).
+
+**Bloquantes v1.0** :
+- Authentification par magic link (pas de mot de passe réutilisable), **MFA optionnelle** (TOTP), **passkeys** recommandés dès que la plateforme le permet.
+- Sessions : tokens JWT courts (15 min) + refresh token révocable, rotation obligatoire, révocation centralisée (logout = invalidation backend).
+- Protection **OWASP Top 10** backend + **MASVS** mobile.
+- Stockage sécurisé sur device : Keychain iOS, Android Keystore, IndexedDB + Web Crypto API sur web.
+- Détection jailbreak/root **non bloquante** (avertissement utilisateur, log d'audit) — bloquer rend l'app inutilisable sur des téléphones parents non-techniques.
+- **CI/CD** : SAST (Semgrep / CodeQL), SCA (Snyk / Dependabot), DAST (OWASP ZAP en recette) — bloqueurs de merge sur criticité haute.
+- **Plan de réponse aux incidents** documenté (runbook : détection → confinement → notification RPRP → notification autorités <72h → notification utilisateurs → post-mortem).
+- **Pen-test externe avant lancement public** — recommandé.
+- **Audit crypto externe** du design MLS / Double Ratchet et de son implémentation.
+
+**Reportables v1.1 / v2.0** :
+- Certification ISO 27001 (v2+).
+- Bug bounty public (v2+).
+- Attestation SOC 2 (uniquement si demande B2B cliniques).
+
+---
+
+## 9. Gouvernance & processus
+
+Livrables concrets à produire **avant lancement v1.0** :
+
+| Livrable | Format | Responsable | Bloquant v1 ? |
+|---|---|---|---|
+| **Registre des activités de traitement (RAT)** | `.md` versionné dans le dépôt privé | RPRP | **Oui** |
+| **Registre des incidents** | Tableau + procédure d'alimentation | RPRP | Oui (vide au démarrage, structure prête) |
+| **ÉFVP / DPIA** | `.md` versionné, signé par le RPRP | RPRP + juriste externe | **Oui** |
+| **Nomination RPRP** | Lettre officielle, publication in-app | Opérateur | **Oui** |
+| **Procédure demande d'exercice des droits** | SLA utilisateur ≤ 30 jours, formulaire dédié | RPRP | **Oui** |
+| **DPA sous-traitants** | AWS, Postmark, APNs (Apple), FCM (Google) | Opérateur | **Oui** |
+| **Plan de réponse aux incidents** | Runbook `.md` | RPRP + lead dev | **Oui** |
+| **Audit annuel conformité** | Revue à date anniversaire | RPRP | v1.1 |
+
+---
+
+## 10. Impact sur les délais v1.0
+
+Les tâches de conformité sont intégrées à la roadmap technique (voir `../architecture/ARCHITECTURE.md` §10). Points saillants :
+
+- Rédaction DPIA / ÉFVP (avec juriste externe).
+- Rédaction Politique de confidentialité + CGU + Mentions légales (revue juriste recommandée).
+- Mise en place registre traitement + registre incidents.
+- Mise en place procédure d'exercice des droits (front + backend + RPRP flow).
+- Signature DPA avec sous-traitants.
+- Plan de réponse aux incidents (runbook).
+- Pen-test externe avant lancement.
+- DPO externe mutualisé (recommandé).
+
+*Section interne détaillée sur budgets et chiffrages retirée de la version publique.*
+
+---
+
+## 11. Risques conformité résiduels & mitigations
+
+| # | Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|---|
+| RC1 | **Non-conformité Loi 25** détectée par la CAI (plainte utilisateur) | Faible | Élevé (amende + réputation) | ÉFVP formelle, RPRP nommé, registre à jour, audit annuel |
+| RC2 | **Incident de sécurité** (fuite de données santé enfant) | Faible | **Critique** (amende RGPD jusqu'à 4 % CA, réputation détruite) | E2EE zero-knowledge + chiffrement applicatif + KMS + pen-test + runbook incident + DPA sous-traitants |
+| RC3 | **Transfert transfrontière non couvert** (ex. vers APNs/FCM US sans SCC) | Moyenne | Moyen | SCC signées, pseudonymisation des payloads push (déjà prévue) |
+| RC4 | **Demande d'effacement non traitée dans les délais** (30 j Loi 25, 1 mois RGPD) | Faible | Moyen | Procédure automatisée en self-service + ticket de backup RPRP |
+| RC5 | **Fork tiers non conforme** utilisant le code Kinhale pour traiter des données santé sans cadre | Moyenne | Faible (pour l'opérateur d'origine) à Élevé (pour utilisateurs finaux du fork) | Clause explicite de non-responsabilité + licence AGPL v3 forçant l'ouverture des forks |
+| RC6 | **Dérive produit vers statut DM** (ajout d'une reco de dose, d'une alerte santé auto-générée) | Moyenne | Bloquant (+12 mois de certification) | Ligne rouge inscrite dans le PRD, revue conformité à chaque évolution fonctionnelle |
+| RC7 | **Utilisateur US <13 ans** s'inscrit sans consentement parental COPPA-vérifiable | Moyenne | Élevé (amende FTC) | v1.0 : disclaimer d'exclusion US + vérification pays via IP/locale. v1.1 : flow COPPA dédié |
+| RC8 | **Sous-traitant change sa politique** (ex : AWS ouvre le trafic hors Canada) | Faible | Élevé | Revue annuelle DPA, monitoring des régions, clauses contractuelles de changement |
+| RC9 | **Expiration du consentement parental** (enfant devient majeur 13/16/18 ans selon juridiction) | Faible v1 | Moyen | v2.0 : flow de transition de consentement à l'adolescent |
+
+---
+
+## 12. Recommandation finale
+
+### 12.1. Stratégie de lancement
+
+- **Aller au lancement v1.0 avec** : cadre **Loi 25 + PIPEDA + RGPD ready**. Instance officielle au Canada, politique de confidentialité exemplaire, ÉFVP signée, RPRP nommé.
+- **COPPA prêt en v1.1** si utilisateurs US détectés (>5 % de la base). V1.0 : afficher un disclaimer d'exclusion US à l'inscription, avec vérification pays (IP + locale navigateur).
+- **HIPAA** : hors périmètre jusqu'à un éventuel partenariat clinique US en v2.0.
+
+### 12.2. Décisions structurantes
+
+1. **Licence** : **AGPL v3** retenue.
+2. **RPRP** : nommé par l'opérateur de l'instance officielle.
+3. **Juriste externe** : revue de la politique de confidentialité + CGU — **recommandée et non négociable** pour des données de santé d'un mineur.
+4. **COPPA v1.0** : afficher un disclaimer d'exclusion US.
+5. **Pen-test v1.0** : recommandé avant d'atteindre 1 000 foyers actifs.
+
+### 12.3. Ligne rouge produit (rappel)
+
+- **Instance officielle = Responsable du traitement**, clairement affiché.
+- **Disclaimer permanent** : *« Kinhale est un outil de suivi et de coordination. Il ne remplace pas un avis médical, ne diagnostique pas et ne recommande aucun traitement. En cas de doute, consultez un professionnel de santé. »* — visible à l'onboarding, en pied de l'écran d'accueil, sur chaque rapport PDF exporté, dans les CGU.
+- **Ne jamais ajouter** : recommandation de dose, alerte santé auto-générée, diagnostic, messagerie avec professionnel de santé sans nouveau passage par une revue conformité ET évaluation du statut DM.
+
+---
+
+*Fin du cadre de conformité Kinhale v1.0 — document publié sous AGPL v3.*

--- a/docs/product/PRD.md
+++ b/docs/product/PRD.md
@@ -1,0 +1,321 @@
+# PRD — Kinhale v1.0
+
+> **Document de cadrage produit (Product Requirements Document)**
+> Version : 0.1.0 — Date : 2026-04-19
+> Licence : AGPL v3
+> Description courte : vision, personas, parcours utilisateur et périmètre fonctionnel de la v1.0 de Kinhale, application open source de coordination des prises de pompes d'un enfant asthmatique.
+
+---
+
+## 1. Résumé exécutif
+
+**Kinhale** est une application multi-plateformes (web + iOS + Android) **open source et gratuite**, destinée aux familles du monde entier dont un enfant est asthmatique. Elle permet à tous les aidants (parents, grands-parents, garderie, nounou) de **coordonner, tracer et partager en temps réel** les prises de pompes de fond et de secours, de recevoir des rappels fiables, et de générer un rapport médical exportable. La v1.0 vise un périmètre resserré (1 enfant par compte). Une v1.1 ouvre la fratrie ; une v2.0 à horizon 6-12 mois intègre HealthKit / Health Connect, un portail pro pour les pneumo-pédiatres, et une offre B2B pour cliniques. Le code est publié sous **AGPL v3** et une instance officielle est hébergée au Canada par Kamez.
+
+## 2. Vision produit
+
+- **Mission** : Donner à chaque famille vivant avec l'asthme d'un enfant l'outil le plus simple et le plus fiable possible pour coordonner son traitement, sans jamais se substituer au médecin.
+- **Vision long terme (2-3 ans)** : Devenir la référence open source du suivi d'observance pédiatrique dans l'asthme, utilisée par des dizaines de milliers de foyers et recommandée par les pneumo-pédiatres au Canada, en France et au-delà. Ouvrir progressivement à d'autres pathologies chroniques pédiatriques partageant la même logique (épilepsie, diabète T1, dermatite atopique).
+- **Proposition de valeur unique (UVP)** : *« La seule application qui synchronise tous les aidants d'un enfant asthmatique — parents, grands-parents, garderie — en temps réel, fonctionne hors-ligne, se configure en 2 minutes, et reste gratuite et open source. »*
+- **Manifeste produit (5 principes directeurs)**
+  1. **Simplicité absolue** — Une prise s'enregistre en moins de 10 secondes, tactile, code couleur, jamais de formulaire long.
+  2. **Fiabilité critique** — Une notification manquée = une perte de confiance définitive. Redondance (push + local + e-mail) et tests E2E non négociables.
+  3. **Hors-ligne par défaut** — L'app doit fonctionner dans une garderie en sous-sol sans wifi. La synchro est un détail technique, pas une condition d'usage.
+  4. **Ouverture par défaut** — Code public, licence libre, instance officielle gratuite, exportation des données toujours possible. Aucun verrou propriétaire.
+  5. **Jamais médecin** — L'app journalise, rappelle, partage. Elle ne recommande **jamais** une dose, ne diagnostique **jamais**, ne remplace **jamais** un avis médical. Disclaimer omniprésent.
+
+## 3. Problème utilisateur
+
+**Problème central** : dans un foyer où plusieurs personnes administrent un traitement inhalé à un même enfant, **aucun outil partagé ne garantit qu'aucune dose n'est oubliée, dupliquée, ou mal tracée**. Le résultat est une charge mentale permanente pour le parent référent, des trous dans le suivi médical, et un risque sanitaire réel.
+
+**Douleurs observées**
+1. **Oublis d'horaires sur la pompe de fond** (matin/soir) — aggravés par la variabilité du quotidien (école, week-end, voyage).
+2. **Absence de visibilité entre aidants** — « Tu lui as donné ? Je ne sais pas, demande à ta mère. » Risque de double dose ou de dose manquée.
+3. **Aucune alerte automatique en cas de dose manquée** — le parent s'en rend compte plusieurs heures après, parfois en pleine nuit.
+4. **Historique non-restituable au médecin** — impossible de répondre précisément à « Combien de prises de secours ce mois-ci ? » ou « Dans quelles circonstances ? ».
+5. **Fin de pompe imprévue** — rupture de médicament un dimanche soir, panique.
+6. **Apps existantes inadaptées** — soit payantes, soit sur-configurées, soit mono-utilisateur (pas de partage).
+
+**Coûts actuels**
+- **Temps perdu** : ~5-10 minutes/jour de coordination verbale ou SMS entre aidants, fatigue de la répétition.
+- **Anxiété** : charge mentale permanente du parent référent (souvent un seul parent assume la vigilance).
+- **Risque de santé** : une crise évitable si l'observance du traitement de fond est dégradée ; prise de secours tardive par incertitude sur l'horaire de la précédente.
+- **Perte d'information médicale** : consultations moins efficaces, ajustements de traitement basés sur le ressenti parental plutôt que sur des données.
+
+## 4. Utilisateurs cibles
+
+### 4.1. Personas détaillés
+
+#### Persona 1 — Parent référent (38 ans, Montréal)
+- **Contexte** : Parent de deux enfants. Sa fille de 5 ans est en début d'asthme, traitement quotidien + pompe de secours. Travaille à distance, non-soignant mais à l'aise avec le numérique.
+- **Objectifs** : Ne plus jamais oublier une prise ; savoir à tout moment où en est sa fille ; sortir un rapport clair au prochain rendez-vous pneumo.
+- **Frustrations** : Les apps testées sont soit payantes, soit demandent 20 minutes de configuration, soit ne gèrent qu'un seul utilisateur.
+- **Contexte d'usage** : Mobile (iOS) à 90 %, web quand il prépare le rendez-vous médecin. Matin et soir principalement, + occasions de secours.
+- **Critère de succès personnel** : *« Je ne me réveille plus la nuit pour vérifier si ma conjointe lui a donné sa pompe. »*
+- **Verbatim** : *« Je veux juste savoir en ouvrant mon téléphone si c'est fait ou pas, point. »*
+
+#### Persona 2 — Aidante secondaire (35 ans, co-parente)
+- **Contexte** : Infirmière, souvent en horaires décalés. Administre la pompe du soir 3-4 jours sur 7, du matin 2 jours sur 7.
+- **Objectifs** : Savoir instantanément ce que le parent référent a déjà fait ; être notifiée si c'est son tour ; ne pas avoir à lire de longs historiques.
+- **Frustrations** : Les SMS avec le co-parent se perdent dans le flux ; elle a déjà donné une dose qui avait déjà été donnée.
+- **Contexte d'usage** : Mobile (Android) en mobilité, entre deux gardes. Souvent dans des zones à couverture instable (sous-sols d'hôpital).
+- **Critère de succès personnel** : *« En 3 secondes je sais où on en est, et je valide ma prise. »*
+- **Verbatim** : *« Si je dois me connecter à un truc compliqué, j'abandonne. »*
+
+#### Persona 3 — Éducatrice en garderie (27 ans, CPE à Laval)
+- **Contexte** : Administre la pompe de midi à 4 enfants différents dans une CPE. Téléphone pro partagé, wifi médiocre, beaucoup de stress en période de pointe.
+- **Objectifs** : Enregistrer la prise en 10 secondes chrono, pouvoir le faire hors-ligne, sans avoir à créer de compte personnel.
+- **Frustrations** : Les parents lui demandent de noter sur un cahier papier qu'elle oublie ; elle n'est pas toujours sûre d'avoir bien donné la dose prescrite.
+- **Contexte d'usage** : Tablette partagée ou téléphone pro, connexion intermittente, environnement bruyant et sollicité.
+- **Critère de succès personnel** : *« Je prends la pompe, je tape sur le bouton, c'est fait. Pas de mot de passe, pas de menu. »*
+- **Verbatim** : *« Si ça plante ou si ça demande internet, je remplis le cahier papier comme d'habitude. »*
+
+#### Persona 4 — Pneumo-pédiatre (52 ans, CHU) — utilisatrice indirecte
+- **Contexte** : Voit 15 patients asthmatiques/jour, consultations de 20 minutes, anamnèse orale essentiellement.
+- **Objectifs** : Obtenir en 30 secondes un historique fiable des prises de secours, des circonstances, et de l'observance du traitement de fond sur les 3 derniers mois.
+- **Frustrations** : Les parents arrivent avec des carnets manuscrits illisibles ou des souvenirs flous ; elle doit deviner l'observance à partir du compteur de la pompe.
+- **Contexte d'usage** : Ordinateur du bureau de consultation, PDF imprimé apporté par le parent, ou envoyé par e-mail avant la consultation.
+- **Critère de succès personnel** : *« J'ouvre le PDF, je vois une courbe claire, j'adapte le traitement. »*
+- **Verbatim** : *« Si le document fait 20 pages, je ne le lis pas. Donnez-moi 1 page lisible. »*
+
+### 4.2. Marché & volume
+
+- **Prévalence de l'asthme pédiatrique** : ~8-10 % des enfants dans les pays à revenu élevé (OMS, SCPE).
+- **Canada** : ~850 000 enfants asthmatiques (Statistique Canada / ALA).
+- **France** : ~1 million d'enfants concernés (Santé Publique France).
+- **États-Unis** : ~4,5 millions d'enfants asthmatiques (CDC) — marché indirectement accessible via l'open source, COPPA à anticiper si <13 ans.
+- **Mondial** : estimation ~100 millions d'enfants asthmatiques (GBD 2019).
+- **Cible réaliste v1.0 (12 mois post-lancement)** : 500-5 000 foyers actifs (bouche-à-oreille + relais communautaires francophones : forums parents, associations d'asthmatiques, pneumo-pédiatres early-adopters).
+- **Cible v2.0 (offre B2B cliniques)** : 50-200 cabinets et cliniques au Québec + France, générant le financement long terme de l'hébergement.
+
+## 5. Objectifs & métriques de succès (OKR v1.0)
+
+| # | Objectif | Indicateur mesurable | Cible v1.0 |
+|---|---|---|---|
+| O1 | Saisie ultra-rapide | Temps médian entre ouverture app et enregistrement d'une prise depuis écran d'accueil | **< 10 secondes** |
+| O2 | Zéro dose manquée non détectée | Dans un foyer actif, % de doses planifiées soit confirmées, soit signalées « manquée » | **100 %** |
+| O3 | Rapport médecin utilisable | Génération PDF depuis la page Historique | **1 clic, < 5 secondes, 1-2 pages** |
+| O4 | Fiabilité notifications | Taux de notifications push délivrées dans les 60 secondes suivant l'heure planifiée (mesure instrumentée) | **> 99 %** |
+| O5 | Onboarding fluide | Durée médiane entre installation et première prise enregistrée | **< 2 minutes** |
+| O6 | Coordination multi-aidants | % de foyers actifs avec ≥ 2 aidants ayant enregistré au moins une prise | **> 60 %** |
+
+## 6. Parcours utilisateurs clés (User Journeys)
+
+### J1 — Onboarding du parent référent
+1. Téléchargement de l'app depuis l'App Store (ou ouverture de l'URL web).
+2. Écran d'accueil : bouton unique *« Commencer »*. Aucune création de compte obligatoire pour démarrer — possibilité de mode local invité.
+3. Création du compte foyer (e-mail + magic link, pas de mot de passe à retenir).
+4. Saisie minimale : prénom de l'enfant, âge, 1 pompe de fond (marque + posologie prescrite), 1 pompe de secours (optionnelle).
+5. Création d'un rappel matin (8h) et soir (20h), horaires pré-remplis, modifiables.
+6. Écran *« Inviter un aidant »* : envoi d'un lien au co-parent (SMS ou e-mail).
+7. Fin : arrivée sur l'écran d'accueil, le bouton *« Enregistrer une prise »* est dominant.
+- **Durée cible** : **< 2 minutes**.
+
+### J2 — Saisie rapide d'une prise de fond
+1. L'aidant ouvre l'app. Sur l'écran d'accueil : nom de l'enfant, statut de la prise du moment (« Prise du soir prévue à 20h — non faite »), gros bouton bleu *« J'ai donné la pompe de fond »*.
+2. Tap unique. Confirmation visuelle (coche verte + vibration légère).
+3. Les autres aidants reçoivent une notification *« [Aidant] a donné la pompe de fond à 19h47 »* dans les 5 secondes.
+- **Durée cible** : **< 10 secondes**.
+
+### J3 — Saisie d'une prise de secours avec symptômes
+1. L'enfant tousse à l'école. L'aidant ouvre l'app, bouton rouge *« Pompe de secours »*.
+2. Écran symptômes (grille d'icônes tactiles, multi-sélection) : toux, sifflement, essoufflement, réveil nocturne…
+3. Circonstances (pré-sélection rapide) : effort, allergène, infection, nuit, inconnu.
+4. Commentaire libre optionnel (1 champ texte, non obligatoire).
+5. Validation. Autres aidants (et médecin si abonné au rapport) reçoivent la notif.
+- **Durée cible** : **< 30 secondes**.
+
+### J4 — Gestion d'une dose manquée
+1. 21h, la prise du soir n'a pas été enregistrée. L'app envoie une notification à tous les aidants actifs : *« Prise du soir non confirmée — donnée ? »*
+2. Deux boutons : *« Je l'ai donnée à tel moment »* (rattrapage, saisie différée) ou *« Non, oubliée »* (marquée manquée, explicite dans l'historique).
+3. Si aucune réponse 30 min plus tard, rappel redondant (push + local + e-mail au référent).
+4. Dans l'historique, les doses manquées sont visuellement distinctes (gris + icône).
+
+### J5 — Invitation et onboarding d'un aidant secondaire (garderie)
+1. L'Admin ouvre *« Aidants »*, clique *« Inviter la garderie »*.
+2. Choix du rôle : **Contributeur restreint** (peut enregistrer une prise, voir la dernière prise, ne voit pas l'historique complet ni les symptômes détaillés).
+3. Génération d'un lien ou QR code + code PIN à 6 chiffres. Remise à l'éducatrice en garderie.
+4. Scan du QR, saisie du PIN, arrivée directement sur un écran épuré : prénom de l'enfant + bouton *« Pompe donnée »*. Aucun mot de passe, session persistante sur l'appareil partagé (révocable par l'Admin).
+- **Durée cible** : **< 60 secondes** côté aidante restreinte.
+
+### J6 — Export d'un rapport pour rendez-vous médecin
+1. Veille du rendez-vous, l'Admin ouvre *« Historique »*.
+2. Bouton *« Rapport médecin »*. Sélection période (dernier mois / 3 mois / personnalisé).
+3. Aperçu 1-2 pages : graphique observance pompe de fond, tableau prises de secours avec symptômes et circonstances, alertes (doses manquées, crises, remplacements de pompe).
+4. Boutons *« Télécharger PDF »*, *« Envoyer par e-mail »*, *« Copier CSV »*.
+- **Durée cible** : **1 clic, < 5 secondes pour générer**.
+
+### J7 — Synchronisation après période hors-ligne (garderie sans réseau)
+1. Prise enregistrée à 12h15 alors que la garderie est en panne wifi.
+2. L'app stocke l'événement localement, affiche un petit badge *« en attente de sync »*.
+3. À 17h, wifi rétabli. L'app synchronise automatiquement, horodatage serveur préservé, les autres aidants reçoivent la notif avec la mention *« enregistrée à 12h15 (sync à 17h02) »*.
+4. Si conflit (deux aidants ont enregistré entre-temps) : résolution automatique last-write-wins par horodatage local, notification croisée informant les deux aidants qu'il y a eu deux enregistrements à vérifier.
+
+## 7. Périmètre fonctionnel
+
+### 7.1. Périmètre v1.0
+
+**Comptes & foyers**
+- Compte foyer unique, authentification par magic link (e-mail) ou OAuth (Apple/Google).
+- **1 enfant par compte** en v1.0.
+- Rôles aidants : **Admin** (parent référent), **Contributeur** (co-parent, grand-parent), **Contributeur restreint** (garderie, nounou — saisie uniquement, pas d'historique complet).
+- Invitation par lien ou QR code + PIN, révocable.
+- Mode invité local (avant création de compte, migration possible).
+
+**Saisie des prises**
+- Pompe de fond : horodatage automatique, aidant capturé implicitement.
+- Pompe de secours : horodatage + symptômes (grille icônes multi-sélection) + circonstances (pré-sélection) + commentaire libre.
+- Saisie différée (rattrapage d'une prise oubliée jusqu'à 24h en arrière).
+- Support de plusieurs pompes par type (ex : 2 pompes de secours si l'enfant a un doublon école/maison).
+
+**Rappels & notifications**
+- Rappels push planifiés (matin/soir minimum, configurables).
+- Alerte dose manquée (push + local + e-mail après délai configurable).
+- Notifications croisées : quand un aidant enregistre une prise, les autres reçoivent push.
+- Alerte fin de pompe (décompte manuel des doses, alerte à seuil configurable, défaut 20 doses restantes).
+
+**Partage multi-aidants & temps réel**
+- Synchronisation temps réel des prises (< 5 secondes).
+- Vue unique partagée entre tous les aidants du foyer.
+- Résolution de conflits automatique (horodatage serveur, last-write-wins).
+
+**Rapports & export**
+- Rapport médecin PDF (1-2 pages, mis en forme clinique).
+- Export CSV brut (données complètes, pour recherche ou sauvegarde).
+- Période paramétrable (semaine / mois / 3 mois / personnalisée).
+
+**Hors-ligne & synchronisation**
+- Saisie hors-ligne complète (prise, symptômes, circonstances).
+- Lecture hors-ligne de l'historique des 30 derniers jours au minimum.
+- Synchronisation automatique à la reconnexion, file d'attente locale chiffrée.
+
+**Plateformes**
+- **Web responsive** (PWA installable).
+- **iOS** natif-like (React Native).
+- **Android** idem.
+- Parité fonctionnelle totale entre les 3 plateformes en v1.0.
+
+**Confidentialité & sécurité**
+- Chiffrement au repos et en transit (E2EE zero-knowledge, cf. `ARCHITECTURE.md`).
+- Hébergement Canada (ca-central-1 par défaut).
+- CGU + politique de confidentialité dédiées mineurs.
+- Export des données + suppression de compte en self-service.
+- Disclaimer omniprésent : *« Ne remplace pas un avis médical. »*
+
+### 7.2. Périmètre v1.1
+- **Multi-enfants** (fratrie) : plusieurs enfants dans un même foyer, sélection rapide sur écran d'accueil.
+- Petites améliorations basées sur retours utilisateurs (priorisation post-lancement).
+- Éventuels correctifs d'UX remontés via support.
+
+### 7.3. Périmètre v2.0 (6-12 mois)
+- Intégration **Apple HealthKit** + **Google Health Connect** (import / export des doses inhalées).
+- **Portail pro** pour pneumo-pédiatres (vue multi-patients, tableau de bord observance).
+- **Offre B2B cliniques** (instance dédiée, logo clinique, support prioritaire) — source de financement long terme de l'hébergement communautaire.
+- Multi-langues étendu (EN, ES).
+- Validation clinique par pneumo-pédiatre partenaire (crédibilité marketing).
+
+### 7.4. Hors-périmètre explicite (protection du non-statut dispositif médical)
+
+L'application **ne fera jamais** :
+- Recommandation ou calcul de dose.
+- Diagnostic ou suggestion de diagnostic.
+- Alerte santé auto-générée (« consultez votre médecin », « crise en cours »).
+- Messagerie bidirectionnelle avec un professionnel de santé.
+- Téléconsultation ou prise de rendez-vous médicale.
+- Intégration avec une pompe connectée (capteurs IoT) pour mesure automatique.
+- Analyse prédictive ou IA de risque de crise.
+- Stockage ou traitement de données médicales tierces (bilans, ordonnances).
+
+Ces limites sont **structurelles** : elles protègent le statut non-DM et donc la mise sur le marché rapide.
+
+## 8. Principes de design produit
+
+1. **Onboarding ultra-rapide** — Une seule étape, un seul écran par action, code couleur clair.
+2. **1 action principale par écran** — Bouton dominant, zéro ambiguïté. Les actions secondaires sont accessibles mais non proéminentes.
+3. **Code couleur cohérent**
+   - Bleu / vert = pompe de fond, action de routine.
+   - Rouge / orange = pompe de secours, action critique.
+   - Jaune / ambre = alertes (dose manquée, fin de pompe).
+   - Gris = doses manquées confirmées, historique passif.
+4. **Accessibilité WCAG 2.1 AA minimum** — Contrastes, tailles tactiles ≥ 44 px, support VoiceOver/TalkBack, usage possible en condition de stress (nuit, enfant qui pleure).
+5. **Zéro configuration obligatoire** — L'app doit être utile en < 2 minutes. Tout ce qui est configurable est pré-rempli avec des valeurs par défaut saines.
+6. **Pas de gamification** — Pas de badges, pas de streaks, pas de score. Le sujet est la santé d'un enfant, pas un jeu.
+7. **Micro-copie rassurante** — Ton sobre, jamais anxiogène. Exemple : « Prise non confirmée » plutôt que « Vous avez oublié ! ».
+
+## 9. Contraintes structurantes (rappel)
+
+- **Statut** : **non dispositif médical** (journal + rappel + partage). Ligne rouge absolue en v1 et v2.
+- **Données de santé d'un mineur** → cadre de conformité strict : **Loi 25 (Québec)**, **PIPEDA (Canada fédéral)**, **RGPD** (compatibilité pour ouverture France/UE), **considérations COPPA** si utilisation US avec enfants <13 ans. Voir `COMPLIANCE.md`.
+- **Multi-juridictions** dès le lancement (distribution mondiale via open source + stores) → architecture de conformité générique.
+- **Hébergement Canada** par défaut (ca-central-1) ; préparation multi-région en v2.
+- **Open source** : licence **AGPL v3** + instance officielle gratuite hébergée par Kamez.
+- **Fiabilité critique** : une notification manquée = perte de confiance immédiate → redondance (push + local + e-mail) et monitoring en production.
+- **Délai v1.0** : ~3 mois calendaires (v1.1 fratrie ~2 mois après).
+
+## 10. Risques produit & hypothèses
+
+| # | Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|---|
+| RP1 | **Adoption multi-aidants réelle faible** : seul le parent référent utilise l'app, les autres ignorent les invitations | Moyenne | Haut (détruit l'UVP) | Onboarding aidant < 60s, QR code + PIN sans compte complet, relances contextuelles ; mesurer O6 dès les premières semaines |
+| RP2 | **Fatigue de notifications** : trop d'alertes, l'utilisateur les désactive ou désinstalle | Haute | Haut (fiabilité perçue effondrée) | Fréquence stricte (max 1 rappel + 1 retard par prise), tonalité sobre, réglages par aidant, opt-out granulaire |
+| RP3 | **Fausse alerte fin de pompe** (décompte manuel divergent de la réalité) | Moyenne | Moyen (perte de confiance) | Décompte manuel remis à zéro à chaque remplacement, alerte conservatrice (seuil 20 doses, non 5), message clair « estimation » |
+| RP4 | **Fracture numérique des grands-parents / garderie** : profil non-numérique, abandon | Moyenne | Moyen (perte d'un segment clé) | Profil restreint ultra-simple (1 bouton), QR code papier, mode kiosque tablette partagée, guide imprimable |
+| RP5 | **Revue stores santé enfants** (App Store, Play Store) : rejet pour mention santé/mineur mal cadrée | Moyenne | Haut (délai mise en ligne) | Kit conformité stores préparé en amont, disclaimer explicite, politique de confidentialité exemplaire, classification non-médicale claire |
+| RP6 | **Dérive scope vers dispositif médical** : pression utilisateur pour ajouter une alerte « crise en cours » ou une recommandation | Moyenne | Bloquant (+12 mois certification) | Périmètre gravé dans le PRD, revue conformité à chaque évolution, backlog guard-rails |
+| RP7 | **Synchro hors-ligne buggée** : conflits, pertes de données | Moyenne | Haut (perte de confiance immédiate) | Tests E2E dédiés, file d'attente locale chiffrée, horodatage serveur, journal de conflits visible par le foyer |
+| RP8 | **Financement long terme de l'instance hébergée** non viable si traction forte | Faible en v1, Haute à 2 ans | Haut | Offre B2B cliniques v2, self-hosting documenté dès v1 comme fallback, monitoring coûts cloud |
+
+**Hypothèses clés (à valider en exécution)**
+- H1 : L'open source + instance gratuite est un accélérateur d'adoption (vs barrière de notoriété).
+- H2 : Les garderies accepteront d'utiliser l'app si profil restreint + pas de compte à créer.
+- H3 : Un rapport PDF 1-2 pages suffit aux pneumo-pédiatres v1 (pas besoin de portail pro immédiat).
+- H4 : Le bouche-à-oreille parental (forums, associations) suffira à atteindre 500-5 000 foyers en 12 mois sans budget marketing.
+
+## 11. Critères de sortie v1.0 (Definition of Done produit)
+
+La v1.0 est considérée livrable si **toutes** les conditions ci-dessous sont vérifiées :
+
+1. **Parcours critiques testés sur vraie pompe avec une vraie famille** pendant ≥ 2 semaines : J1, J2, J3, J4, J5, J6, J7 tous passants.
+2. **Rapport médecin validé** par au moins **1 pneumo-pédiatre** (critiques formelles et itération intégrée, même sans validation clinique formelle).
+3. **Fiabilité des notifications démontrée** : O4 (> 99 % de délivrabilité sous 60s) mesurée sur banc de test instrumenté.
+4. **Conformité publiée** : politique de confidentialité + CGU + mentions légales dédiées mineurs, en français et anglais.
+5. **Parité web + iOS + Android** : aucun parcours critique n'est bloqué sur une plateforme.
+6. **Accessibilité WCAG 2.1 AA** : audit automatique (axe-core ou équivalent) + navigation au lecteur d'écran validée sur J2, J3, J5.
+7. **Code open source publié** sur GitHub avec licence AGPL v3, README, guide de contribution.
+8. **Guide de self-hosting publié** : Docker Compose ou équivalent, documentation pas-à-pas pour une famille technique ou une clinique.
+9. **Instance officielle en production** au Canada avec monitoring (uptime, push delivery, erreurs).
+10. **Tests E2E automatisés** couvrant les 7 parcours critiques.
+11. **Onboarding < 2 minutes** mesuré sur ≥ 5 utilisateurs externes (hors équipe).
+12. **Disclaimer non-dispositif-médical** visible à l'onboarding, dans les CGU, dans le pied de page du rapport PDF.
+
+## 12. Métriques de suivi post-lancement
+
+**Utilisation**
+- Foyers actifs hebdomadaires / mensuels (DAU/WAU/MAU foyer).
+- Nombre moyen de prises enregistrées / jour / foyer.
+- Ratio prises de fond confirmées / prises de fond planifiées (proxy observance).
+- Nombre moyen d'aidants actifs par foyer.
+
+**Fiabilité**
+- Taux de délivrabilité push (sous 60 s).
+- Taux de doses manquées non signalées (doit tendre vers 0).
+- Taux d'erreurs de synchro hors-ligne (cible < 0,1 %).
+- Uptime de l'instance officielle (cible > 99,5 %).
+
+**Expérience**
+- Temps médian d'onboarding (J1 complet).
+- Temps médian de saisie d'une prise (J2, J3).
+- NPS aidants mesuré à J30.
+- Taux de rétention J7 / J30 / J90 (foyer actif).
+
+**Écosystème**
+- Étoiles GitHub, contributions externes.
+- Nombre d'instances self-hostées déclarées (opt-in telemetry).
+- Demandes entrantes cliniques / pneumo-pédiatres (signal B2B v2).
+
+**Santé**
+- Nombre moyen de prises de secours / mois / enfant (indicateur de contrôle, remonté au médecin).
+- Taux de foyers avec ≥ 1 rapport médecin généré / mois (preuve d'usage médical).
+
+---
+
+*Fin du PRD Kinhale v1.0 — document publié sous AGPL v3.*

--- a/docs/product/SPECS.md
+++ b/docs/product/SPECS.md
@@ -1,0 +1,936 @@
+# Spécifications fonctionnelles — Kinhale v1.0
+
+> **Document de spécifications fonctionnelles**
+> Version : 0.1.0 — Date : 2026-04-19
+> Licence : AGPL v3
+> Description courte : modèle de données logique, règles métier (RM1-RM28), workflows (W1-W12), contrats API, exigences non fonctionnelles et critères d'acceptation de la v1.0 de Kinhale.
+
+---
+
+## 1. Introduction & portée
+
+### 1.1. Rappel du périmètre v1.0
+
+Kinhale v1.0 est une application **multi-plateformes (web PWA + iOS + Android)**, **open source (AGPL v3)**, hébergée au Canada (ca-central-1). Elle permet à plusieurs aidants d'un même enfant asthmatique de **coordonner, tracer et partager en temps réel** les prises de pompes de fond et de secours, de recevoir des **rappels fiables**, de détecter les **doses manquées**, de surveiller le **niveau des pompes**, et de générer un **rapport médical exportable** (PDF + CSV).
+
+La v1.0 est strictement positionnée comme un **outil de journal + rappel + partage**, **jamais un dispositif médical**. L'application **ne recommande jamais de dose**, **ne diagnostique jamais**, **ne propose jamais d'action thérapeutique**. Ce principe structure l'ensemble du document.
+
+Caractéristiques v1.0 :
+- **1 enfant par foyer** (la fratrie arrive en v1.1).
+- **Pas d'intégration Apple HealthKit / Google Health Connect** (reporté en v2.0).
+- **Pas de portail pro médecin** (reporté en v2.0).
+- **Pas de monétisation** (open source + instance gratuite).
+- **Hors-ligne complet** (saisie + lecture 30 derniers jours + sync différée).
+- **Temps réel multi-aidants** (propagation < 5 s en ligne).
+- **FR + EN** à la sortie, structure prête pour ES / DE en v1.1+.
+
+### 1.2. Hors-périmètre explicite v1.0
+
+Ne font **pas partie** de la v1.0 (garde-fous, à rouvrir uniquement par décision produit explicite) :
+- Recommandation ou calcul de dose.
+- Diagnostic, alerte de crise, score de contrôle auto-généré.
+- Messagerie bidirectionnelle avec un professionnel de santé.
+- Téléconsultation, prise de rendez-vous médicale.
+- Intégration avec pompe connectée (capteurs IoT).
+- Stockage d'ordonnances scannées, bilans sanguins, radiographies.
+- IA prédictive de risque d'exacerbation.
+- Multi-enfants (fratrie) — repoussé à v1.1.
+- Portail pro pneumo-pédiatre — repoussé à v2.0.
+- Intégration Apple Health / Health Connect — repoussée à v2.0.
+- Paiement, abonnement, facturation.
+- Support client en direct (chat, téléphone).
+
+### 1.3. Glossaire
+
+| Terme | Définition |
+|---|---|
+| **Foyer** | Unité logique regroupant un enfant, ses aidants et toutes les données associées (pompes, prises, plans, rapports). Une instance Kinhale héberge N foyers isolés les uns des autres. |
+| **Aidant** | Toute personne habilitée à saisir / consulter des prises pour l'enfant du foyer (parent, grand-parent, éducatrice de garderie, nounou). |
+| **Parent référent (Admin)** | Aidant ayant créé le foyer (ou désigné par l'Admin sortant) ; il a tous les droits administratifs. |
+| **Contributeur** | Aidant avec compte complet qui peut saisir et consulter l'historique. |
+| **Contributeur restreint** | Aidant connecté via QR + PIN (sans compte personnel), session 8 h, saisie uniquement + dernière prise visible. |
+| **Pompe (ou inhalateur)** | Dispositif médical prescrit à l'enfant, de type **fond** (traitement quotidien préventif) ou **secours** (en crise). Chaque pompe porte un nombre fini de doses. |
+| **Prise de fond** | Administration planifiée d'une pompe de fond à un créneau cible (matin / soir typiquement). |
+| **Prise de secours** | Administration ponctuelle d'une pompe de secours en réaction à des symptômes ou des circonstances (effort, allergène…). Jamais planifiée. |
+| **Plan de traitement** | Prescription médicale transcrite par l'Admin : quelle pompe, fréquence, heures cibles, date de début, date de fin éventuelle. |
+| **Rappel** | Événement système programmé par un plan, qui génère une notification push à l'heure cible. |
+| **Dose manquée** | Prise de fond planifiée dont la fenêtre de confirmation s'est fermée sans qu'aucun aidant l'ait confirmée ni rattrapée. |
+| **Rattrapage** | Saisie différée d'une prise déjà administrée mais non enregistrée à l'heure. |
+| **Fenêtre de confirmation** | Plage autour de l'heure cible (par défaut ±30 min) dans laquelle la prise est considérée « à l'heure ». |
+| **RPRP** | Responsable de la Protection des Renseignements Personnels (Loi 25). |
+| **DPIA / ÉFVP** | Évaluation des Facteurs relatifs à la Vie Privée (équivalent RGPD). |
+| **Audit trail** | Journal horodaté de tous les accès, modifications et exports sur données sensibles. |
+
+---
+
+## 2. Acteurs du système
+
+### 2.1. Parent référent (Admin)
+
+- **Rôle** : crée le foyer, déclare l'enfant, gère les pompes et plans de traitement, invite et révoque les aidants, exporte les rapports, gère la conformité (consentement, suppression).
+- **Droits** : tous (CRUD sur foyer, enfant, pompes, plans, prises, aidants ; lecture audit trail ; export / suppression).
+- **Parcours-clés** : W1 onboarding, W5 invitation aidant, W7 remplacement pompe, W9 export rapport, W10 suppression, W11 transfert admin.
+- **Contraintes** : un foyer doit avoir **au moins 1 Admin** à tout moment (RM1).
+
+### 2.2. Aidant contributeur
+
+- **Rôle** : co-parent, grand-parent, tout aidant familial avec compte complet.
+- **Droits** : saisie de prises (fond, secours, rattrapage), lecture complète de l'historique, consultation du plan de traitement, consultation des pompes, réception de rappels et notifications croisées, paramétrage de ses propres préférences de notifications.
+- **Non-droits** : ne peut pas inviter / révoquer d'autres aidants, modifier le plan, ajouter une pompe, exporter un rapport, supprimer le foyer.
+- **Parcours-clés** : W2, W3, W4, W8.
+
+### 2.3. Aidant contributeur restreint (garderie / nounou)
+
+- **Rôle** : administrer une prise dans un contexte pro, sans compte perso.
+- **Droits** : uniquement la saisie d'une prise (fond ou secours, avec symptômes / circonstances), consultation de **la dernière prise uniquement** (pour éviter un doublon), lecture du nom et prénom de l'enfant + photo optionnelle.
+- **Non-droits** : pas d'historique complet, pas de consultation des autres aidants, pas de rappel personnel, pas de symptôme lié à d'autres enfants.
+- **Authentification** : QR code + PIN 6 chiffres, session 8 h, sur un appareil partagé (mode kiosque).
+- **Parcours-clés** : W6 onboarding aidant restreint.
+
+### 2.4. Système (tâches automatiques)
+
+Acteur non humain, représente le backend et les workers qui exécutent :
+- Programmation et envoi des **rappels** de prise (push + local + e-mail fallback).
+- Détection et signalement des **doses manquées** après fermeture de la fenêtre + délai de grâce.
+- Calcul du **niveau restant** des pompes et envoi de l'**alerte fin de pompe**.
+- **Purge** automatique des comptes supprimés (après 30 jours).
+- **Régénération** du rapport PDF à la demande.
+- **Nettoyage** des invitations expirées / consommées.
+- **Synchronisation** (push temps réel WebSocket + réconciliation des files hors-ligne).
+
+### 2.5. Médecin (destinataire indirect)
+
+- **Rôle** : consomme le **rapport PDF / CSV** remis ou envoyé par le parent lors d'une consultation. Non-utilisateur direct de l'app en v1.
+- **Droits** : aucun dans le système (pas de compte). Sa seule interface est le document exporté.
+- **Exigence produit** : le document doit être **lisible en 30 s** (1-2 pages max), **fidèle au journal** (pas de reco auto).
+
+---
+
+## 3. Modèle de données (logique)
+
+> Niveau logique uniquement. Le modèle physique (SQL, index, partitionnement) est détaillé en annexe technique.
+
+### 3.1. Entité `Utilisateur`
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | Clé primaire opaque. |
+| `email` | String, unique | Normalisé lowercase. Obligatoire pour Admin et Contributeur, non utilisé pour Contributeur restreint. |
+| `auth_method` | Enum | `magic_link` \| `passkey` \| `oauth_apple` \| `oauth_google`. |
+| `password_hash` | String, nullable | Non utilisé en v1 (magic link / passkey). Réservé pour v2. |
+| `mfa_enabled` | Bool | TOTP optionnelle (recommandée pour Admin). |
+| `preferred_language` | Enum | `fr` \| `en`. |
+| `timezone` | String | IANA (ex : `America/Montreal`). |
+| `consent_version_accepted` | String | Hash SHA-256 de la version CGU + PC acceptée. |
+| `consent_accepted_at` | Timestamp | ISO 8601 UTC. |
+| `created_at`, `updated_at`, `deleted_at` | Timestamp | Soft delete pour l'audit. |
+
+**Contraintes** : un utilisateur peut appartenir à 0..N foyers via `Aidant`. Unicité `email` à l'échelle globale de l'instance.
+
+### 3.2. Entité `Foyer`
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | Clé opaque, utilisée dans tous les filtres multi-tenant. |
+| `name` | String | Nom donné par l'Admin (ex : « Famille Tremblay »). |
+| `timezone` | String | IANA, hérité du fuseau de l'Admin à la création, modifiable. |
+| `language` | Enum | `fr` \| `en`. |
+| `confirmation_window_minutes` | Int | Défaut 30. Configurable par l'Admin (cf. RM2). |
+| `pump_alert_threshold_doses` | Int | Défaut 20. Configurable (cf. RM7). |
+| `created_by_user_id` | UUID | FK `Utilisateur`. |
+| `rprp_user_id` | UUID | FK vers l'utilisateur Admin désigné comme RPRP local du foyer (défaut = créateur). |
+| `created_at`, `updated_at`, `deleted_at` | Timestamp | Soft delete. |
+
+**Cardinalité** : `Foyer` 1 ↔ 1 `Enfant` en v1.0 (contrainte produit). `Foyer` 1 ↔ N `Pompe`, N `Aidant`, N `Plan`, N `Prise`, N `Rapport`.
+
+### 3.3. Entité `Enfant`
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | |
+| `household_id` | UUID | FK `Foyer`, unique en v1.0 (1:1). |
+| `first_name` | String chiffré | Prénom en clair uniquement côté applicatif. |
+| `year_of_birth` | Int | **Pas de date complète** (minimisation Loi 25). Juste l'année. |
+| `medical_notes` | Text chiffré, nullable | Champ libre court (allergies connues, autre pathologie). Non-médical par conception. |
+| `photo_url` | String, nullable | Optionnelle, hébergée sur S3 Canada, chiffrée. |
+| `pathology` | Enum | `asthma` en v1 ; `asthma_plus_other` préparé v2 (jamais coté produit). |
+| `created_at`, `updated_at` | Timestamp | |
+
+### 3.4. Entité `Pompe` (Inhalateur)
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | |
+| `child_id` | UUID | FK `Enfant`. |
+| `commercial_name` | String | Ex : « Flovent HFA 125 µg ». Saisi par l'Admin. |
+| `type` | Enum | `maintenance` (fond) \| `rescue` (secours). |
+| `active_substance` | String, nullable | Corticostéroïde, bronchodilatateur, etc. Informatif, jamais utilisé pour calcul. |
+| `dose_per_puff_mcg` | Int, nullable | Informatif (apparaît sur le rapport). |
+| `total_doses_initial` | Int | Nombre total d'inhalations à neuf. Saisi par l'Admin. |
+| `doses_remaining` | Int | Décrémenté à chaque prise (RM7). |
+| `expiration_date` | Date, nullable | Optionnel, déclenche un avertissement à 30 j. |
+| `status` | Enum | `active` \| `replaced` \| `expired` \| `empty`. |
+| `replaced_at` | Timestamp, nullable | Trace du remplacement. |
+| `replacement_pump_id` | UUID, nullable | Auto-chaînage à la pompe qui l'a remplacée. |
+| `created_at`, `updated_at` | Timestamp | |
+
+### 3.5. Entité `Plan de traitement`
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | |
+| `child_id` | UUID | FK. |
+| `pump_id` | UUID | FK (doit être une pompe de type `maintenance`). |
+| `frequency` | Enum | `daily_once` \| `daily_twice` \| `daily_custom` \| `as_needed`. |
+| `target_times` | JSON liste de `HH:mm` locales | Ex : `["08:00", "20:00"]`. |
+| `doses_per_target` | Int | Ex : 1 ou 2 inhalations par prise. |
+| `start_date` | Date | |
+| `end_date` | Date, nullable | Si vide : plan en cours. |
+| `created_by_user_id` | UUID | FK `Utilisateur` (doit être Admin). |
+| `status` | Enum | `active` \| `paused` \| `completed` \| `cancelled`. |
+| `created_at`, `updated_at` | Timestamp | |
+
+**Contraintes** : au plus **un plan `active` par pompe de fond** à un instant T. Pas de plan pour pompe de secours (RM3).
+
+### 3.6. Entité `Prise administrée` (cœur du modèle)
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | Généré **côté client** à la saisie (pour idempotence offline). |
+| `client_event_id` | UUID | Identique à `id`, exposé via header `Idempotency-Key`. |
+| `household_id` | UUID | FK. |
+| `child_id` | UUID | FK. |
+| `pump_id` | UUID | FK. |
+| `plan_id` | UUID, nullable | FK vers le plan si prise planifiée, sinon null. |
+| `caregiver_user_id` | UUID, nullable | FK `Utilisateur` si compte. Null si Contributeur restreint. |
+| `caregiver_restricted_session_id` | UUID, nullable | FK vers la session QR+PIN si restreint. |
+| `caregiver_display_name` | String | Nom affiché dans les notifications (sécurité d'affichage). |
+| `type` | Enum | `maintenance_planned` \| `maintenance_unplanned` \| `rescue`. |
+| `administered_at_local` | Timestamp | Date/heure de prise réelle, en local utilisateur. |
+| `administered_at_utc` | Timestamp | UTC côté serveur (autoritaire pour l'ordre). |
+| `recorded_at_utc` | Timestamp | Quand l'événement est parvenu au serveur (sync). |
+| `doses_administered` | Int | Défaut 1. |
+| `symptoms` | JSON liste d'enum | Obligatoire pour `rescue`, grille pré-définie (toux, sifflement, essoufflement, réveil nocturne, gêne thoracique, autre). |
+| `circumstances` | JSON liste d'enum + tag libre | Obligatoire pour `rescue` si aucun symptôme ; pré-sélection (effort, allergène, infection, nuit, fumée, autre) + champ libre optionnel <500 car. |
+| `free_text_note` | Text chiffré, nullable | Commentaire libre optionnel, jamais requis. |
+| `source` | Enum | `manual_entry` \| `reminder_confirmation` \| `backfill` \| `sync_replay`. |
+| `geolocation` | JSON {lat, lon}, nullable | **Opt-in strict**, jamais par défaut. |
+| `is_disputed` | Bool | True si détection de double saisie (RM6), en attente de résolution. |
+| `dispute_resolved_at` | Timestamp, nullable | |
+| `status` | Enum | `confirmed` \| `voided` (annulation explicite) \| `pending_review` (double saisie en cours). |
+| `created_at`, `updated_at` | Timestamp | |
+
+**Principe fondateur** : une prise n'est **jamais physiquement supprimée**. L'annulation passe par un changement de `status` à `voided` avec un `voided_reason` et un `voided_by_user_id`. Garantie d'intégrité pour l'audit médical.
+
+### 3.7. Entité `Rappel`
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | |
+| `plan_id` | UUID | FK `Plan`. |
+| `target_at_utc` | Timestamp | Moment où le rappel doit partir. |
+| `window_start_utc`, `window_end_utc` | Timestamp | Fenêtre de confirmation ±N min autour de la cible. |
+| `status` | Enum | `scheduled` \| `sent` \| `confirmed` \| `missed` \| `snoozed` \| `cancelled`. |
+| `confirmed_by_dose_id` | UUID, nullable | Si confirmé, FK vers la `Prise` associée. |
+| `last_state_change_at` | Timestamp | |
+| `created_at`, `updated_at` | Timestamp | |
+
+### 3.8. Entité `Aidant` (adhésion d'un utilisateur à un foyer)
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | |
+| `user_id` | UUID, nullable | FK `Utilisateur` (null si Contributeur restreint). |
+| `household_id` | UUID | FK `Foyer`. |
+| `role` | Enum | `admin` \| `contributor` \| `restricted_contributor`. |
+| `invited_at`, `accepted_at`, `revoked_at` | Timestamp | |
+| `permissions_overrides` | JSON | Granularité fine (ex : désactivation de certaines notifications). |
+| `display_name` | String | Affichage foyer (ex : « Maman », « Garderie CPE Soleil »). |
+| `created_at`, `updated_at` | Timestamp | |
+
+**Contraintes** : un `user_id` apparaît au plus une fois par `household_id` (unique composite). Un `role = restricted_contributor` impose `user_id = null`.
+
+### 3.9. Entité `Invitation aidant`
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | |
+| `household_id` | UUID | FK. |
+| `target_role` | Enum | `contributor` \| `restricted_contributor`. |
+| `invite_code` | String opaque | Token aléatoire 256 bits. |
+| `qr_payload` | String | Encodage compact du code pour QR. |
+| `pin` | String (6 chiffres) | Hash stocké, jamais en clair. |
+| `channel` | Enum | `email` \| `sms` \| `link_share` \| `qr_physical`. |
+| `max_uses` | Int | Défaut 1. Cas tablette garderie : peut être >1 mais sous supervision Admin. |
+| `uses_count` | Int | |
+| `expires_at` | Timestamp | Défaut +7 jours pour compte, +48 h pour restreint. |
+| `created_by_user_id` | UUID | FK. |
+| `consumed_by_user_id` | UUID, nullable | Pour invitation Contributeur complet. |
+| `status` | Enum | `active` \| `consumed` \| `expired` \| `revoked`. |
+| `created_at`, `updated_at` | Timestamp | |
+
+### 3.10. Entité `Notification`
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | |
+| `recipient_user_id` | UUID | FK. |
+| `household_id` | UUID | FK. |
+| `type` | Enum | `reminder` \| `missed_dose` \| `peer_dose_recorded` \| `pump_low` \| `pump_expiring` \| `dispute_detected` \| `admin_handover` \| `consent_update_required` \| `security_alert`. |
+| `payload` | JSON | **Aucune donnée santé en clair**, uniquement identifiants et timestamps. |
+| `channel` | Enum | `push` \| `local` \| `email`. |
+| `state` | Enum | `pending` \| `sent` \| `delivered` \| `read` \| `failed`. |
+| `sent_at`, `delivered_at`, `read_at` | Timestamp, nullable | |
+| `created_at`, `updated_at` | Timestamp | |
+
+### 3.11. Entité `Événement de journal` (audit trail)
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | |
+| `household_id` | UUID | FK. |
+| `actor_user_id` | UUID, nullable | FK `Utilisateur`. Null si système. |
+| `actor_type` | Enum | `user` \| `system` \| `restricted_session`. |
+| `event_type` | Enum | `auth_login` \| `auth_logout` \| `dose_created` \| `dose_voided` \| `plan_created` \| `plan_modified` \| `invitation_sent` \| `invitation_accepted` \| `invitation_revoked` \| `report_generated` \| `report_downloaded` \| `data_exported` \| `account_deletion_requested` \| `account_deleted` \| `consent_updated`. |
+| `target_type` | String | Ex : `dose`, `plan`, `household`. |
+| `target_id` | UUID | |
+| `payload` | JSON pseudonymisé | Jamais de donnée santé en clair. |
+| `occurred_at` | Timestamp | |
+| `source_ip_hash` | String | Haché (sel rotatif) pour la preuve sans fingerprinting. |
+
+**Rétention** : 12 mois, accès exclusif RPRP, **non purgée** lors d'une suppression de compte (pseudonymisation à la place).
+
+### 3.12. Entité `Rapport exporté`
+
+| Attribut | Type | Notes |
+|---|---|---|
+| `id` | UUID | |
+| `household_id` | UUID | FK. |
+| `child_id` | UUID | FK. |
+| `date_range_start`, `date_range_end` | Date | |
+| `format` | Enum | `pdf` \| `csv`. |
+| `generated_at` | Timestamp | |
+| `generated_by_user_id` | UUID | FK. |
+| `intended_recipient` | Enum | `self` \| `physician` \| `caregiver`. |
+| `file_sha256` | String | Signature intégrité (affichée en pied de PDF). |
+| `file_storage_key` | String | Chemin S3 chiffré, expiration 7 jours après génération. |
+| `downloaded_at` | Timestamp, nullable | |
+
+---
+
+## 4. Règles métier clés
+
+Ces règles sont la référence pour la qualité et le backlog ; chacune doit être vérifiable par un test.
+
+- **RM1 — Admin permanent** : un foyer a **au moins un Admin** en permanence. Si le dernier Admin demande à quitter ou supprime son compte, l'app propose (a) de promouvoir le plus ancien `contributor` en `admin`, (b) de supprimer le foyer. Impossible de « sortir » sans choisir une des deux.
+- **RM2 — Fenêtre de confirmation** : une prise de fond planifiée est confirmable dans la fenêtre `[target - X, target + X]` (défaut X = 30 min, configurable par foyer, entre 10 et 120 min). Au-delà, le rappel passe à `missed` ; la prise reste rattrapable jusqu'à **24 h après la cible** avec le marqueur `source = backfill`.
+- **RM3 — Pas de planification du secours** : une prise de type `rescue` n'est **jamais** liée à un `Plan`. Toute tentative de créer un plan sur une pompe de type `rescue` est refusée côté API et UI.
+- **RM4 — Secours documenté** : une prise de type `rescue` exige **au moins** un symptôme OU une circonstance (ou un tag libre non vide). Sinon : refus côté API avec erreur 422 et explication à l'aidant.
+- **RM5 — Notification croisée** : lorsqu'une prise (fond ou secours) est enregistrée par un aidant A, **tous les autres aidants actifs du foyer** reçoivent une notification informative dans les **5 secondes en ligne** (cible), ou dès que le réseau est disponible pour les clients hors-ligne.
+- **RM6 — Détection de double saisie** : si deux prises du **même type** (fond ou secours) pour la **même pompe** sont enregistrées à **moins de 2 minutes d'écart** (en temps réel serveur), l'app marque les deux en `pending_review`, notifie les deux aidants et propose de **confirmer** ou **annuler (voided)** l'une des deux. Aucune prise n'est silencieusement supprimée.
+- **RM7 — Décompte doses pompe** : à chaque prise `confirmed` sur une pompe, `doses_remaining -= doses_administered`. Quand `doses_remaining <= pump_alert_threshold_doses` (défaut 20 ou 20 %), une notification `pump_low` est envoyée à l'Admin. À `doses_remaining = 0`, le statut passe à `empty` et une notification urgente est envoyée.
+- **RM8 — Rapport sans reco** : le rapport médecin inclut **toutes les prises `confirmed`** (voidées signalées séparément) sur la plage demandée + un graphique de fréquence secours/semaine + la liste des symptômes et circonstances. Il **n'inclut jamais** : recommandation de dose, interprétation, score de contrôle, diagnostic.
+- **RM9 — Consentement** : l'acceptation des CGU + Politique de Confidentialité est **obligatoire** à la création de compte (case non pré-cochée, granulaire) **ET** à chaque changement majeur de version (bump mineur de hash ignoré, bump majeur bloque l'usage jusqu'à ré-acceptation).
+- **RM10 — Suppression de compte / foyer** : la suppression déclenche (a) un e-mail contenant **l'archive de portabilité** (CSV + PDF des 12 derniers mois), (b) une purge complète sous **30 jours max** (délai technique pour backups rotatifs), (c) la **pseudonymisation** de l'historique d'audit (jamais purgé, conservé pour preuve).
+- **RM11 — Multi-tenant strict** : toute requête backend filtre par `household_id` **à partir du token**, jamais d'un paramètre client. Test automatisé anti-IDOR au CI.
+- **RM12 — Session Contributeur restreint** : valide **8 heures** max, **non renouvelable automatiquement**. Au renouvellement, PIN re-demandé. Admin peut révoquer la session à tout moment.
+- **RM13 — Un seul enfant par foyer en v1.0** : toute tentative de créer un deuxième enfant renvoie une erreur 409 « feature_not_yet_available », avec lien vers le roadmap v1.1.
+- **RM14 — Horodatage autoritaire** : l'ordre canonique des événements est celui de `administered_at_utc` côté serveur. En cas d'arrivée tardive (sync), le serveur conserve `administered_at_utc` local déclaré par le client, mais pose un `recorded_at_utc` de réception. Les notifications post-sync mentionnent explicitement les deux.
+- **RM15 — Idempotence des saisies** : toute création de `Prise` via API est idempotente via header `Idempotency-Key` = `client_event_id`. Deux appels identiques renvoient la même réponse, jamais deux insertions.
+- **RM16 — Jamais de donnée santé dans les push** : le payload APNs / FCM ne contient **que** `title` générique, `household_id` opaque et `notification_id`. Le contenu réel est récupéré via un appel authentifié à l'ouverture.
+- **RM17 — Rattrapage borné** : une prise `backfill` peut être datée jusqu'à **24 h dans le passé**, jamais dans le futur. Saisie hors fenêtre exige une confirmation explicite « Je confirme cette prise à cette heure ».
+- **RM18 — Annulation (voided)** : seul l'aidant ayant saisi la prise OU un Admin peut la voider, **dans les 30 minutes** suivant la saisie. Passé ce délai : l'Admin seul peut voider, avec `voided_reason` obligatoire. La prise voidée reste visible dans l'historique en gris barré.
+- **RM19 — Expiration de pompe** : à 30 j de la date de péremption, notification `pump_expiring`. À échéance, statut `expired`, la pompe n'est plus sélectionnable pour une nouvelle prise (sauf si Admin force avec justification texte).
+- **RM20 — Mode hors-ligne et lecture** : l'historique des **30 derniers jours** est consultable hors-ligne. Au-delà, nécessite connexion. Saisie hors-ligne **toujours possible** pour fond et secours.
+- **RM21 — Limite anti-spam invitation** : un Admin ne peut créer **plus de 10 invitations actives** simultanément, pour éviter l'exploitation des liens. Erreur 429 au-delà.
+- **RM22 — Consentement aidant à l'acceptation** : un aidant invité consent **pour ses propres données** (e-mail, rôle, horodatages de ses saisies) à l'acceptation de l'invitation. Mention explicite qu'il ne consent **pas** pour l'enfant (mandat implicite du parent).
+- **RM23 — Opt-in géolocalisation** : la géoloc sur prise est désactivée par défaut et opt-in par aidant. Jamais activée pour Contributeur restreint.
+- **RM24 — Intégrité rapport** : le PDF exporté contient en pied de page un hash SHA-256 du contenu + timestamp + nom du générateur, pour tracer les falsifications.
+- **RM25 — Rappels bornés** : un rappel manqué déclenche **au plus 2 relances** (T+15 min push local, T+30 min e-mail). Au-delà : `missed`, plus de relance automatique.
+- **RM26 — Regroupement notifications peer** : si un aidant enregistre **plusieurs prises** dans une heure, les autres aidants reçoivent **une seule notification regroupée** (« 3 prises enregistrées par [Aidant] dans la dernière heure »).
+- **RM27 — Disclaimer omniprésent** : la mention « *Kinhale est un outil de suivi et de coordination. Il ne remplace pas un avis médical.* » apparaît (a) à l'onboarding, (b) dans les CGU, (c) en pied de chaque rapport exporté, (d) dans les paramètres « À propos ».
+- **RM28 — Purge des invitations expirées** : tâche nocturne système nettoie les invitations `expired` depuis plus de 30 j et les invitations `consumed` depuis plus de 90 j.
+
+---
+
+## 5. Workflows détaillés
+
+> Format : **Précondition → Étapes → Post-condition → Cas d'erreur → Impact notifications**.
+
+### W1 — Onboarding parent référent
+
+- **Précondition** : utilisateur sans compte, ouvre l'app ou le site.
+- **Étapes** :
+  1. Écran d'accueil : CTA *« Commencer »* + lien *« Continuer en mode invité »* (mode local).
+  2. Saisie e-mail → envoi magic link (ou OAuth Apple/Google). Vérification e-mail par clic sur le lien.
+  3. Création utilisateur avec langue + fuseau détectés, CGU + PC à accepter (RM9).
+  4. Création foyer : nom (pré-rempli « Famille de [prénom] »), confirmation fuseau.
+  5. Ajout enfant : prénom, année de naissance, photo optionnelle (minimisation, pas de date complète).
+  6. Ajout première pompe de fond : nom commercial, doses totales, optionnellement substance/dosage/péremption.
+  7. Création du premier plan de traitement : fréquence (par défaut `daily_twice` 08:00 / 20:00), doses par prise (défaut 1).
+  8. Ajout optionnel de la pompe de secours (peut être passé).
+  9. Écran final : CTA *« Inviter un autre aidant »* (menu vers W5) ou *« Commencer »*.
+- **Post-condition** : foyer créé, 1 enfant, 1 pompe de fond, 1 plan actif, 0 prise, 0 aidant secondaire, consentement horodaté.
+- **Cas d'erreur** : e-mail déjà utilisé → redirection login. Magic link expiré → renvoi. Perte de connexion entre étape 5 et 7 → reprise à l'étape suivante (état persisté).
+- **Notifications** : aucune push à ce stade (pas de rappel actif tant que l'utilisateur n'a pas quitté l'onboarding).
+
+### W2 — Saisie d'une prise planifiée (fond)
+
+- **Précondition** : foyer actif, plan actif, aidant connecté.
+- **Étapes** :
+  1. Aidant arrive sur la home (E1) : carte « Prochaine prise : 20:00 — pompe Flovent ». CTA dominant *« J'ai donné la pompe »*.
+  2. Tap → pop-up de confirmation minimal (3 s avec undo) : « Prise enregistrée à 19:47. Annuler ? ».
+  3. Si fenêtre respectée (`|now - target| <= X min`) : `type = maintenance_planned`, rappel associé passe à `confirmed`.
+  4. Si hors fenêtre : prompt « Rattrapage ? » → confirmation explicite (RM17) → `type = maintenance_unplanned`, `source = backfill`.
+  5. Décrément `doses_remaining` (RM7). Alerte `pump_low` si seuil atteint.
+  6. Propagation WebSocket aux autres aidants du foyer (RM5).
+- **Post-condition** : 1 `Prise` confirmée, rappel associé mis à jour, doses décomptées.
+- **Cas d'erreur** :
+  - Mode hors-ligne : événement ajouté à la file, affiché avec badge « en attente de sync ». Sync au retour réseau (W8).
+  - Double saisie détectée (RM6) : les deux prises passent `pending_review`, W4 bis.
+  - Pompe `expired` ou `empty` : saisie refusée, prompt « remplacer la pompe » (W7).
+- **Notifications** : RM5 aux autres aidants sous 5 s (en ligne).
+
+### W3 — Saisie d'une prise de secours avec symptômes
+
+- **Précondition** : foyer actif, pompe de secours déclarée.
+- **Étapes** :
+  1. Home (E1) : bouton rouge *« Pompe de secours »*.
+  2. Écran symptômes (E3) : grille tactile (toux, sifflement, essoufflement, réveil nocturne, gêne thoracique, autre). Multi-sélection.
+  3. Écran circonstances : pré-sélection (effort, allergène, infection, nuit, fumée, autre) + champ texte libre ≤ 500 car.
+  4. Validation → RM4 : au moins 1 symptôme OU 1 circonstance obligatoire. Sinon bloqué avec message sobre.
+  5. Confirmation saisie, décrément doses (RM7).
+  6. Propagation (RM5).
+- **Post-condition** : 1 `Prise` de type `rescue` avec symptômes et/ou circonstances.
+- **Cas d'erreur** : validation vide (rejet), hors-ligne (file d'attente), pompe expirée (refus).
+- **Notifications** : RM5 aux autres aidants + éventuelle surcharge (plusieurs secours dans 24 h → aucune alerte auto, le médecin voit via le rapport, RM produit : **jamais d'alerte santé auto-générée**).
+
+### W4 — Gestion d'une dose manquée
+
+- **Précondition** : plan actif, rappel `scheduled`.
+- **Étapes** :
+  1. T-0 = heure cible : push envoyé à tous les aidants de type `reminder`.
+  2. Fin de fenêtre (T + X min, défaut 30) : aucun aidant n'a confirmé → rappel passe à `missed`.
+  3. Notification `missed_dose` envoyée (push + local + e-mail fallback après 30 min supplémentaires, RM25).
+  4. L'aidant peut répondre : *« Je l'ai donnée à »* (picker heure jusqu'à 24 h arrière, W2 rattrapage) OU *« Non, oubliée »* (journalise la dose manquée explicite, visible en gris dans l'historique).
+  5. Au-delà de 24 h sans action : statut final `missed`, visible dans le rapport médecin (indicateur d'observance).
+- **Post-condition** : rappel en statut final (`confirmed` via rattrapage OU `missed`).
+- **Cas d'erreur** : push non délivré → fallback local + e-mail (RM25).
+- **Notifications** : 1 push à T-0, 1 push à T+X, 1 e-mail à T+X+30 min maximum.
+
+### W5 — Invitation d'un aidant
+
+- **Précondition** : Admin connecté, <10 invitations actives (RM21).
+- **Étapes** :
+  1. Admin ouvre E8 (Gestion aidants) → CTA *« Inviter »*.
+  2. Choix du rôle : `contributor` ou `restricted_contributor`.
+  3. Saisie du nom d'affichage (« Maman », « Garderie CPE Soleil »).
+  4. Génération : `invite_code` + `qr_payload` + `pin` (6 chiffres aléatoires, jamais stocké en clair).
+  5. Choix du canal : e-mail, SMS (futur), QR à afficher / imprimer, lien à copier.
+  6. Envoi ou partage manuel.
+  7. Aidant cible ouvre le lien → si `contributor` : création de compte (magic link + acceptation CGU + consentement propres données RM22) ; si `restricted_contributor` : W6.
+  8. Matérialisation : ligne `Aidant` créée, invitation passe en `consumed`, notification à l'Admin.
+- **Post-condition** : 1 aidant actif supplémentaire, invitation archivée.
+- **Cas d'erreur** : expiration, PIN faux 3 fois → verrouillage invitation 15 min, quota d'invitations atteint, e-mail invalide.
+- **Notifications** : push à l'Admin à chaque acceptation, audit log `invitation_accepted`.
+
+### W6 — Onboarding aidant restreint sans compte
+
+- **Précondition** : invitation `restricted_contributor` active, aidant reçoit lien + PIN.
+- **Étapes** :
+  1. Aidant ouvre l'app (ou la PWA) sur un appareil partagé.
+  2. Scan QR OU clic lien → pré-remplit `invite_code`.
+  3. Saisie PIN 6 chiffres.
+  4. Backend valide, émet un token de session 8 h (RM12) lié à une `caregiver_restricted_session_id`.
+  5. Écran épuré : prénom + photo (si opt-in) de l'enfant + 2 boutons géants (Fond / Secours).
+  6. Saisie d'une prise = W2 ou W3 simplifiés (pas d'historique accessible).
+  7. Session expirée : retour à l'écran PIN, pas de logout manuel nécessaire.
+- **Post-condition** : session restreinte 8 h, saisies attribuées à `caregiver_display_name` + `caregiver_restricted_session_id`.
+- **Cas d'erreur** : PIN faux 3 fois → verrouillage 15 min. Session expirée en pleine saisie → buffer local préservé, PIN à re-saisir.
+- **Notifications** : aucune reçue (aidant restreint ne reçoit pas de push). Envoi RM5 normal aux autres.
+
+### W7 — Alerte fin de pompe et remplacement
+
+- **Précondition** : pompe `active`, `doses_remaining <= threshold`.
+- **Étapes** :
+  1. Système détecte seuil atteint → notification `pump_low` à l'Admin (et contributeurs si opt-in).
+  2. Admin ouvre E7 (Pompes) → CTA *« Remplacer »*.
+  3. Saisie de la nouvelle pompe (nom, doses totales, péremption) ; ancienne passe à `status = replaced`, `replaced_at = now`, `replacement_pump_id = nouvelle`.
+  4. Plans actifs liés à l'ancienne pompe sont automatiquement migrés vers la nouvelle (même prescription).
+- **Post-condition** : nouvelle pompe active, ancienne archivée (visible en historique), plans migrés.
+- **Cas d'erreur** : remplacement sans nouvelle pompe saisie → refus. Péremption déjà passée à la saisie → avertissement.
+- **Notifications** : confirmation de remplacement aux autres aidants.
+
+### W8 — Synchronisation après mode hors-ligne
+
+- **Précondition** : 1 à N événements en file locale, reconnexion réseau.
+- **Étapes** :
+  1. Détection retour réseau (web / mobile).
+  2. Envoi batch (`POST /sync/batch`) avec tous les événements + `Idempotency-Key` par événement (RM15).
+  3. Serveur : validation, ordonnancement par `administered_at_utc`, détection des conflits (double saisie RM6, édition simultanée d'une même prise).
+  4. Réponse batch : par événement, statut `accepted` / `conflict` / `duplicate` / `rejected`.
+  5. Client : mise à jour locale, affichage des conflits à l'aidant (liste interactive).
+  6. Émission des notifications `peer_dose_recorded` (RM5) avec mention « synchronisée à [heure] » si décalage > 5 min.
+- **Post-condition** : file locale vide, base serveur cohérente, conflits présentés à l'aidant.
+- **Cas d'erreur** : 5xx backend → retry exponentiel (60s, 2min, 5min, 15min, 1h). Conflit non résolu → prise reste `pending_review` jusqu'à action Admin.
+- **Notifications** : regroupement (RM26) si > 3 prises à la fois.
+
+### W9 — Export rapport médecin
+
+- **Précondition** : foyer actif, Admin connecté (recommandation v1 : Admin uniquement).
+- **Étapes** :
+  1. Aidant ouvre E10 (Export) → sélection plage (dernier mois / 3 mois / personnalisé).
+  2. Bouton *« Générer PDF »* → serveur génère (< 5 s cible).
+  3. Aperçu en ligne + CTA *« Télécharger »*, *« Envoyer par e-mail »*, *« Copier le lien signé »* (lien expire 7 j).
+  4. Le CSV brut est également téléchargeable.
+  5. Entrée `report_generated` dans audit trail + notification `report_generated` à tous les Admins.
+- **Post-condition** : entrée `Rapport exporté` en base, fichier S3 chiffré, lien signé expirable.
+- **Cas d'erreur** : plage > 24 mois → refus (performance). Génération > 10 s → fallback asynchrone, e-mail quand prêt.
+- **Notifications** : e-mail à l'Admin demandeur avec lien signé.
+
+### W10 — Suppression de compte / foyer (RM10)
+
+- **Précondition** : Admin connecté.
+- **Étapes** :
+  1. E11 Paramètres → *« Supprimer mon foyer »* → confirmation avec saisie du mot « SUPPRIMER ».
+  2. Système prépare une **archive de portabilité** : export CSV complet + PDF complet des 12 derniers mois → envoi e-mail sécurisé (lien signé 7 j).
+  3. Statut foyer → `pending_deletion`, affichage in-app « Suppression prévue le [date+30j] ». Possibilité d'annuler pendant 7 j.
+  4. À J+7 : passage à `deleted` ; données chiffrées rendues illisibles (rotation clé KMS spécifique au foyer), purge des backups rotatifs dans les 30 j suivants.
+  5. Audit trail pseudonymisé, conservé.
+- **Post-condition** : foyer inaccessible, données purgées sous 30 j, preuves conservées.
+- **Cas d'erreur** : plusieurs Admins → bloqué si l'Admin qui supprime n'est pas le seul ; passe par W11 d'abord.
+- **Notifications** : e-mail confirmation + e-mail archive + e-mails d'information aux autres aidants 24 h avant purge effective.
+
+### W11 — Transfert d'admin (RM1)
+
+- **Précondition** : Admin connecté, ≥ 1 autre aidant avec rôle `contributor`.
+- **Étapes** :
+  1. E8 → *« Transférer l'admin »*.
+  2. Sélection du contributeur cible.
+  3. MFA / magic link reconfirmation de l'Admin sortant.
+  4. Notification push + e-mail à la cible pour acceptation explicite.
+  5. Acceptation → rôle Admin sortant devient `contributor`, cible devient `admin`, mise à jour de `rprp_user_id` si c'était le sortant.
+- **Post-condition** : foyer avec nouvel Admin, ancien Admin en `contributor`.
+- **Cas d'erreur** : refus de la cible → aucun changement, Admin sortant notifié.
+- **Notifications** : push + e-mail aux deux parties.
+
+### W12 — Ré-acceptation CGU après mise à jour majeure
+
+- **Précondition** : publication d'une nouvelle version majeure des CGU / PC.
+- **Étapes** :
+  1. Backend pousse le nouveau `consent_version` aux clients via WebSocket ou au prochain login.
+  2. Modale bloquante à l'ouverture : résumé des changements + CTA *« Voir les détails »* + *« Accepter »*.
+  3. Ré-acceptation horodatée, mise à jour `consent_log`.
+  4. Refus → compte mis en lecture seule, aucune nouvelle saisie. Option de suppression de compte (W10).
+- **Post-condition** : tous les utilisateurs actifs sur la nouvelle version, anciens en lecture seule.
+- **Cas d'erreur** : aidant restreint en cours de session → l'Admin doit ré-inviter (nouvelle session).
+
+---
+
+## 6. Interfaces utilisateur (écrans principaux)
+
+Format : objectif, contenu, actions, navigation, cas particuliers.
+
+### E1 — Accueil / tableau de bord du foyer
+
+- **Objectif** : en 3 secondes, savoir où en est l'enfant.
+- **Contenu** : prénom + photo enfant, carte « Prochaine prise prévue » (heure, statut : à venir / à l'heure / en retard / manquée), carte « Dernière prise » (aidant, heure, type), badge hors-ligne si pertinent.
+- **Actions** : bouton dominant *« J'ai donné la pompe de fond »* (bleu), bouton secondaire *« Pompe de secours »* (rouge), icône historique, icône paramètres.
+- **Navigation** : vers E2, E4, E11.
+- **Cas vide** : pas encore de plan → CTA *« Créer un plan »*.
+- **Cas offline** : badge *« Hors-ligne — x action(s) en attente »*.
+
+### E2 — Saisie rapide prise
+
+- **Objectif** : confirmer une prise en ≤ 10 s (cible O1).
+- **Contenu** : pompe sélectionnée (par défaut = plan actif), heure (now par défaut, éditable), doses (par défaut 1).
+- **Actions** : *« Confirmer »* (vert), *« Annuler »* (texte).
+- **Navigation** : retour E1 après confirmation (toast undo 5 s).
+- **Cas erreur** : pompe `expired` → blocage + lien vers E7 remplacement.
+
+### E3 — Formulaire symptômes / circonstances (secours)
+
+- **Objectif** : documenter une prise `rescue` en ≤ 30 s (cible J3).
+- **Contenu** : grille icônes symptômes (6 items pré-définis + « Autre »), liste circonstances (6 items + « Autre »), champ texte libre optionnel.
+- **Actions** : *« Valider »* (grisé tant que RM4 non satisfaite), *« Annuler »*.
+- **Navigation** : vers E1 avec toast.
+
+### E4 — Historique des prises (timeline filtrable)
+
+- **Objectif** : consulter / filtrer l'historique.
+- **Contenu** : timeline chronologique inversée, cartes par jour, chaque carte avec heure + aidant + type (icône + couleur) + symptômes si secours.
+- **Actions** : filtres (type, plage, aidant), tap sur carte → E5.
+- **Cas offline** : lecture des 30 derniers jours accessible (RM20).
+
+### E5 — Détails / édition d'une prise
+
+- **Objectif** : voir toutes les infos d'une prise, permettre correction ou annulation.
+- **Contenu** : heure locale + UTC + heure de sync (si décalée), aidant, pompe, doses, symptômes, circonstances, commentaire, source (manuel / rattrapage / rappel).
+- **Actions** : *« Modifier »* (auteur ≤ 30 min, RM18), *« Annuler la prise »* (Admin), audit trail visible.
+- **Cas erreur** : modification refusée hors délai → message clair.
+
+### E6 — Plan de traitement
+
+- **Objectif** : visualiser et ajuster la prescription.
+- **Contenu** : pompe, fréquence, heures cibles, doses par prise, statut, dates.
+- **Actions** : édition (Admin), pause, reprise, nouveau plan (si ancienne pompe remplacée).
+- **Cas particulier** : changement de plan en cours de journée → ajuste les rappels du reste de la journée, conserve les rappels passés en `cancelled`.
+
+### E7 — Gestion des pompes
+
+- **Objectif** : lister, ajouter, remplacer, consulter le niveau.
+- **Contenu** : liste des pompes actives + barre de remaining doses + date péremption ; onglet historique pompes.
+- **Actions** : *« Ajouter »*, *« Remplacer »* (W7), *« Archiver »*.
+- **Cas erreur** : nouvelle pompe avec même nom commercial → avertissement non bloquant.
+
+### E8 — Gestion des aidants
+
+- **Objectif** : inviter, lister, révoquer aidants.
+- **Contenu** : liste des aidants actifs avec rôle, nom d'affichage, statut (connecté il y a…, session restreinte expirant à…), invitations en cours.
+- **Actions** : *« Inviter »* (W5), *« Transférer admin »* (W11), *« Retirer »*.
+- **Cas particulier** : dernier Admin essaye de se retirer → prompt RM1.
+
+### E9 — Profil enfant
+
+- **Objectif** : infos minimales.
+- **Contenu** : prénom, année de naissance, photo, notes médicales.
+- **Actions** : édition par Admin uniquement.
+- **Cas particulier** : ajout second enfant bloqué (RM13) → teasing v1.1.
+
+### E10 — Export / rapport médecin
+
+- **Objectif** : générer un PDF en 1 clic.
+- **Contenu** : sélecteur de plage (Derniers 30 j / 90 j / personnalisé), aperçu miniature.
+- **Actions** : *« Générer PDF »*, *« Télécharger CSV »*, *« Envoyer par e-mail »*, *« Copier le lien signé »*.
+- **Cas erreur** : plage > 24 mois → refus.
+
+### E11 — Paramètres & compte
+
+- **Objectif** : préférences, conformité, suppression.
+- **Contenu** : langue, fuseau, fenêtre confirmation, seuil pompe, notifications (opt-in granulaire), confidentialité (RPRP contact, version CGU, révocation consentement), export / suppression (W10).
+- **Actions** : modification, export complet, suppression.
+- **Cas particulier** : refus ré-acceptation CGU → lecture seule.
+
+### E12 — Onboarding (3-5 écrans)
+
+- **Objectif** : première mise en service en < 2 min (cible O5).
+- **Écrans** :
+  1. Bienvenue + disclaimer non-DM (RM27).
+  2. Identité (e-mail magic link OU OAuth).
+  3. Enfant (prénom, année).
+  4. Pompe de fond + plan (valeurs par défaut 08:00 / 20:00).
+  5. Invitation aidant (skip possible).
+- **Cas particulier** : mode invité local sans compte, migration au premier login.
+
+### E13 — Écran de synchronisation / conflits
+
+- **Objectif** : transparence sur la file d'attente et les conflits.
+- **Contenu** : liste des événements en attente, badge état, liste des conflits `pending_review`.
+- **Actions** : *« Forcer la sync »*, *« Résoudre »* sur chaque conflit (choix parmi les doublons).
+
+---
+
+## 7. Contrats API
+
+### 7.1. Approche recommandée
+
+**REST + JSON**. Justification :
+- Cache HTTP natif, outillage mature (OpenAPI, Postman, SDK auto-générés).
+- Granularité fine utile pour le multi-tenant strict et l'idempotence.
+- Les clients mobiles et web ont des besoins homogènes (pas de sur-fetch justifiant GraphQL).
+- Temps réel assuré hors REST via **WebSocket** dédié (`/realtime`).
+
+**Authentification** : JWT court (15 min) + refresh token rotatif (7 j), header `Authorization: Bearer <jwt>`. Sessions Contributeur restreint utilisent un token JWT spécifique avec claim `session_type=restricted` et TTL 8 h.
+
+**Idempotence** : sur tous les `POST` de création (prises, invitations, rapports), header `Idempotency-Key` obligatoire (UUID v4). Stockage 24 h côté backend.
+
+**Pagination** : cursor-based sur historique (`?cursor=...&limit=50`), limite 100.
+
+**Versioning** : URL `/v1/...`. Changements majeurs = `/v2`.
+
+**Erreurs** : format standardisé `{ "error": { "code": "string", "message": "string", "details": {...} } }`, codes métier stables.
+
+### 7.2. Domaines et endpoints
+
+#### Auth & comptes (`/v1/auth/*`)
+- `POST /auth/magic-link` — envoi magic link (body `{email}`).
+- `POST /auth/magic-link/verify` — vérification (body `{token}`, renvoie JWT).
+- `POST /auth/oauth/apple`, `POST /auth/oauth/google` — OAuth.
+- `POST /auth/passkey/register`, `POST /auth/passkey/authenticate` — WebAuthn.
+- `POST /auth/restricted/authenticate` — body `{invite_code, pin}`.
+- `POST /auth/refresh` — renouvellement JWT.
+- `POST /auth/logout` — invalidation session.
+
+#### Foyers (`/v1/households/*`)
+- `GET /households/me` — foyer courant.
+- `POST /households` — création (Admin uniquement, à l'onboarding).
+- `PATCH /households/:id` — mise à jour (timezone, langue, fenêtres, seuils).
+- `DELETE /households/:id` — déclenche W10.
+
+#### Enfants (`/v1/children/*`)
+- `GET /children/:id`.
+- `POST /children` — v1.0 refuse si un enfant existe déjà (RM13).
+- `PATCH /children/:id`.
+
+#### Pompes (`/v1/inhalers/*`)
+- `GET /inhalers?status=active`.
+- `POST /inhalers` — Admin.
+- `PATCH /inhalers/:id`.
+- `POST /inhalers/:id/replace` — corps : `{new_inhaler_payload}`.
+
+#### Plans (`/v1/treatment-plans/*`)
+- `GET /treatment-plans?child_id=...`.
+- `POST /treatment-plans` — Admin.
+- `PATCH /treatment-plans/:id` — pause / reprise / modification.
+
+#### Prises (`/v1/doses/*`) — **critique, avec idempotence**
+- `GET /doses?range=...&cursor=...`.
+- `POST /doses` — idempotent via `Idempotency-Key`.
+- `PATCH /doses/:id` — édition dans les 30 min (RM18).
+- `POST /doses/:id/void` — annulation avec raison.
+
+**Exemple `POST /v1/doses`** :
+```json
+{
+  "client_event_id": "b9e3...",
+  "pump_id": "7c2f...",
+  "plan_id": "4a10...",
+  "type": "maintenance_planned",
+  "administered_at_local": "2026-04-19T20:05:00-04:00",
+  "doses_administered": 1,
+  "symptoms": [],
+  "circumstances": [],
+  "free_text_note": null,
+  "source": "manual_entry"
+}
+```
+Réponse `201 Created` avec entité complète + `server_administered_at_utc` + statut. Renvoi `200 OK` si déjà traité (même `Idempotency-Key`).
+
+#### Aidants & invitations (`/v1/invitations/*`, `/v1/caregivers/*`)
+- `POST /invitations` — body `{target_role, channel, display_name, max_uses}` → renvoie `{invite_code, pin, qr_payload, expires_at}`.
+- `GET /invitations` — liste invitations actives (Admin).
+- `DELETE /invitations/:id` — révocation.
+- `POST /invitations/:code/accept` — acceptation (avec `pin` si restreint).
+- `GET /caregivers` — liste aidants.
+- `PATCH /caregivers/:id` — changement rôle, permissions.
+- `DELETE /caregivers/:id` — retrait.
+- `POST /caregivers/:id/transfer-admin` — W11.
+
+#### Notifications (`/v1/notifications/*`)
+- `GET /notifications?cursor=...`.
+- `PATCH /notifications/:id/read`.
+- `POST /notifications/preferences` — opt-in granulaire par type.
+
+#### Rapports (`/v1/reports/*`)
+- `POST /reports/generate` — body `{range_start, range_end, format, intended_recipient}` → renvoie `{report_id, signed_url, expires_at}`.
+- `GET /reports/:id`.
+- `GET /reports/:id/download` — via signed URL.
+
+**Exemple `POST /v1/reports/generate`** :
+```json
+{
+  "range_start": "2026-01-19",
+  "range_end": "2026-04-19",
+  "format": "pdf",
+  "intended_recipient": "physician"
+}
+```
+Réponse `202 Accepted` avec `{report_id, status: "processing"}` si > 5 s, ou `201 Created` avec URL signée si immédiat.
+
+#### Confidentialité & droits (`/v1/privacy/*`)
+- `POST /privacy/export` — archive complète CSV + PDF, envoi e-mail.
+- `POST /privacy/delete` — déclenche W10.
+- `POST /privacy/consent` — acceptation version CGU (body `{version_hash}`).
+- `GET /privacy/consent-log` — historique consentements.
+
+#### Synchronisation (`/v1/sync/*`)
+- `POST /sync/batch` — batch d'événements hors-ligne.
+- `GET /sync/since?cursor=...` — pull des modifications serveur depuis le dernier timestamp.
+
+**Exemple `POST /v1/sync/batch`** :
+```json
+{
+  "events": [
+    {
+      "type": "dose.create",
+      "client_event_id": "b9e3...",
+      "payload": { /* identique POST /doses */ }
+    },
+    {
+      "type": "dose.void",
+      "client_event_id": "c1a2...",
+      "payload": { "dose_id": "1234...", "voided_reason": "double saisie" }
+    }
+  ]
+}
+```
+Réponse `200 OK` avec liste `{client_event_id, status, server_entity | error}` par événement.
+
+#### Temps réel
+- `GET /realtime` — upgrade WebSocket, authentifié par JWT, scopé `household_id`. Événements serveur : `dose.created`, `dose.voided`, `reminder.missed`, `pump.low`, `invitation.accepted`, etc.
+
+---
+
+## 8. Règles spécifiques hors-ligne & synchronisation
+
+- **Stockage local** : pompes actives, plans actifs, 30 derniers jours de prises, préférences notifications, file d'attente d'événements. Chiffré (Keychain iOS, Android Keystore, IndexedDB + Web Crypto API web).
+- **Rétention locale** : 90 j maximum (purge automatique au-delà), même si lecture offline n'est garantie qu'à 30 j.
+- **Stratégie sync** :
+  - **Push** par le client dès retour réseau (W8).
+  - **Pull** incrémental (`GET /sync/since`) à l'ouverture de l'app et toutes les 60 s en foreground ; WebSocket pour le temps réel en plus.
+  - **Horodatage serveur autoritaire** pour l'ordre, `administered_at_utc` fourni par le client conservé.
+- **Résolution de conflits** :
+  - **Prises** : jamais perdues, jamais fusionnées. Double saisie suspectée = RM6 (`pending_review`).
+  - **Éditions simultanées** : last-write-wins par `updated_at` serveur, avec journal de l'ancienne valeur dans l'audit trail.
+  - **Plan modifié puis prise offline selon ancien plan** : la prise est conservée, rattachée à la version du plan historique.
+- **Délai max notification post-sync** : 5 s après `recorded_at_utc`, pas de retard artificiel.
+- **Limites hors-ligne** :
+  - Pas de création de plan offline (nécessite synchro pour cohérence).
+  - Pas d'invitation d'aidant offline.
+  - Pas d'export de rapport offline.
+  - Pas de modification de l'enfant offline.
+
+---
+
+## 9. Règles de notifications
+
+- **Types** :
+  - `reminder` — rappel planifié (push).
+  - `missed_dose` — dose manquée (push + e-mail fallback).
+  - `peer_dose_recorded` — prise enregistrée par un autre (push).
+  - `pump_low` — fin de pompe (push à Admin, + contributeurs si opt-in).
+  - `pump_expiring` — péremption proche.
+  - `dispute_detected` — double saisie suspectée (push aux deux aidants).
+  - `admin_handover` — transfert admin en attente (push + e-mail).
+  - `consent_update_required` — nouvelle version CGU (in-app).
+  - `security_alert` — login suspect, changement mot de passe, export de données (push + e-mail).
+- **Canaux** :
+  - **Push OS** (APNs, FCM) — canal principal. Payload minimal (RM16).
+  - **Notification locale** — redondance si push KO (programmée côté OS pour les rappels connus).
+  - **E-mail** — fallback pour `missed_dose` (après 30 min sans action), `security_alert`, archives de portabilité, rapports.
+- **Fréquence max** : **≤ 15 notifications/jour/aidant** toutes catégories confondues. Au-delà, regroupement forcé (RM26).
+- **Regroupement** : plusieurs `peer_dose_recorded` d'un même aidant dans une fenêtre de 60 min = 1 seule notification agrégée.
+- **Paramétrage** : chaque aidant désactive individuellement chaque type **sauf** `missed_dose` et `security_alert` (protection sanitaire / sécurité).
+- **Quiet hours** : chaque aidant peut définir une plage « ne pas déranger » (push silencieux, pas de notification locale) — sauf `missed_dose` de nuit si plan `daily_twice` 20:00 n'a pas été confirmé à 21:00 (règle de sécurité).
+
+---
+
+## 10. Règles de conformité à exposer dans l'app
+
+Correspondance directe avec `COMPLIANCE.md`.
+
+- **Écran onboarding** : disclaimer non-DM (RM27), lien CGU + PC, case non pré-cochée de consentement (art. 9.2.a RGPD), case opt-in séparée pour crash reports.
+- **Écran paramètres / confidentialité** :
+  - Version des CGU acceptée (hash SHA-256 tronqué visible).
+  - Date d'acceptation.
+  - Bouton *« Exporter mes données »* (W9 complet).
+  - Bouton *« Supprimer mon foyer »* (W10).
+  - Coordonnées du RPRP.
+  - Lien vers la politique de confidentialité dédiée mineurs.
+  - Bouton *« Retirer mon consentement »* (implique W10).
+- **Chaque rapport exporté** : mention disclaimer en pied + hash intégrité.
+- **Ré-acceptation CGU** : modale bloquante (W12) à chaque version majeure.
+- **Journal d'accès** : l'Admin peut consulter un résumé des 90 derniers événements d'audit le concernant (hors événements d'autres aidants).
+- **Disclaimer pied d'écran** : présent discrètement sur E1, E4, E10.
+- **Audit trail consultable par le RPRP** : back-office protégé, pas accessible via l'app utilisateur.
+
+---
+
+## 11. Exigences non fonctionnelles (NFR)
+
+- **Performance** :
+  - Ouverture app < **2 s** (95e percentile) sur mobile milieu de gamme.
+  - Saisie prise (E1 → confirmation) < **10 s** médiane (cible O1).
+  - `POST /sync/batch` < **5 s** pour 100 événements (95e percentile).
+  - `POST /reports/generate` < **5 s** pour 90 j d'historique.
+- **Disponibilité** : **99,5 %** mensuel sur l'instance officielle (SLO interne, pas d'engagement contractuel en v1).
+- **Fiabilité notifications** : > **99 %** de push délivrés sous 60 s de la cible (cible O4). Monitoring instrumenté.
+- **Scalabilité** : supporter **10 000 foyers actifs** sans refactor. Preuves : tests de charge sur `POST /doses`, `POST /sync/batch`, WebSocket concurrents.
+- **Internationalisation** : FR + EN en v1.0. Tous les textes via fichiers i18n (pas de chaînes en dur). Dates / nombres / fuseaux formatés selon locale.
+- **Accessibilité** : **WCAG 2.1 AA**. Audit automatique (axe-core) + navigation lecteur d'écran validée sur J2, J3, J5.
+- **Sécurité** : conforme à `COMPLIANCE.md` (OWASP Top 10, MASVS niveau 2, chiffrement KMS, audit trail, gestion secrets).
+- **Observabilité** : logs structurés JSON, métriques Prometheus-like, traces OpenTelemetry, dashboards Grafana. RPRP accès audit trail en lecture.
+- **Portabilité** : code open source (AGPL v3), Docker Compose de self-hosting, documentation d'installation.
+- **Compatibilité** :
+  - iOS ≥ 15, Android ≥ 9 (API 28), navigateurs evergreen (Chrome / Safari / Firefox / Edge derniers 2 ans).
+  - PWA installable sur Android et iOS.
+
+---
+
+## 12. Critères d'acceptation globaux
+
+Par bloc fonctionnel. Les critères détaillés par story sont produits dans le backlog projet.
+
+### Compte & foyer
+- CA1 : un parent peut créer un compte et un foyer en moins de 2 min sans assistance.
+- CA2 : un aidant secondaire peut rejoindre un foyer en moins de 60 s via lien + PIN.
+- CA3 : un aidant restreint peut enregistrer une prise en moins de 10 s via QR + PIN.
+
+### Saisie des prises
+- CA4 : une prise de fond planifiée se confirme en 1 tap sur E1 et propage aux autres < 5 s.
+- CA5 : une prise de secours sans symptôme ni circonstance est refusée avec message clair.
+- CA6 : une prise enregistrée offline est synchronisée au retour réseau avec horodatage initial préservé.
+
+### Rappels et doses manquées
+- CA7 : 99 % des rappels planifiés sont livrés < 60 s de la cible sur banc de test.
+- CA8 : une dose non confirmée 30 min après l'heure cible génère une notification `missed_dose`.
+- CA9 : un rattrapage jusqu'à 24 h en arrière est possible avec confirmation explicite.
+
+### Pompes
+- CA10 : une pompe atteignant le seuil 20 doses restantes génère une notification à l'Admin.
+- CA11 : le remplacement d'une pompe migre automatiquement les plans actifs.
+
+### Rapport médecin
+- CA12 : un PDF 1-2 pages est généré en < 5 s pour une plage de 3 mois.
+- CA13 : le PDF contient disclaimer + hash intégrité en pied.
+- CA14 : un médecin peut lire le PDF en moins de 30 s pour prendre une décision (validation par 1 pneumo-pédiatre).
+
+### Conformité
+- CA15 : un utilisateur peut exporter toutes ses données en 1 action.
+- CA16 : un utilisateur peut supprimer son foyer, reçoit une archive et la purge s'exécute sous 30 j.
+- CA17 : une mise à jour majeure des CGU bloque l'utilisation jusqu'à ré-acceptation.
+- CA18 : le payload des notifications push ne contient aucune donnée santé en clair (vérifié par test automatisé).
+
+### Multi-tenant & sécurité
+- CA19 : un test d'accès IDOR à un foyer tiers renvoie systématiquement 403 / 404.
+- CA20 : l'audit trail enregistre login, saisie, export, suppression, consentement.
+
+---
+
+## 13. Ouvertures pour v1.1 et v2.0
+
+### v1.1 — Multi-enfants (fratrie)
+
+- **Impact modèle** : `Foyer` 1 → N `Enfant` (le 1:1 v1.0 devient 1:N). Les tables `Pompe`, `Plan`, `Prise` référencent déjà `child_id` — aucun refactor.
+- **Impact UI** : ajout sélecteur d'enfant sur E1 (picker en haut), filtrage E4 par enfant, E9 devient liste.
+- **Impact API** : `POST /children` s'ouvre (levée RM13), `GET /children` retourne liste.
+- **Impact rapport** : PDF séparé par enfant (1 enfant = 1 rapport).
+
+### v2.0 — Apple HealthKit / Google Health Connect
+
+- **Impact modèle** : ajout table `HealthIntegration` (child_id, provider, status, last_sync_at, scopes), ajout champ `external_refs` sur `Prise` (pour dédoublonner les imports).
+- **Impact UI** : paramètres d'intégration par enfant, bandeau d'état (sync OK / erreur).
+- **Impact API** : endpoints `/v1/integrations/apple-health/*`, `/v1/integrations/health-connect/*`.
+- **Impact conformité** : DPIA additionnel, mise à jour PC, nouveau consentement.
+
+### v2.0 — Portail pro médecin
+
+- **Impact modèle** : nouveau rôle `physician`, table `HouseholdAccessGrant` (foyer consent à partager en lecture seule), table `Practice` / `Clinic`, table `Billing` (B2B).
+- **Impact API** : domaine `/v1/practices/*`, scopes différenciés.
+
+---
+
+## 14. Points ouverts pour l'architecture technique
+
+Ces points sont détaillés dans `../architecture/ARCHITECTURE.md` :
+
+1. **Stratégie temps réel** : WebSocket vs Server-Sent Events vs polling long. Choix retenu : **WebSocket**.
+2. **Framework cross-platform** : choix retenu : **React Native + Expo + React Native Web + Next.js 15**.
+3. **Génération PDF** : client-side (local-first) ou server-side. Choix retenu : **client-side** pour cohérence zero-knowledge.
+4. **Stack offline + sync** : choix retenu : **Automerge 2 + op-sqlite**.
+5. **Authentification** : choix retenu : **magic link + passkey WebAuthn** implémenté dans le relais.
+6. **Hébergement backend** : choix retenu : **AWS natif (ca-central-1) via CDK**.
+
+---
+
+*Fin des spécifications fonctionnelles Kinhale v1.0 — document publié sous AGPL v3.*


### PR DESCRIPTION
## Résumé

Première PR du projet Kinhale : publication des documents de cadrage de la v1.0 sous forme publiable (AGPL v3), dans `docs/`.

Livrables publiés :

- **`docs/product/PRD.md`** — vision produit, personas, parcours utilisateurs J1-J7, périmètre v1.0 / v1.1 / v2.0, OKR et critères de sortie
- **`docs/product/SPECS.md`** — spécifications fonctionnelles détaillées, règles métier RM1-RM9, contrats API du relais E2EE, matrices de permissions
- **`docs/architecture/ARCHITECTURE.md`** — architecture local-first + E2EE zero-knowledge, stack (React Native / Next.js / Fastify / Postgres / libsodium / MLS), flux de synchronisation, ADRs de référence
- **`docs/product/COMPLIANCE.md`** — cadre réglementaire multi-juridictions (Loi 25, PIPEDA, RGPD, COPPA), privacy by design, consentement, gouvernance et matrice des risques
- **`docs/README.md`** — index de la documentation publiable

## Sanitisation appliquée

Les sources internes (dans `.agents/current-run/`, gitignoré) contenaient des données commerciales. Les versions publiées en ont été expurgées :

- Retrait de **tous** les montants (CAD / EUR / USD) — budgets, honoraires, TJM, marges
- Retrait de toutes les estimations en jours·hommes ou heures facturables
- Neutralisation des références à Kamez Conseils en tant que prestataire commercial (Kamez reste mentionné comme mainteneur / créateur, conformément à la licence AGPL)
- Anonymisation des prénoms dans les personas (libellés génériques)
- Retrait des sections commerciales (propositions chiffrées, clauses contractuelles)

Contenu produit, fonctionnel, technique et réglementaire conservé **intégralement**.

## Vérifications

- [x] Aucune donnée commerciale résiduelle (vérifié par grep sur motifs monétaires)
- [x] Liens internes entre documents cohérents
- [x] Conformité à la licence AGPL v3
- [x] Chemins alignés avec les références listées dans `CLAUDE.md`

## Points d'attention pour la revue

- Certains liens pointent vers des fichiers non encore créés (`docs/contributing/GITFLOW.md`, `docs/user/SELF_HOSTING.md`, `SECURITY.md`) — prévus dans les prochaines PR de bootstrap.
- La section §10 de `COMPLIANCE.md` (gouvernance chiffrée) a nécessité une sanitisation plus intrusive : la table originale listait des montants ligne par ligne — remplacée par une liste de tâches sans chiffrage.

## Test plan

- [ ] Relire `docs/README.md` et valider la cohérence des descriptions
- [ ] Parcourir `PRD.md` — valider que le périmètre v1.0 / v1.1 / v2.0 reste fidèle au cadrage
- [ ] Parcourir `SPECS.md` — valider les règles métier RM1-RM9 et les contrats API
- [ ] Parcourir `ARCHITECTURE.md` — valider la stack et les ADRs
- [ ] Parcourir `COMPLIANCE.md` — valider l'applicabilité Loi 25 / RGPD / COPPA et les livrables bloquants v1.0
- [ ] Confirmer visuellement via GitHub que les 4 documents s'affichent correctement

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)