### PR TITLE
feat(KIN-008): RM7 décompte doses pompe + alertes pump_low/empty

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,19 @@ Résumé — détails complets dans `docs/contributing/GITFLOW.md`.
 - Pas de commit direct sur `main` ou `develop`.
 - Un ADR (`docs/architecture/adr/`) pour toute décision architecturale structurante.
 
+### Workflow de revue assistée (obligatoire avant toute PR)
+
+Avant d'ouvrir une PR vers `develop`, le workflow suivant est obligatoire :
+
+1. **Implémentation TDD** — tests rouges d'abord, puis code minimal, puis refactor.
+2. **Passage `kz-review` systématique** — revue automatisée du diff : fit fonctionnel, qualité TypeScript strict, pureté, couverture et granularité des tests, conventions, gestion d'erreurs, risques de régression, anti-patterns. Le rapport est intégré au corps de la PR ou mentionné dans un commentaire.
+3. **Passage `kz-securite` systématique** dès que la zone touchée est sensible : `packages/crypto`, `packages/sync`, authentification, I/O, secrets, données santé, payloads push/email, dépendances. En cas de doute, invoquer plutôt que d'omettre.
+4. **Correction** des points MAJEURS relevés avant ouverture de PR. Les points MINEURS sont traités soit dans la même PR, soit dans un ticket de suivi explicite.
+5. **Push + PR** vers `develop` : la revue humaine ne voit que du code déjà auto-filtré.
+6. **Revue humaine + squash-merge** (seul mode autorisé par les settings repo).
+
+Ce workflow n'est pas optionnel. Il a été adopté le 2026-04-20 après constat que les 3 premières PRs du domaine (KIN-005, KIN-007, KIN-008) s'étaient reposées uniquement sur la revue humaine GitHub.
+
 ## Format des messages de commit
 
 Chaque commit comporte **obligatoirement** une ligne de description (sujet) **et** un corps (body). Conforme à [Conventional Commits 1.0](https://www.conventionalcommits.org/fr/v1.0.0/).

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -28,8 +28,9 @@ src/
 | **RM3** | Pas de plan de traitement sur une pompe `rescue`                   | §4, RM3      |
 | **RM4** | Prise `rescue` exige symptôme, circonstance ou tag libre           | §4, RM4      |
 | **RM6** | Détection double saisie : même pompe + type à moins de 2 min       | §4, RM6      |
+| **RM7** | Décompte doses pompe + alertes `pump_low` / `pump_emptied`         | §4, RM7      |
 
-Les règles RM5, RM7-RM9 arrivent dans les PRs suivantes.
+Les règles RM5, RM8, RM9 arrivent dans les PRs suivantes.
 
 ## Usage
 

--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -38,5 +38,5 @@ export type DomainErrorCode =
   | 'RM7_INVALID_THRESHOLD'
   /** RM7 — tentative de décrémenter une pompe déjà `empty`. */
   | 'RM7_PUMP_ALREADY_EMPTY'
-  /** RM7 — tentative de décrémenter une pompe inutilisable (expired / replaced / archived). */
+  /** RM7 — tentative de décrémenter une pompe inutilisable (expired / archived). */
   | 'RM7_PUMP_NOT_USABLE';

--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -31,4 +31,12 @@ export type DomainErrorCode =
   /** RM4 — prise `rescue` sans symptôme, circonstance ou tag libre. */
   | 'RM4_RESCUE_NOT_DOCUMENTED'
   /** RM6 — double saisie détectée : deux prises mêmes type + pompe à < 2 min. */
-  | 'RM6_DUPLICATE_DETECTED';
+  | 'RM6_DUPLICATE_DETECTED'
+  /** RM7 — `dosesAdministered` nul ou négatif (décrément absurde). */
+  | 'RM7_INVALID_DOSES_AMOUNT'
+  /** RM7 — seuil d'alerte non strictement positif. */
+  | 'RM7_INVALID_THRESHOLD'
+  /** RM7 — tentative de décrémenter une pompe déjà `empty`. */
+  | 'RM7_PUMP_ALREADY_EMPTY'
+  /** RM7 — tentative de décrémenter une pompe inutilisable (expired / replaced / archived). */
+  | 'RM7_PUMP_NOT_USABLE';

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -16,3 +16,10 @@ export {
   mustFlagAsPendingReview,
 } from './rm6-duplicate-detection';
 export type { DoseSignature } from './rm6-duplicate-detection';
+export {
+  applyConfirmedDoseToPump,
+  DEFAULT_PUMP_ALERT_THRESHOLD_DOSES,
+  isPumpEmpty,
+  isPumpLow,
+} from './rm7-pump-dose-countdown';
+export type { PumpCountdownEvent, PumpCountdownUpdate } from './rm7-pump-dose-countdown';

--- a/packages/domain/src/rules/rm7-pump-dose-countdown.test.ts
+++ b/packages/domain/src/rules/rm7-pump-dose-countdown.test.ts
@@ -217,10 +217,11 @@ describe('RM7 — applyConfirmedDoseToPump — erreurs', () => {
 
   it('refuse un décrément sur une pompe archived (RM7_PUMP_NOT_USABLE)', () => {
     const pump = makePump({ status: 'archived' });
-    expect(() => applyConfirmedDoseToPump({ pump, dosesAdministered: 1 })).toThrow(DomainError);
     try {
       applyConfirmedDoseToPump({ pump, dosesAdministered: 1 });
+      expect.fail('attendu: DomainError RM7_PUMP_NOT_USABLE');
     } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
       expect((err as DomainError).code).toBe('RM7_PUMP_NOT_USABLE');
     }
   });

--- a/packages/domain/src/rules/rm7-pump-dose-countdown.test.ts
+++ b/packages/domain/src/rules/rm7-pump-dose-countdown.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, it } from 'vitest';
+import type { Pump, PumpStatus, PumpType } from '../entities/pump';
+import { DomainError } from '../errors';
+import {
+  applyConfirmedDoseToPump,
+  DEFAULT_PUMP_ALERT_THRESHOLD_DOSES,
+  isPumpEmpty,
+  isPumpLow,
+} from './rm7-pump-dose-countdown';
+
+const BASE_CREATED_AT = new Date('2026-04-01T00:00:00Z');
+const BASE_EXPIRES_AT = new Date('2026-10-01T00:00:00Z');
+
+function makePump(overrides: Partial<Pump> = {}): Pump {
+  return {
+    id: 'pump-1',
+    householdId: 'h1',
+    type: 'maintenance',
+    status: 'active',
+    label: 'Flovent HFA 125',
+    dosesRemaining: 100,
+    expiresAt: BASE_EXPIRES_AT,
+    createdAt: BASE_CREATED_AT,
+    ...overrides,
+  };
+}
+
+describe('RM7 — constants', () => {
+  it('expose un seuil d alerte par défaut de 20 doses', () => {
+    expect(DEFAULT_PUMP_ALERT_THRESHOLD_DOSES).toBe(20);
+  });
+});
+
+describe('RM7 — applyConfirmedDoseToPump — décrément simple', () => {
+  it('décrémente doses_remaining de 1 sur une prise standard', () => {
+    const pump = makePump({ dosesRemaining: 100, status: 'active' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 1,
+    });
+    expect(updated.dosesRemaining).toBe(99);
+    expect(updated.status).toBe('active');
+    expect(events).toEqual([]);
+  });
+
+  it('décrémente doses_remaining de N pour une prise multi-doses', () => {
+    const pump = makePump({ dosesRemaining: 100, status: 'active' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 5,
+    });
+    expect(updated.dosesRemaining).toBe(95);
+    expect(updated.status).toBe('active');
+    expect(events).toEqual([]);
+  });
+
+  it('préserve tous les autres champs de la pompe (immutabilité partielle)', () => {
+    const pump = makePump({
+      id: 'pump-42',
+      householdId: 'h-xyz',
+      type: 'rescue',
+      label: 'Ventolin HFA',
+      dosesRemaining: 80,
+      status: 'active',
+      expiresAt: BASE_EXPIRES_AT,
+      createdAt: BASE_CREATED_AT,
+    });
+    const { pump: updated } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 2,
+    });
+    expect(updated).toMatchObject({
+      id: 'pump-42',
+      householdId: 'h-xyz',
+      type: 'rescue',
+      label: 'Ventolin HFA',
+      expiresAt: BASE_EXPIRES_AT,
+      createdAt: BASE_CREATED_AT,
+      dosesRemaining: 78,
+      status: 'active',
+    });
+  });
+});
+
+describe('RM7 — applyConfirmedDoseToPump — franchissement seuil bas (pump_low)', () => {
+  it('bascule active → low et émet pump_low_threshold_crossed au franchissement', () => {
+    const pump = makePump({ dosesRemaining: 21, status: 'active' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 2,
+      alertThresholdDoses: 20,
+    });
+    expect(updated.dosesRemaining).toBe(19);
+    expect(updated.status).toBe('low');
+    expect(events).toEqual(['pump_low_threshold_crossed']);
+  });
+
+  it('franchit le seuil à la valeur exacte (inclusif, <=)', () => {
+    const pump = makePump({ dosesRemaining: 21, status: 'active' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 1,
+      alertThresholdDoses: 20,
+    });
+    expect(updated.dosesRemaining).toBe(20);
+    expect(updated.status).toBe('low');
+    expect(events).toEqual(['pump_low_threshold_crossed']);
+  });
+
+  it('n émet aucun événement tant que le seuil n est pas franchi', () => {
+    const pump = makePump({ dosesRemaining: 22, status: 'active' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 1,
+      alertThresholdDoses: 20,
+    });
+    expect(updated.dosesRemaining).toBe(21);
+    expect(updated.status).toBe('active');
+    expect(events).toEqual([]);
+  });
+
+  it('utilise le seuil par défaut 20 si alertThresholdDoses est omis', () => {
+    const pump = makePump({ dosesRemaining: 21, status: 'active' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 1,
+    });
+    expect(updated.status).toBe('low');
+    expect(events).toEqual(['pump_low_threshold_crossed']);
+  });
+
+  it('n émet pas pump_low_threshold_crossed si la pompe est déjà low', () => {
+    const pump = makePump({ dosesRemaining: 15, status: 'low' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 3,
+      alertThresholdDoses: 20,
+    });
+    expect(updated.dosesRemaining).toBe(12);
+    expect(updated.status).toBe('low');
+    expect(events).toEqual([]);
+  });
+});
+
+describe('RM7 — applyConfirmedDoseToPump — pump_emptied', () => {
+  it('bascule active → empty en franchissant zéro pile', () => {
+    const pump = makePump({ dosesRemaining: 3, status: 'active' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 3,
+    });
+    expect(updated.dosesRemaining).toBe(0);
+    expect(updated.status).toBe('empty');
+    expect(events).toEqual(['pump_emptied']);
+  });
+
+  it('clamp à 0 (pas de remaining négatif) même si on dépasse', () => {
+    const pump = makePump({ dosesRemaining: 3, status: 'active' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 10,
+    });
+    expect(updated.dosesRemaining).toBe(0);
+    expect(updated.status).toBe('empty');
+    expect(events).toEqual(['pump_emptied']);
+  });
+
+  it('bascule active → empty sans réémettre pump_low_threshold_crossed (saut direct)', () => {
+    // active 5, threshold 20 — on saute depuis active (5 > 0 et 5 <= 20 mais pompe active)
+    // En fait active avec remaining=5 est déjà un état incohérent en amont, mais la
+    // fonction doit gérer : émettre uniquement pump_emptied, pas low.
+    const pump = makePump({ dosesRemaining: 5, status: 'active' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 5,
+      alertThresholdDoses: 20,
+    });
+    expect(updated.dosesRemaining).toBe(0);
+    expect(updated.status).toBe('empty');
+    expect(events).toEqual(['pump_emptied']);
+  });
+
+  it('bascule low → empty quand on atteint zéro depuis low', () => {
+    const pump = makePump({ dosesRemaining: 2, status: 'low' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 2,
+    });
+    expect(updated.dosesRemaining).toBe(0);
+    expect(updated.status).toBe('empty');
+    expect(events).toEqual(['pump_emptied']);
+  });
+});
+
+describe('RM7 — applyConfirmedDoseToPump — erreurs', () => {
+  it('refuse un décrément sur une pompe déjà empty (RM7_PUMP_ALREADY_EMPTY)', () => {
+    const pump = makePump({ dosesRemaining: 0, status: 'empty' });
+    try {
+      applyConfirmedDoseToPump({ pump, dosesAdministered: 1 });
+      expect.fail('attendu: DomainError RM7_PUMP_ALREADY_EMPTY');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM7_PUMP_ALREADY_EMPTY');
+    }
+  });
+
+  it('refuse un décrément sur une pompe expired (RM7_PUMP_NOT_USABLE)', () => {
+    const pump = makePump({ status: 'expired' });
+    try {
+      applyConfirmedDoseToPump({ pump, dosesAdministered: 1 });
+      expect.fail('attendu: DomainError RM7_PUMP_NOT_USABLE');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM7_PUMP_NOT_USABLE');
+    }
+  });
+
+  it('refuse un décrément sur une pompe archived (RM7_PUMP_NOT_USABLE)', () => {
+    const pump = makePump({ status: 'archived' });
+    expect(() => applyConfirmedDoseToPump({ pump, dosesAdministered: 1 })).toThrow(DomainError);
+    try {
+      applyConfirmedDoseToPump({ pump, dosesAdministered: 1 });
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM7_PUMP_NOT_USABLE');
+    }
+  });
+
+  it('refuse dosesAdministered = 0 (RM7_INVALID_DOSES_AMOUNT)', () => {
+    const pump = makePump();
+    try {
+      applyConfirmedDoseToPump({ pump, dosesAdministered: 0 });
+      expect.fail('attendu: DomainError RM7_INVALID_DOSES_AMOUNT');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM7_INVALID_DOSES_AMOUNT');
+    }
+  });
+
+  it('refuse dosesAdministered négatif (RM7_INVALID_DOSES_AMOUNT)', () => {
+    const pump = makePump();
+    try {
+      applyConfirmedDoseToPump({ pump, dosesAdministered: -3 });
+      expect.fail('attendu: DomainError RM7_INVALID_DOSES_AMOUNT');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM7_INVALID_DOSES_AMOUNT');
+    }
+  });
+
+  it('refuse dosesAdministered non entier (RM7_INVALID_DOSES_AMOUNT)', () => {
+    const pump = makePump();
+    try {
+      applyConfirmedDoseToPump({ pump, dosesAdministered: 1.5 });
+      expect.fail('attendu: DomainError RM7_INVALID_DOSES_AMOUNT');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM7_INVALID_DOSES_AMOUNT');
+    }
+  });
+
+  it('refuse alertThresholdDoses = 0 (RM7_INVALID_THRESHOLD)', () => {
+    const pump = makePump();
+    try {
+      applyConfirmedDoseToPump({ pump, dosesAdministered: 1, alertThresholdDoses: 0 });
+      expect.fail('attendu: DomainError RM7_INVALID_THRESHOLD');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM7_INVALID_THRESHOLD');
+    }
+  });
+
+  it('refuse alertThresholdDoses négatif (RM7_INVALID_THRESHOLD)', () => {
+    const pump = makePump();
+    try {
+      applyConfirmedDoseToPump({ pump, dosesAdministered: 1, alertThresholdDoses: -5 });
+      expect.fail('attendu: DomainError RM7_INVALID_THRESHOLD');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM7_INVALID_THRESHOLD');
+    }
+  });
+});
+
+describe('RM7 — applyConfirmedDoseToPump — type de pompe', () => {
+  it('s applique identiquement à une pompe maintenance', () => {
+    const pump = makePump({ type: 'maintenance', dosesRemaining: 50 });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 1,
+    });
+    expect(updated.dosesRemaining).toBe(49);
+    expect(events).toEqual([]);
+  });
+
+  it('s applique identiquement à une pompe rescue', () => {
+    const pump = makePump({ type: 'rescue', dosesRemaining: 50 });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 1,
+    });
+    expect(updated.dosesRemaining).toBe(49);
+    expect(updated.type).toBe('rescue');
+    expect(events).toEqual([]);
+  });
+
+  it('déclenche pump_low_threshold_crossed sur pompe rescue aussi', () => {
+    const pump = makePump({ type: 'rescue', dosesRemaining: 21, status: 'active' });
+    const { pump: updated, events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 2,
+    });
+    expect(updated.status).toBe('low');
+    expect(events).toEqual(['pump_low_threshold_crossed']);
+  });
+});
+
+describe('RM7 — applyConfirmedDoseToPump — pureté', () => {
+  it('ne mute pas la pompe en entrée (dosesRemaining)', () => {
+    const pump = makePump({ dosesRemaining: 100, status: 'active' });
+    applyConfirmedDoseToPump({ pump, dosesAdministered: 5 });
+    expect(pump.dosesRemaining).toBe(100);
+    expect(pump.status).toBe('active');
+  });
+
+  it('ne mute pas la pompe en entrée (status)', () => {
+    const pump = makePump({ dosesRemaining: 21, status: 'active' });
+    applyConfirmedDoseToPump({ pump, dosesAdministered: 1, alertThresholdDoses: 20 });
+    expect(pump.status).toBe('active');
+    expect(pump.dosesRemaining).toBe(21);
+  });
+
+  it('renvoie une nouvelle instance de pompe (différente référence)', () => {
+    const pump = makePump({ dosesRemaining: 100, status: 'active' });
+    const { pump: updated } = applyConfirmedDoseToPump({ pump, dosesAdministered: 1 });
+    expect(updated).not.toBe(pump);
+  });
+
+  it('renvoie events en tableau read-only figé (pas de partage mutable)', () => {
+    const pump = makePump({ dosesRemaining: 21, status: 'active' });
+    const { events } = applyConfirmedDoseToPump({
+      pump,
+      dosesAdministered: 1,
+      alertThresholdDoses: 20,
+    });
+    // On vérifie juste que c'est bien un array et qu'il contient les bons éléments ;
+    // la structure ReadonlyArray est garantie par le type.
+    expect(Array.isArray(events)).toBe(true);
+    expect(events).toHaveLength(1);
+  });
+});
+
+describe('RM7 — isPumpLow', () => {
+  it('renvoie true pour une pompe active avec remaining <= threshold', () => {
+    const pump = makePump({ dosesRemaining: 15, status: 'active' });
+    expect(isPumpLow(pump, 20)).toBe(true);
+  });
+
+  it('renvoie true pour une pompe de statut low', () => {
+    const pump = makePump({ dosesRemaining: 15, status: 'low' });
+    expect(isPumpLow(pump)).toBe(true);
+  });
+
+  it('renvoie false pour une pompe empty (empty n est pas low)', () => {
+    const pump = makePump({ dosesRemaining: 0, status: 'empty' });
+    expect(isPumpLow(pump)).toBe(false);
+  });
+
+  it('renvoie false quand remaining est strictement au-dessus du seuil', () => {
+    const pump = makePump({ dosesRemaining: 25, status: 'active' });
+    expect(isPumpLow(pump, 20)).toBe(false);
+  });
+
+  it('renvoie true à la valeur exacte du seuil (inclusif, <=)', () => {
+    const pump = makePump({ dosesRemaining: 20, status: 'active' });
+    expect(isPumpLow(pump, 20)).toBe(true);
+  });
+
+  it('utilise le seuil par défaut 20 si non fourni', () => {
+    const pump = makePump({ dosesRemaining: 19, status: 'active' });
+    expect(isPumpLow(pump)).toBe(true);
+  });
+});
+
+describe('RM7 — isPumpEmpty', () => {
+  it('renvoie true pour une pompe de statut empty', () => {
+    const pump = makePump({ dosesRemaining: 0, status: 'empty' });
+    expect(isPumpEmpty(pump)).toBe(true);
+  });
+
+  it('renvoie false pour une pompe active', () => {
+    const pump = makePump({ dosesRemaining: 10, status: 'active' });
+    expect(isPumpEmpty(pump)).toBe(false);
+  });
+
+  it('renvoie false pour une pompe low', () => {
+    const pump = makePump({ dosesRemaining: 5, status: 'low' });
+    expect(isPumpEmpty(pump)).toBe(false);
+  });
+});
+
+describe('RM7 — contrat de typage', () => {
+  // Ces tests vérifient simplement que le typage public est correct ; ils
+  // tournent en exécution mais la vraie valeur est à la compilation.
+  it('accepte tous les PumpStatus et PumpType', () => {
+    const statuses: PumpStatus[] = ['active', 'low', 'empty', 'expired', 'archived'];
+    const types: PumpType[] = ['maintenance', 'rescue'];
+    expect(statuses).toHaveLength(5);
+    expect(types).toHaveLength(2);
+  });
+});

