### PR TITLE
docs(KIN-002): formalise la nomenclature des messages de commit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Chaque commit comporte **obligatoirement** une ligne de description (sujet) **et
 
 Une seule ligne, **≤ 72 caractères**, à l'impératif présent, sans point final, structure :
 
-```
+```text
 <type>(<scope>): <description>
 ```
 
@@ -127,7 +127,7 @@ Une seule ligne, **≤ 72 caractères**, à l'impératif présent, sans point fi
 
 Exemples de sujets valides :
 
-```
+```text
 fix(sync): corrige la perte d'événements lors d'une reconnexion WS
 feat(auth): ajoute la connexion via passkey WebAuthn
 docs(compliance): met à jour la matrice Loi 25 / RGPD
@@ -147,7 +147,7 @@ Le corps explique **pourquoi** le changement est fait, pas quoi (le diff le mont
 
 ### Exemple complet
 
-```
+```text
 fix(sync): corrige la perte d'événements lors d'une reconnexion WS
 
 Lorsque le client se reconnecte après une perte réseau, le serveur

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,8 +107,68 @@ Résumé — détails complets dans `docs/contributing/GITFLOW.md`.
 - Review d'au moins 1 pair ; **2 reviews obligatoires** si la PR touche `packages/crypto`, `packages/sync`, ou tout code de sécurité.
 - Aucune PR ne touche plus de ~400 lignes modifiées sauf exception justifiée.
 - Pas de commit direct sur `main` ou `develop`.
-- Conventional commits (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `security`).
 - Un ADR (`docs/architecture/adr/`) pour toute décision architecturale structurante.
+
+## Format des messages de commit
+
+Chaque commit comporte **obligatoirement** une ligne de description (sujet) **et** un corps (body). Conforme à [Conventional Commits 1.0](https://www.conventionalcommits.org/fr/v1.0.0/).
+
+### Ligne de description (sujet)
+
+Une seule ligne, **≤ 72 caractères**, à l'impératif présent, sans point final, structure :
+
+```
+<type>(<scope>): <description>
+```
+
+- **`type`** (obligatoire) : `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `security`, `revert`.
+- **`scope`** (optionnel, recommandé) : module ou package touché — `crypto`, `sync`, `domain`, `api`, `mobile`, `web`, `ui`, `i18n`, `infra`, `ci`, `auth`, `push`, `offline`, …
+- **`description`** : verbe à l'impératif + contexte minimal, en minuscules, sans ponctuation finale.
+
+Exemples de sujets valides :
+
+```
+fix(sync): corrige la perte d'événements lors d'une reconnexion WS
+feat(auth): ajoute la connexion via passkey WebAuthn
+docs(compliance): met à jour la matrice Loi 25 / RGPD
+security(crypto): active l'Argon2id params OWASP 2024
+```
+
+### Corps (body)
+
+Séparé du sujet par **une ligne vide**. Obligatoire pour tout commit non trivial (≥ quelques lignes modifiées ou toute modification métier / sécurité / infra).
+
+Le corps explique **pourquoi** le changement est fait, pas quoi (le diff le montre) :
+
+- Contexte et motivation du changement.
+- Impacts (migrations DB, breaking changes, dépendances, feature flags, ADR liée).
+- Références ticket / issue (`Refs: KIN-042`, `Closes: #137`).
+- Signature `Co-Authored-By:` si pair-programming ou assistance IA.
+
+### Exemple complet
+
+```
+fix(sync): corrige la perte d'événements lors d'une reconnexion WS
+
+Lorsque le client se reconnecte après une perte réseau, le serveur
+renvoyait le cursor `lastSeq` avant de confirmer la souscription.
+Résultat : les événements arrivés pendant la fenêtre de reconnexion
+étaient perdus silencieusement.
+
+La séquence est désormais : ack subscribe -> replay depuis lastSeq.
+Test de reconnexion avec latence simulée ajouté.
+
+Refs: KIN-042
+Closes: #73
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+### Cas particuliers
+
+- **Breaking change** : ajouter `!` après le type / scope (`feat(api)!: …`) **et** un footer `BREAKING CHANGE: <description>` dans le body.
+- **Hotfix prod** : toujours `fix(<scope>): …` + référence incident + ticket dans le body.
+- **Revert** : `revert: <sujet du commit reverté>` + dans le body la raison et le SHA reverté (`Reverts: <sha>`).
+- **Changements crypto ou sécurité** : type `security(<scope>)` obligatoire ; body mentionne l'ADR, le test vector ajouté et l'auditeur informé.
 
 ## Règles de code
 


### PR DESCRIPTION
## Résumé

Formalise la structure **sujet + corps** des messages de commit dans `CLAUDE.md`, conforme à Conventional Commits 1.0.

## Changements

- Retrait du bullet unique « Conventional commits » de la section *Méthodologie*.
- Ajout d'une section dédiée **« Format des messages de commit »** couvrant :
  - **Sujet** : une ligne ≤ 72 car., impératif, minuscules, sans point final, format `<type>(<scope>): <description>` avec liste exhaustive des types (`feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`, `build`, `ci`, `security`, `revert`) et scopes recommandés.
  - **Corps** : obligatoire pour tout commit non trivial, explique le **pourquoi** (contexte, impacts, ADR, références ticket / issue, co-auteurs).
  - 4 exemples de sujets valides + 1 exemple complet sujet + body.
  - Cas particuliers : breaking change, hotfix, revert, sécurité / crypto.

## Vérifications

- [x] Nomenclature conforme Conventional Commits 1.0
- [x] Blocs de code tagués `text` (MD040 markdownlint OK)
- [x] Commits de cette PR eux-mêmes conformes à la nouvelle convention

## Test plan

- [ ] Relire la section ajoutée dans `CLAUDE.md`
- [ ] Confirmer la liste des types (ajout/retrait éventuel)
- [ ] Confirmer la liste des scopes recommandés
- [ ] Valider l'exigence de body obligatoire pour tout commit non trivial

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)