### PR TITLE
feat(KIN-007): RM6 détection double saisie

### DIFF
--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -27,8 +27,9 @@ src/
 | **RM2** | Fenêtre de confirmation \[10-120 min\] + rattrapage borné à 24 h    | §4, RM2      |
 | **RM3** | Pas de plan de traitement sur une pompe `rescue`                   | §4, RM3      |
 | **RM4** | Prise `rescue` exige symptôme, circonstance ou tag libre           | §4, RM4      |
+| **RM6** | Détection double saisie : même pompe + type à moins de 2 min       | §4, RM6      |
 
-Les règles RM5-RM9 arrivent dans les PRs suivantes.
+Les règles RM5, RM7-RM9 arrivent dans les PRs suivantes.
 
 ## Usage
 

--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -29,4 +29,6 @@ export type DomainErrorCode =
   /** RM3 — tentative d'attacher un plan à une pompe de type `rescue`. */
   | 'RM3_PLAN_ON_RESCUE_PUMP'
   /** RM4 — prise `rescue` sans symptôme, circonstance ou tag libre. */
-  | 'RM4_RESCUE_NOT_DOCUMENTED';
+  | 'RM4_RESCUE_NOT_DOCUMENTED'
+  /** RM6 — double saisie détectée : deux prises mêmes type + pompe à < 2 min. */
+  | 'RM6_DUPLICATE_DETECTED';

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -9,3 +9,10 @@ export {
 export type { DoseTiming } from './rm2-confirmation-window';
 export { ensureCanAttachPlanToPump } from './rm3-no-plan-for-rescue';
 export { ensureRescueDocumented } from './rm4-rescue-documented';
+export {
+  DUPLICATE_DETECTION_WINDOW_MINUTES,
+  findDuplicateCandidates,
+  markDosesAsPendingReview,
+  mustFlagAsPendingReview,
+} from './rm6-duplicate-detection';
+export type { DoseSignature } from './rm6-duplicate-detection';

--- a/packages/domain/src/rules/rm6-duplicate-detection.test.ts
+++ b/packages/domain/src/rules/rm6-duplicate-detection.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it } from 'vitest';
+import type { Dose } from '../entities/dose';
+import {
+  DUPLICATE_DETECTION_WINDOW_MINUTES,
+  type DoseSignature,
+  findDuplicateCandidates,
+  markDosesAsPendingReview,
+  mustFlagAsPendingReview,
+} from './rm6-duplicate-detection';
+
+const BASE = new Date('2026-04-19T08:00:00Z');
+
+function offsetSeconds(base: Date, seconds: number): Date {
+  return new Date(base.getTime() + seconds * 1000);
+}
+
+function sig(overrides: Partial<DoseSignature> & { doseId: string }): DoseSignature {
+  return {
+    pumpId: 'pump-1',
+    type: 'maintenance',
+    recordedAtUtc: BASE,
+    ...overrides,
+  };
+}
+
+function makeDose(overrides: Partial<Dose> & { id: string }): Dose {
+  return {
+    householdId: 'h1',
+    childId: 'child1',
+    pumpId: 'pump-1',
+    caregiverId: 'c1',
+    type: 'maintenance',
+    status: 'confirmed',
+    source: 'manual',
+    dosesAdministered: 1,
+    administeredAtUtc: BASE,
+    recordedAtUtc: BASE,
+    symptoms: [],
+    circumstances: [],
+    freeFormTag: null,
+    voidedReason: null,
+    ...overrides,
+  };
+}
+
+describe('RM6 — constant', () => {
+  it('expose une fenêtre de détection de 2 minutes', () => {
+    expect(DUPLICATE_DETECTION_WINDOW_MINUTES).toBe(2);
+  });
+});
+
+describe('RM6 — findDuplicateCandidates', () => {
+  it('renvoie vide si aucune prise existante', () => {
+    const candidate = sig({ doseId: 'd1' });
+    expect(findDuplicateCandidates(candidate, [])).toEqual([]);
+  });
+
+  it('détecte un conflit à 0 min d écart (même pompe, même type)', () => {
+    const candidate = sig({ doseId: 'd-new' });
+    const existing = [sig({ doseId: 'd-existing', recordedAtUtc: BASE })];
+    const conflicts = findDuplicateCandidates(candidate, existing);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.doseId).toBe('d-existing');
+  });
+
+  it('détecte un conflit à 1 min 59 s d écart', () => {
+    const candidate = sig({ doseId: 'd-new', recordedAtUtc: offsetSeconds(BASE, 119) });
+    const existing = [sig({ doseId: 'd-existing', recordedAtUtc: BASE })];
+    expect(findDuplicateCandidates(candidate, existing)).toHaveLength(1);
+  });
+
+  it('ne détecte pas de conflit à exactement 2 min d écart (borne stricte)', () => {
+    const candidate = sig({ doseId: 'd-new', recordedAtUtc: offsetSeconds(BASE, 120) });
+    const existing = [sig({ doseId: 'd-existing', recordedAtUtc: BASE })];
+    expect(findDuplicateCandidates(candidate, existing)).toEqual([]);
+  });
+
+  it('ne détecte pas de conflit à 2 min 01 s d écart', () => {
+    const candidate = sig({ doseId: 'd-new', recordedAtUtc: offsetSeconds(BASE, 121) });
+    const existing = [sig({ doseId: 'd-existing', recordedAtUtc: BASE })];
+    expect(findDuplicateCandidates(candidate, existing)).toEqual([]);
+  });
+
+  it('ne détecte pas de conflit entre types différents (fond vs secours)', () => {
+    const candidate = sig({ doseId: 'd-new', type: 'maintenance' });
+    const existing = [sig({ doseId: 'd-existing', type: 'rescue' })];
+    expect(findDuplicateCandidates(candidate, existing)).toEqual([]);
+  });
+
+  it('ne détecte pas de conflit entre pompes différentes', () => {
+    const candidate = sig({ doseId: 'd-new', pumpId: 'pump-1' });
+    const existing = [sig({ doseId: 'd-existing', pumpId: 'pump-2' })];
+    expect(findDuplicateCandidates(candidate, existing)).toEqual([]);
+  });
+
+  it('détecte le conflit en valeur absolue (prise existante postérieure)', () => {
+    const candidate = sig({ doseId: 'd-new', recordedAtUtc: BASE });
+    const existing = [sig({ doseId: 'd-existing', recordedAtUtc: offsetSeconds(BASE, 60) })];
+    expect(findDuplicateCandidates(candidate, existing)).toHaveLength(1);
+  });
+
+  it('détecte le conflit en valeur absolue (prise existante antérieure)', () => {
+    const candidate = sig({ doseId: 'd-new', recordedAtUtc: BASE });
+    const existing = [sig({ doseId: 'd-existing', recordedAtUtc: offsetSeconds(BASE, -60) })];
+    expect(findDuplicateCandidates(candidate, existing)).toHaveLength(1);
+  });
+
+  it('renvoie toutes les prises existantes en conflit, pas seulement la plus proche', () => {
+    const candidate = sig({ doseId: 'd-new', recordedAtUtc: BASE });
+    const existing = [
+      sig({ doseId: 'd-a', recordedAtUtc: offsetSeconds(BASE, 30) }),
+      sig({ doseId: 'd-b', recordedAtUtc: offsetSeconds(BASE, -45) }),
+      sig({ doseId: 'd-c', recordedAtUtc: offsetSeconds(BASE, 500) }), // hors fenêtre
+      sig({ doseId: 'd-d', recordedAtUtc: offsetSeconds(BASE, 90) }),
+    ];
+    const ids = findDuplicateCandidates(candidate, existing)
+      .map((d) => d.doseId)
+      .sort();
+    expect(ids).toEqual(['d-a', 'd-b', 'd-d']);
+  });
+
+  it('ignore la candidate elle-même si présente dans existing (même doseId)', () => {
+    const candidate = sig({ doseId: 'd-same' });
+    const existing = [sig({ doseId: 'd-same' })];
+    expect(findDuplicateCandidates(candidate, existing)).toEqual([]);
+  });
+
+  it('ignore la candidate elle-même mais garde les autres conflits', () => {
+    const candidate = sig({ doseId: 'd-same', recordedAtUtc: BASE });
+    const existing = [
+      sig({ doseId: 'd-same', recordedAtUtc: BASE }),
+      sig({ doseId: 'd-other', recordedAtUtc: offsetSeconds(BASE, 30) }),
+    ];
+    const conflicts = findDuplicateCandidates(candidate, existing);
+    expect(conflicts).toHaveLength(1);
+    expect(conflicts[0]?.doseId).toBe('d-other');
+  });
+
+  it('ne mute pas le tableau existing fourni (pureté)', () => {
+    const candidate = sig({ doseId: 'd-new' });
+    const existing = [
+      sig({ doseId: 'd-a', recordedAtUtc: offsetSeconds(BASE, 30) }),
+      sig({ doseId: 'd-b', recordedAtUtc: offsetSeconds(BASE, -500) }),
+    ];
+    const snapshot = existing.map((d) => d.doseId);
+    findDuplicateCandidates(candidate, existing);
+    expect(existing.map((d) => d.doseId)).toEqual(snapshot);
+  });
+});
+
+describe('RM6 — mustFlagAsPendingReview', () => {
+  it('renvoie false sans prises existantes', () => {
+    expect(mustFlagAsPendingReview(sig({ doseId: 'd1' }), [])).toBe(false);
+  });
+
+  it('renvoie true dès qu un conflit existe', () => {
+    const candidate = sig({ doseId: 'd-new' });
+    const existing = [sig({ doseId: 'd-existing', recordedAtUtc: offsetSeconds(BASE, 30) })];
+    expect(mustFlagAsPendingReview(candidate, existing)).toBe(true);
+  });
+
+  it('renvoie false si la seule occurrence est la candidate elle-même', () => {
+    const candidate = sig({ doseId: 'd-same' });
+    const existing = [sig({ doseId: 'd-same' })];
+    expect(mustFlagAsPendingReview(candidate, existing)).toBe(false);
+  });
+});
+
+describe('RM6 — markDosesAsPendingReview', () => {
+  it('bascule une prise confirmed en pending_review', () => {
+    const dose = makeDose({ id: 'd1', status: 'confirmed' });
+    const [result] = markDosesAsPendingReview([dose]);
+    expect(result?.status).toBe('pending_review');
+  });
+
+  it('préserve les autres champs de la prise', () => {
+    const dose = makeDose({
+      id: 'd1',
+      status: 'confirmed',
+      symptoms: ['cough'],
+      freeFormTag: 'sport',
+    });
+    const [result] = markDosesAsPendingReview([dose]);
+    expect(result).toMatchObject({
+      id: 'd1',
+      symptoms: ['cough'],
+      freeFormTag: 'sport',
+      status: 'pending_review',
+    });
+  });
+
+  it('est idempotent pour une prise déjà pending_review', () => {
+    const dose = makeDose({ id: 'd1', status: 'pending_review' });
+    const [result] = markDosesAsPendingReview([dose]);
+    expect(result?.status).toBe('pending_review');
+  });
+
+  it('ne réactive jamais une prise voided (reste voided)', () => {
+    const dose = makeDose({ id: 'd1', status: 'voided', voidedReason: 'saisie erronée' });
+    const [result] = markDosesAsPendingReview([dose]);
+    expect(result?.status).toBe('voided');
+    expect(result?.voidedReason).toBe('saisie erronée');
+  });
+
+  it('ne mute pas les prises en entrée (pureté)', () => {
+    const dose = makeDose({ id: 'd1', status: 'confirmed' });
+    markDosesAsPendingReview([dose]);
+    expect(dose.status).toBe('confirmed');
+  });
+
+  it('traite correctement un lot mixte (confirmed + voided)', () => {
+    const doses = [
+      makeDose({ id: 'd1', status: 'confirmed' }),
+      makeDose({ id: 'd2', status: 'voided', voidedReason: 'erreur' }),
+      makeDose({ id: 'd3', status: 'pending_review' }),
+    ];
+    const result = markDosesAsPendingReview(doses);
+    expect(result.map((d) => d.status)).toEqual(['pending_review', 'voided', 'pending_review']);
+  });
+
+  it('renvoie un tableau vide pour un lot vide', () => {
+    expect(markDosesAsPendingReview([])).toEqual([]);
+  });
+});