--- a/packages/domain/src/rules/rm7-pump-dose-countdown.ts
+++ b/packages/domain/src/rules/rm7-pump-dose-countdown.ts
@@ -130,7 +130,10 @@ export function applyConfirmedDoseToPump(options: {
  * Les statuts non utilisables (`expired`, `archived`) renvoient `false` : ils
  * ne participent plus au cycle de vie des alertes.
  */
-export function isPumpLow(pump: Pump, threshold: number = DEFAULT_PUMP_ALERT_THRESHOLD_DOSES): boolean {
+export function isPumpLow(
+  pump: Pump,
+  threshold: number = DEFAULT_PUMP_ALERT_THRESHOLD_DOSES,
+): boolean {
   if (pump.status === 'low') {
     return true;
   }

--- a/packages/domain/src/rules/rm7-pump-dose-countdown.ts
+++ b/packages/domain/src/rules/rm7-pump-dose-countdown.ts
@@ -1,0 +1,149 @@
+import type { Pump, PumpStatus } from '../entities/pump';
+import { DomainError } from '../errors';
+
+/**
+ * Seuil d'alerte par défaut (en doses restantes) en dessous duquel une pompe
+ * bascule en statut `low` et déclenche une notification `pump_low`. Valeur
+ * configurable par foyer via `Foyer.pump_alert_threshold_doses` (SPECS §3.2).
+ */
+export const DEFAULT_PUMP_ALERT_THRESHOLD_DOSES = 20;
+
+/**
+ * Événements métier émis par {@link applyConfirmedDoseToPump} pour signaler
+ * les transitions d'état de la pompe. Consommés côté `apps/api` pour mapper
+ * vers les notifications `pump_low` et `pump_emptied` (SPECS §3.10).
+ *
+ * - `pump_low_threshold_crossed` : la pompe vient de franchir (descendant) le
+ *   seuil d'alerte configuré. Émis **une seule fois** au franchissement, pas à
+ *   chaque prise en dessous du seuil.
+ * - `pump_emptied` : la pompe vient d'atteindre `dosesRemaining = 0`. Émis
+ *   une fois au passage à l'état vide.
+ */
+export type PumpCountdownEvent = 'pump_low_threshold_crossed' | 'pump_emptied';
+
+/**
+ * Résultat de l'application d'une prise `confirmed` sur une pompe : nouvelle
+ * instance de pompe (décrémentée + statut mis à jour) et liste d'événements
+ * métier déclenchés par cette prise.
+ */
+export interface PumpCountdownUpdate {
+  readonly pump: Pump;
+  readonly events: ReadonlyArray<PumpCountdownEvent>;
+}
+
+/** Statuts sur lesquels un décompte est autorisé. */
+const USABLE_STATUSES: ReadonlySet<PumpStatus> = new Set<PumpStatus>(['active', 'low']);
+
+/**
+ * RM7 — applique une prise `confirmed` à une pompe : décrémente
+ * `dosesRemaining` et calcule les transitions de statut (`active` → `low` →
+ * `empty`) ainsi que les événements à propager (`pump_low_threshold_crossed`,
+ * `pump_emptied`).
+ *
+ * Sémantique de déclenchement :
+ * - `pump_low_threshold_crossed` n'est émis **qu'une seule fois**, au moment
+ *   où la pompe franchit le seuil (ancien remaining > seuil ET nouveau
+ *   remaining ≤ seuil). Pas réémis aux prises suivantes sous le seuil.
+ * - Si la prise amène directement la pompe à zéro, seul `pump_emptied` est
+ *   émis (pas de double événement low + empty).
+ * - `dosesRemaining` est clampé à 0 : un décrément qui dépasserait zéro amène
+ *   la pompe à l'état `empty` sans valeur négative.
+ *
+ * Fonction **pure** : aucune mutation des arguments, retour d'une nouvelle
+ * instance de pompe. Aucun I/O, aucune lecture d'horloge.
+ *
+ * @throws {DomainError} `RM7_INVALID_DOSES_AMOUNT` si `dosesAdministered` ≤ 0
+ *   ou non entier.
+ * @throws {DomainError} `RM7_INVALID_THRESHOLD` si `alertThresholdDoses` ≤ 0.
+ * @throws {DomainError} `RM7_PUMP_ALREADY_EMPTY` si la pompe est déjà `empty`.
+ * @throws {DomainError} `RM7_PUMP_NOT_USABLE` si la pompe est `expired` ou
+ *   `archived` (état qui interdit toute nouvelle prise).
+ */
+export function applyConfirmedDoseToPump(options: {
+  readonly pump: Pump;
+  readonly dosesAdministered: number;
+  readonly alertThresholdDoses?: number;
+}): PumpCountdownUpdate {
+  const { pump, dosesAdministered } = options;
+  const threshold = options.alertThresholdDoses ?? DEFAULT_PUMP_ALERT_THRESHOLD_DOSES;
+
+  if (!Number.isInteger(dosesAdministered) || dosesAdministered <= 0) {
+    throw new DomainError(
+      'RM7_INVALID_DOSES_AMOUNT',
+      `dosesAdministered must be a positive integer, got ${String(dosesAdministered)}.`,
+      { dosesAdministered },
+    );
+  }
+
+  if (!Number.isFinite(threshold) || threshold <= 0) {
+    throw new DomainError(
+      'RM7_INVALID_THRESHOLD',
+      `alertThresholdDoses must be strictly positive, got ${String(threshold)}.`,
+      { alertThresholdDoses: threshold },
+    );
+  }
+
+  if (pump.status === 'empty') {
+    throw new DomainError(
+      'RM7_PUMP_ALREADY_EMPTY',
+      `Pump ${pump.id} is already empty; cannot record a new dose against it.`,
+      { pumpId: pump.id },
+    );
+  }
+
+  if (!USABLE_STATUSES.has(pump.status)) {
+    throw new DomainError(
+      'RM7_PUMP_NOT_USABLE',
+      `Pump ${pump.id} has status ${pump.status}; only active and low pumps accept doses.`,
+      { pumpId: pump.id, pumpStatus: pump.status },
+    );
+  }
+
+  const previousRemaining = pump.dosesRemaining;
+  const rawNext = previousRemaining - dosesAdministered;
+  const newRemaining = rawNext < 0 ? 0 : rawNext;
+
+  const events: PumpCountdownEvent[] = [];
+  let nextStatus: PumpStatus = pump.status;
+
+  if (newRemaining <= 0) {
+    nextStatus = 'empty';
+    events.push('pump_emptied');
+  } else if (newRemaining <= threshold && previousRemaining > threshold) {
+    nextStatus = 'low';
+    events.push('pump_low_threshold_crossed');
+  }
+
+  const updatedPump: Pump = {
+    ...pump,
+    dosesRemaining: newRemaining,
+    status: nextStatus,
+  };
+
+  return { pump: updatedPump, events };
+}
+
+/**
+ * RM7 — vrai ssi la pompe est considérée « basse » : statut déjà `low`, OU
+ * statut `active` avec `dosesRemaining` inférieur ou égal au seuil. Une pompe
+ * `empty` n'est **pas** considérée « low » (elle est vide — état distinct).
+ * Les statuts non utilisables (`expired`, `archived`) renvoient `false` : ils
+ * ne participent plus au cycle de vie des alertes.
+ */
+export function isPumpLow(pump: Pump, threshold: number = DEFAULT_PUMP_ALERT_THRESHOLD_DOSES): boolean {
+  if (pump.status === 'low') {
+    return true;
+  }
+  if (pump.status !== 'active') {
+    return false;
+  }
+  return pump.dosesRemaining <= threshold;
+}
+
+/**
+ * RM7 — vrai ssi la pompe est en statut `empty`. La comparaison se fait sur
+ * le statut (source de vérité), pas uniquement sur `dosesRemaining`.
+ */
+export function isPumpEmpty(pump: Pump): boolean {
+  return pump.status === 'empty';
+}


### PR DESCRIPTION
## Résumé

Quatrième vague de règles métier dans `@kinhale/domain`. Implémente **RM7 — Décompte doses pompe** : à chaque prise `confirmed`, `doses_remaining -= dosesAdministered`, émission de `pump_low_threshold_crossed` au franchissement descendant du seuil et de `pump_emptied` à 0.

Pur TypeScript, zéro I/O, **38 nouveaux tests**, total package `@kinhale/domain` passe de 55 à **93 tests** tous verts.

## API domaine exposée

```ts
export const DEFAULT_PUMP_ALERT_THRESHOLD_DOSES = 20;

export type PumpCountdownEvent =
  | 'pump_low_threshold_crossed'
  | 'pump_emptied';

export interface PumpCountdownUpdate {
  readonly pump: Pump;   // nouvelle instance — input non muté
  readonly events: ReadonlyArray<PumpCountdownEvent>;
}

export function applyConfirmedDoseToPump(options: {
  pump: Pump;
  dosesAdministered: number;
  alertThresholdDoses?: number;
}): PumpCountdownUpdate;

export function isPumpLow(pump: Pump, threshold?: number): boolean;
export function isPumpEmpty(pump: Pump): boolean;
```

## Sémantique précise

| État avant | État après décrément | Événement émis |
|---|---|---|
| `active` et `remaining > threshold` | `active` et `remaining > threshold` | — |
| `active` et `remaining > threshold` | `low` et `0 < remaining <= threshold` | `pump_low_threshold_crossed` |
| `low` | `low` | — (pas de ré-émission) |
| `active`/`low` et `remaining > 0` | `empty` et `remaining = 0` | `pump_emptied` |
| `active` saut direct à 0 | `empty` | `pump_emptied` **seul** |
| `empty` | — | erreur `RM7_PUMP_ALREADY_EMPTY` |
| `expired` / `archived` | — | erreur `RM7_PUMP_NOT_USABLE` |

RM7 clampe `dosesRemaining` à 0 (une saisie excessive ne descend pas sous 0).

Les événements sont **edge-triggered** (franchissement), pas level-triggered — cohérent avec la spec qui demande UNE notification `pump_low`, pas une par prise en dessous du seuil.

## Tests (TDD, Vitest) — 38 cas

- **Décrément** simple, multi-doses, indépendant du type de pompe (maintenance/rescue)
- **Franchissement seuil** descendant : bornes `> threshold → = threshold`, `= threshold+1 → = threshold-1`, etc.
- **Pas de double événement** sur prises consécutives en `low`
- **Saut direct `active → empty`** sans double événement
- **Clamp à 0** sur saisie excessive
- **Pompe `empty`** → `RM7_PUMP_ALREADY_EMPTY`
- **Pompe `expired` / `archived`** → `RM7_PUMP_NOT_USABLE`
- **`dosesAdministered` ≤ 0 ou non entier** → `RM7_INVALID_DOSES_AMOUNT`
- **`alertThresholdDoses` ≤ 0** → `RM7_INVALID_THRESHOLD`
- **Pureté** : input non muté (égalité référentielle + contenu), retour = nouvelle instance
- **Helpers** `isPumpLow` / `isPumpEmpty` : sémantique défensive sur états hors cycle

Discipline TDD stricte : test rouge écrit avant chaque ligne de code.

## Codes d'erreur ajoutés à `DomainError.code`

- `RM7_INVALID_DOSES_AMOUNT` — `dosesAdministered` ≤ 0 ou non entier (décrément aberrant)
- `RM7_INVALID_THRESHOLD` — `alertThresholdDoses` ≤ 0 (seuil absurde)
- `RM7_PUMP_ALREADY_EMPTY` — refus explicite d'un décrément sur pompe déjà `empty`, cohérent avec W2/W7 (la saisie d'une prise sur pompe vide doit être refusée côté API)
- `RM7_PUMP_NOT_USABLE` — pompe `expired` ou `archived` : hors cycle RM7

## Vérifications

- [x] `pnpm --filter @kinhale/domain typecheck` : vert
- [x] `pnpm --filter @kinhale/domain lint` : vert (0 warning)
- [x] `pnpm --filter @kinhale/domain test` : **93/93** en < 20 ms
- [x] Commit conforme (`feat(domain): … (RM7)` + body + `Refs: KIN-008`)
- [x] Aucun test existant modifié, aucune règle existante touchée
- [x] Aucun champ ajouté à l'entité Pump (seuil reste paramètre de fonction)
- [x] README domaine mis à jour avec RM7

## Points de vigilance pour la revue

1. **Edge-triggered vs level-triggered** : le choix est edge-triggered pour éviter le spam de notifications. Si la spec évolue vers level-triggered (ex. "rappeler tous les 3 jours tant que low"), il faudra un état de "dernière notification envoyée" côté infra, pas côté domaine.
2. **Saut direct `active → empty`** : le choix de n'émettre que `pump_emptied` (sans `pump_low_threshold_crossed`) évite un double événement avec la même cause. Vérifier si le produit veut une trace explicite du passage par le seuil dans ce cas.
3. **Seuil injecté par l'appelant** : le domaine ne connaît pas `Foyer.pump_alert_threshold_doses`. L'API devra le lire côté Foyer et l'injecter à chaque appel. Cohérent avec le découpage en couches.
4. **`isPumpLow` défensive** : retourne `true` si `status='active'` et `remaining <= threshold` (incohérence détectable). Utile pour réconcilier un état suite à une migration ou un import, mais à discuter si on préfère strict (`status === 'low'` seulement).

## Ce qui arrive ensuite

- **KIN-009** : RM14 (horodatage serveur autoritaire), RM15 (idempotence), RM17 (backfill borné), RM18 (void fenêtre 30 min)

## Test plan

- [ ] Cloner + `pnpm install` + `pnpm --filter @kinhale/domain test` → vert (93/93)
- [ ] Valider le choix edge-triggered pour les événements `pump_low`
- [ ] Valider le non-cumul `pump_low + pump_emptied` sur saut direct active→empty
- [ ] Statuer sur la sémantique défensive de `isPumpLow`

---

Refs : KIN-008

🤖 Generated with [Claude Code](https://claude.com/claude-code)