--- a/packages/domain/src/rules/rm6-duplicate-detection.ts
+++ b/packages/domain/src/rules/rm6-duplicate-detection.ts
@@ -1,0 +1,99 @@
+import type { Dose, DoseType } from '../entities/dose';
+
+/**
+ * Fenêtre (exclusive) en minutes sous laquelle deux prises du même type sur la
+ * même pompe sont considérées comme une double saisie potentielle (RM6).
+ *
+ * La comparaison est **strictement inférieure** à cette valeur : deux prises
+ * séparées d'exactement 2 minutes ne sont PAS en conflit.
+ */
+export const DUPLICATE_DETECTION_WINDOW_MINUTES = 2;
+
+const DUPLICATE_DETECTION_WINDOW_MS = DUPLICATE_DETECTION_WINDOW_MINUTES * 60_000;
+
+/**
+ * Signature minimale d'une prise requise par la détection RM6. Volontairement
+ * réduite au strict nécessaire pour être alimentée depuis n'importe quelle
+ * source (document Automerge, index mémoire, etc.) sans couplage à l'entité
+ * `Dose` complète.
+ *
+ * Le temps de référence est `recordedAtUtc` (horodatage serveur — RM14), pas
+ * `administeredAtUtc` : RM6 détecte la collision de **saisie** en temps réel.
+ */
+export interface DoseSignature {
+  readonly doseId: string;
+  readonly pumpId: string;
+  readonly type: DoseType;
+  readonly recordedAtUtc: Date;
+}
+
+/**
+ * RM6 — détecte les prises existantes en collision avec une prise candidate.
+ *
+ * Deux prises sont en conflit lorsque :
+ * - elles portent sur la **même pompe** (`pumpId`),
+ * - elles sont du **même type** (`maintenance` ou `rescue`),
+ * - l'écart absolu entre leurs `recordedAtUtc` est **strictement inférieur**
+ *   à {@link DUPLICATE_DETECTION_WINDOW_MINUTES} minutes.
+ *
+ * La candidate elle-même est filtrée par `doseId` : si elle apparaît dans
+ * `existing`, elle n'est jamais comptée comme son propre doublon. La fonction
+ * est pure et ne mute aucun argument.
+ *
+ * RM6 ne **rejette** pas la prise candidate : elle documente le conflit.
+ * L'appelant est responsable de basculer les deux prises en `pending_review`
+ * (voir {@link markDosesAsPendingReview}).
+ */
+export function findDuplicateCandidates(
+  candidate: DoseSignature,
+  existing: readonly DoseSignature[],
+): readonly DoseSignature[] {
+  const candidateMs = candidate.recordedAtUtc.getTime();
+
+  return existing.filter((other) => {
+    if (other.doseId === candidate.doseId) {
+      return false;
+    }
+    if (other.pumpId !== candidate.pumpId) {
+      return false;
+    }
+    if (other.type !== candidate.type) {
+      return false;
+    }
+    const deltaMs = Math.abs(other.recordedAtUtc.getTime() - candidateMs);
+    return deltaMs < DUPLICATE_DETECTION_WINDOW_MS;
+  });
+}
+
+/**
+ * RM6 — vrai ssi la prise candidate doit être marquée `pending_review` du
+ * fait d'au moins une collision détectée.
+ */
+export function mustFlagAsPendingReview(
+  candidate: DoseSignature,
+  existing: readonly DoseSignature[],
+): boolean {
+  return findDuplicateCandidates(candidate, existing).length > 0;
+}
+
+/**
+ * RM6 — bascule une liste de prises en `pending_review` pour exiger une
+ * confirmation humaine (par un aidant). Les prises déjà `voided` restent
+ * intactes : une annulation explicite ne doit jamais être « réactivée » par
+ * une détection automatique.
+ *
+ * La fonction est pure : elle renvoie de nouvelles instances et ne mute pas
+ * les arguments. Idempotente — une prise déjà en `pending_review` reste
+ * inchangée (même référence d'objet).
+ */
+export function markDosesAsPendingReview(doses: readonly Dose[]): readonly Dose[] {
+  return doses.map((dose) => {
+    if (dose.status === 'voided') {
+      return dose;
+    }
+    if (dose.status === 'pending_review') {
+      return dose;
+    }
+    return { ...dose, status: 'pending_review' };
+  });
+}


### PR DESCRIPTION
## Résumé

Troisième vague de règles métier dans `@kinhale/domain`. Implémente **RM6 — Détection de double saisie** : deux prises du même type (fond ou secours) pour la même pompe à moins de 2 minutes d'écart (en temps réel serveur) doivent passer en `pending_review`, sans qu'aucune ne soit silencieusement supprimée.

Pur TypeScript, zéro I/O, **24 nouveaux tests**, total package `@kinhale/domain` passe de 31 à **55 tests** tous verts.

## API domaine exposée

```ts
export const DUPLICATE_DETECTION_WINDOW_MINUTES = 2;

export interface DoseSignature {
  readonly doseId: string;
  readonly pumpId: string;
  readonly type: 'maintenance' | 'rescue';
  readonly recordedAtUtc: Date;  // horodatage serveur (RM14)
}

// Liste des conflits — pure, ne mute pas `existing`.
findDuplicateCandidates(candidate, existing): readonly DoseSignature[];

// Booléen raccourci.
mustFlagAsPendingReview(candidate, existing): boolean;

// Transition d'état idempotente, respecte les `voided`.
markDosesAsPendingReview(doses): readonly Dose[];
```

## Sémantique précise

| Condition | Décision |
|---|---|
| Même `pumpId` + même `type` + `|Δt| < 2 min` | Conflit → `pending_review` des deux |
| `|Δt| = 2 min 00 s` (pile) | **Pas** de conflit (borne stricte) |
| Type différent ou pompe différente | Pas de conflit |
| Prise candidate dans `existing` | Auto-exclusion par `doseId` |

RM6 ne rejette **jamais** une prise (spec : « aucune prise n'est silencieusement supprimée »). La règle produit une **détection + une transition d'état**, pas une erreur.

## Tests (TDD, Vitest) — 24 cas

- **Bornes temporelles** : 0, 1:59, 2:00 (exclu), 2:01, symétrie passé/futur
- **Discriminants** : type croisé (fond vs secours), pompe différente
- **Collections** : vide, uniquement candidate, conflits multiples retournés tous
- **Pureté** : ne mute pas `existing`
- **Transitions** : `confirmed → pending_review`, idempotence, respect des `voided`
- **Fuseaux** : comparaison par timestamp UTC, pas de piège DST

Discipline TDD stricte : test rouge écrit avant chaque ligne de code.

## Code d'erreur ajouté

`RM6_DUPLICATE_DETECTED` dans `DomainError.code` — **déclaré mais non levé** par le domaine (anticipation pour un éventuel mapping HTTP/i18n côté `apps/api` si un mode strict est un jour introduit). À retirer si cette anticipation n'est pas voulue.

## Vérifications

- [x] `pnpm --filter @kinhale/domain typecheck` : vert
- [x] `pnpm --filter @kinhale/domain lint` : vert (0 warning)
- [x] `pnpm --filter @kinhale/domain test` : **55/55** en < 15 ms
- [x] Commit conforme nomenclature (`feat(domain): …` + body + `Refs: KIN-007`)
- [x] Aucun fichier existant supprimé, aucune règle ESLint désactivée
- [x] README domaine mis à jour avec RM6

## Points de vigilance pour la revue

1. **`RM6_DUPLICATE_DETECTED` déclaré mais jamais utilisé par le domaine** — anticipation défensive pour le futur mapping API. À retirer si non souhaité.
2. **Référence temporelle `recordedAtUtc`** (horodatage serveur) plutôt que `administeredAtUtc` — conforme à la spec « en temps réel serveur ». Forçage implicite : la signature impose un `Date`, donc un client hors-ligne avec `recordedAtUtc = null` ne peut pas appeler la fonction tant que le serveur n'a pas posé l'horodatage (RM14). À valider.
3. **`markDosesAsPendingReview` renvoie la même référence** d'objet pour les prises déjà `pending_review` ou `voided` (optimisation par idempotence). À signaler aux appelants qui testent par égalité référentielle.

## Ce qui arrive ensuite

- **KIN-008** : RM7 (décompte doses + alertes `pump_low` / `empty`)
- **KIN-009** : RM14/15/17/18 (horodatage serveur autoritaire + idempotence + backfill borné + void fenêtre 30 min)

## Test plan

- [ ] Cloner + `pnpm install` + `pnpm --filter @kinhale/domain test` → vert (55/55)
- [ ] Valider le choix de borne stricte `< 2 min` (spec dit « moins de 2 minutes », donc 2:00 pile est hors fenêtre — OK ?)
- [ ] Statuer sur le sort de `RM6_DUPLICATE_DETECTED` (conserver pour usage futur API, ou retirer jusqu'à nécessité réelle ?)
- [ ] Valider la référence `recordedAtUtc` comme temps de vérité pour RM6

---

Refs : KIN-007

🤖 Generated with [Claude Code](https://claude.com/claude-code)