### PR TITLE
feat(KIN-009): RM14/15/17/18 horodatage, idempotence, backfill, void

### DIFF
--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -29,6 +29,10 @@ src/
 | **RM4** | Prise `rescue` exige symptôme, circonstance ou tag libre           | §4, RM4      |
 | **RM6** | Détection double saisie : même pompe + type à moins de 2 min       | §4, RM6      |
 | **RM7** | Décompte doses pompe + alertes `pump_low` / `pump_emptied`         | §4, RM7      |
+| **RM14**| Horodatage serveur autoritaire (`recordedAtUtc`) + flag sync tardive | §4, RM14     |
+| **RM15**| Idempotence des saisies via `clientEventId` (UUID v4)              | §4, RM15     |
+| **RM17**| Rattrapage borné : backfill ≤ 24 h, futur refusé, confirmation au-delà | §4, RM17 |
+| **RM18**| Annulation : 30 min libres pour l'auteur ou un Admin, puis Admin + raison | §4, RM18 |
 
 Les règles RM5, RM8, RM9 arrivent dans les PRs suivantes.
 

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -1,6 +1,6 @@
 # @kinhale/domain
 
-Entités métier et règles RM1-RM9 du projet Kinhale. **Pure TypeScript, aucun I/O** : ni réseau, ni base, ni fichier, ni date du système en argument implicite. Chaque règle est une fonction pure ou presque (horloge injectée quand nécessaire).
+Entités métier et règles RMx du projet Kinhale. **Pure TypeScript, aucun I/O** : ni réseau, ni base, ni fichier, ni date du système en argument implicite. Chaque règle est une fonction pure ou presque (horloge injectée quand nécessaire).
 
 ## Principes
 
@@ -14,7 +14,7 @@ Entités métier et règles RM1-RM9 du projet Kinhale. **Pure TypeScript, aucun 
 ```text
 src/
 ├── entities/         Types purs : Household, Caregiver, Child, Pump, Role…
-├── rules/            Règles RM1-RM9 (fonctions pures)
+├── rules/            Règles RMx (fonctions pures)
 ├── errors.ts         DomainError + codes d'erreur
 └── index.ts          Barrel export
 ```
@@ -34,7 +34,7 @@ src/
 | **RM17**| Rattrapage borné : backfill ≤ 24 h, futur refusé, confirmation au-delà | §4, RM17 |
 | **RM18**| Annulation : 30 min libres pour l'auteur ou un Admin, puis Admin + raison | §4, RM18 |
 
-Les règles RM5, RM8, RM9 arrivent dans les PRs suivantes.
+Les règles RM5, RM8-RM13, RM16, RM19-RM28 arrivent dans les PRs suivantes.
 
 ## Usage
 

--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -39,4 +39,16 @@ export type DomainErrorCode =
   /** RM7 — tentative de décrémenter une pompe déjà `empty`. */
   | 'RM7_PUMP_ALREADY_EMPTY'
   /** RM7 — tentative de décrémenter une pompe inutilisable (expired / archived). */
-  | 'RM7_PUMP_NOT_USABLE';
+  | 'RM7_PUMP_NOT_USABLE'
+  /** RM15 — `clientEventId` absent, vide ou non conforme au format UUID v4. */
+  | 'RM15_INVALID_CLIENT_EVENT_ID'
+  /** RM17 — prise datée dans le futur (strictement après `recordedAtUtc`). */
+  | 'RM17_FUTURE_ADMINISTRATION_REFUSED'
+  /** RM17 — prise au-delà de 24 h dans le passé, exige une confirmation explicite. */
+  | 'RM17_TOO_OLD_REQUIRES_CONFIRMATION'
+  /** RM18 — prise déjà en statut `voided` ; annulation idempotente refusée. */
+  | 'RM18_ALREADY_VOIDED'
+  /** RM18 — le demandeur n'est ni l'auteur dans la fenêtre libre, ni admin. */
+  | 'RM18_NOT_AUTHORIZED'
+  /** RM18 — hors fenêtre libre : `voidedReason` non vide obligatoire. */
+  | 'RM18_VOIDED_REASON_REQUIRED';

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -23,3 +23,24 @@ export {
   isPumpLow,
 } from './rm7-pump-dose-countdown';
 export type { PumpCountdownEvent, PumpCountdownUpdate } from './rm7-pump-dose-countdown';
+export { assignAuthoritativeTimestamp, LATE_SYNC_THRESHOLD_MS } from './rm14-recorded-timestamp';
+export type { DoseTimestampingResult, RecordTimestampOptions } from './rm14-recorded-timestamp';
+export {
+  createEmptyIdempotencyRegistry,
+  decideIdempotency,
+  recordProcessedEvent,
+} from './rm15-idempotency';
+export type { IdempotencyDecision, IdempotencyRegistry, ProcessedEvent } from './rm15-idempotency';
+export {
+  BACKFILL_MAX_WINDOW_HOURS,
+  ensureBackfillAllowed,
+  validateBackfillTiming,
+} from './rm17-backfill-window';
+export type { BackfillOptions, BackfillValidation, BackfillValidity } from './rm17-backfill-window';
+export {
+  canVoidDose,
+  ensureCanVoidDose,
+  VOID_FREE_WINDOW_MINUTES,
+  voidDose,
+} from './rm18-void-dose';
+export type { VoidDoseOptions, VoidRequester } from './rm18-void-dose';

--- a/packages/domain/src/rules/rm14-recorded-timestamp.test.ts
+++ b/packages/domain/src/rules/rm14-recorded-timestamp.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import { assignAuthoritativeTimestamp, LATE_SYNC_THRESHOLD_MS } from './rm14-recorded-timestamp';
+
+const SERVER = new Date('2026-04-19T12:00:00Z');
+
+function offsetMs(base: Date, ms: number): Date {
+  return new Date(base.getTime() + ms);
+}
+
+describe('RM14 — constant', () => {
+  it('expose un seuil de sync tardive de 60 000 ms par défaut', () => {
+    expect(LATE_SYNC_THRESHOLD_MS).toBe(60_000);
+  });
+});
+
+describe('RM14 — assignAuthoritativeTimestamp (saisie en ligne)', () => {
+  it('administeredAtUtc == serverReceivedAtUtc : latence nulle', () => {
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: SERVER,
+      serverReceivedAtUtc: SERVER,
+    });
+    expect(result.syncLatencyMs).toBe(0);
+    expect(result.isLateSync).toBe(false);
+    expect(result.clockSkewWarning).toBe(false);
+    expect(result.administeredAtUtc.getTime()).toBe(SERVER.getTime());
+    expect(result.recordedAtUtc.getTime()).toBe(SERVER.getTime());
+  });
+
+  it('écart de 10 s : latence faible, pas de flag', () => {
+    const administered = offsetMs(SERVER, -10_000);
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: administered,
+      serverReceivedAtUtc: SERVER,
+    });
+    expect(result.syncLatencyMs).toBe(10_000);
+    expect(result.isLateSync).toBe(false);
+  });
+
+  it('écart de 59 999 ms : sous le seuil, pas de flag', () => {
+    const administered = offsetMs(SERVER, -59_999);
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: administered,
+      serverReceivedAtUtc: SERVER,
+    });
+    expect(result.isLateSync).toBe(false);
+  });
+
+  it('écart de 60 000 ms pile : borne stricte — encore hors flag', () => {
+    // Borne exclusive : isLateSync TRUE ssi syncLatencyMs > 60 000
+    const administered = offsetMs(SERVER, -60_000);
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: administered,
+      serverReceivedAtUtc: SERVER,
+    });
+    expect(result.isLateSync).toBe(false);
+  });
+
+  it('écart de 60 001 ms : franchit le seuil de sync tardive', () => {
+    const administered = offsetMs(SERVER, -60_001);
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: administered,
+      serverReceivedAtUtc: SERVER,
+    });
+    expect(result.isLateSync).toBe(true);
+  });
+});
+
+describe('RM14 — assignAuthoritativeTimestamp (sync tardive)', () => {
+  it('saisie synchronisée 6 h plus tard : latence ≈ 6 h, isLateSync=true', () => {
+    const administered = offsetMs(SERVER, -(6 * 60 * 60_000));
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: administered,
+      serverReceivedAtUtc: SERVER,
+    });
+    expect(result.syncLatencyMs).toBe(6 * 60 * 60_000);
+    expect(result.isLateSync).toBe(true);
+    expect(result.clockSkewWarning).toBe(false);
+    expect(result.administeredAtUtc.getTime()).toBe(administered.getTime());
+    expect(result.recordedAtUtc.getTime()).toBe(SERVER.getTime());
+  });
+});
+
+describe('RM14 — assignAuthoritativeTimestamp (dérive horloge client)', () => {
+  it('administered dans le futur (+500 ms) : latence négative, pas de warn (tolérance)', () => {
+    // Tolérance d'horloge : un écart ≤ 1 s vers le futur est absorbé
+    // silencieusement (bruit NTP usuel) et ne lève pas clockSkewWarning.
+    const administered = offsetMs(SERVER, 500);
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: administered,
+      serverReceivedAtUtc: SERVER,
+    });
+    expect(result.syncLatencyMs).toBe(-500);
+    expect(result.isLateSync).toBe(false);
+    expect(result.clockSkewWarning).toBe(false);
+  });
+
+  it('administered +5 min dans le futur : clockSkewWarning=true', () => {
+    const administered = offsetMs(SERVER, 5 * 60_000);
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: administered,
+      serverReceivedAtUtc: SERVER,
+    });
+    expect(result.syncLatencyMs).toBe(-5 * 60_000);
+    expect(result.isLateSync).toBe(false);
+    expect(result.clockSkewWarning).toBe(true);
+  });
+
+  it('préserve administeredAtUtc tel quel, même dans le futur (client fait foi)', () => {
+    const administered = offsetMs(SERVER, 5 * 60_000);
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: administered,
+      serverReceivedAtUtc: SERVER,
+    });
+    expect(result.administeredAtUtc.getTime()).toBe(administered.getTime());
+  });
+});
+
+describe('RM14 — pureté', () => {
+  it('ne mute pas les Date en entrée', () => {
+    const administered = offsetMs(SERVER, -30_000);
+    const adminMs = administered.getTime();
+    const serverMs = SERVER.getTime();
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: administered,
+      serverReceivedAtUtc: SERVER,
+    });
+    // Mutation explicite sur la sortie
+    result.administeredAtUtc.setTime(0);
+    result.recordedAtUtc.setTime(0);
+    expect(administered.getTime()).toBe(adminMs);
+    expect(SERVER.getTime()).toBe(serverMs);
+  });
+
+  it('renvoie de nouvelles instances de Date (défense contre aliasing)', () => {
+    const administered = offsetMs(SERVER, -30_000);
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: administered,
+      serverReceivedAtUtc: SERVER,
+    });
+    expect(result.administeredAtUtc).not.toBe(administered);
+    expect(result.recordedAtUtc).not.toBe(SERVER);
+  });
+});
+
+describe('RM14 — seuil configurable', () => {
+  it('accepte un seuil personnalisé', () => {
+    const administered = offsetMs(SERVER, -30_000);
+    const result = assignAuthoritativeTimestamp({
+      administeredAtUtc: administered,
+      serverReceivedAtUtc: SERVER,
+      lateSyncThresholdMs: 10_000,
+    });
+    expect(result.isLateSync).toBe(true);
+  });
+});

--- a/packages/domain/src/rules/rm14-recorded-timestamp.ts
+++ b/packages/domain/src/rules/rm14-recorded-timestamp.ts
@@ -1,0 +1,96 @@
+/**
+ * Seuil par défaut (ms) au-delà duquel une saisie est considérée comme une
+ * **sync tardive** : le client a saisi la prise hors-ligne puis s'est
+ * synchronisé plus tard. Les notifications post-sync doivent alors mentionner
+ * explicitement les deux horodatages (« saisie il y a X, prise à HH:MM »).
+ *
+ * La comparaison est **strictement supérieure** (`>` seuil) — un écart de
+ * exactement 60 000 ms reste classé « en ligne ».
+ */
+export const LATE_SYNC_THRESHOLD_MS = 60_000;
+
+/**
+ * Tolérance admise pour les saisies « légèrement dans le futur » dues au bruit
+ * NTP ou à la latence réseau (le client marque `now` puis envoie la requête,
+ * le serveur la reçoit quelques ms plus tard avec une horloge légèrement en
+ * arrière). En dessous de 1 s vers le futur, aucun `clockSkewWarning`.
+ */
+const CLOCK_SKEW_TOLERANCE_MS = 1_000;
+
+/** Options d'application de la règle RM14. */
+export interface RecordTimestampOptions {
+  /** Horodatage déclaré par le client. Conservé tel quel (client fait foi). */
+  readonly administeredAtUtc: Date;
+  /** Horodatage serveur « maintenant » — injecté, jamais `Date.now()`. */
+  readonly serverReceivedAtUtc: Date;
+  /**
+   * Surcharge du seuil de sync tardive (ms). Par défaut
+   * {@link LATE_SYNC_THRESHOLD_MS}. Utile pour tester des scénarios spécifiques
+   * ou adapter la sensibilité côté client mobile vs. web.
+   */
+  readonly lateSyncThresholdMs?: number;
+}
+
+/**
+ * Résultat de l'application RM14 : horodatages consolidés + métadonnées de
+ * latence pour la couche notification.
+ */
+export interface DoseTimestampingResult {
+  /** Copie de `administeredAtUtc` (client fait foi). */
+  readonly administeredAtUtc: Date;
+  /** Horodatage serveur autoritaire. Copie de `serverReceivedAtUtc`. */
+  readonly recordedAtUtc: Date;
+  /**
+   * `recordedAtUtc - administeredAtUtc` en ms.
+   * - Positif : cas normal (saisie dans le passé, éventuellement tardive).
+   * - Négatif : le client a déclaré un horodatage dans le futur (dérive NTP
+   *   ou tentative de falsification). La saisie **n'est pas refusée ici**
+   *   (RM14 = traçabilité, pas contrôle) ; c'est RM17 qui peut rejeter.
+   */
+  readonly syncLatencyMs: number;
+  /** `true` si `syncLatencyMs > lateSyncThresholdMs`. */
+  readonly isLateSync: boolean;
+  /**
+   * `true` si la saisie est déclarée plus loin dans le futur que la tolérance
+   * d'horloge (≥ 1 s). Sert à informer l'opérateur sans bloquer la saisie.
+   */
+  readonly clockSkewWarning: boolean;
+}
+
+/**
+ * RM14 — applique l'horodatage serveur autoritaire à une prise.
+ *
+ * Sémantique :
+ * - `administeredAtUtc` du client est **conservé tel quel** : c'est la source
+ *   de vérité métier (« quand la pompe a été prise »). Cf. SPECS §RM14.
+ * - `recordedAtUtc` est posé par le serveur à la réception : c'est l'heure de
+ *   saisie, utilisée pour la détection de doublons (RM6), l'ordre canonique
+ *   dans les journaux et la fenêtre de void (RM18).
+ *
+ * Fonction pure, aucun `Date.now()`, aucune lecture d'horloge interne : tout
+ * est injecté par l'appelant. Retourne de nouvelles instances de `Date` pour
+ * éviter tout aliasing externe.
+ *
+ * RM14 n'émet **aucune erreur** : c'est une règle de traçabilité, pas de
+ * refus. Les contrôles d'acceptabilité (futur, trop vieux) relèvent de RM17.
+ */
+export function assignAuthoritativeTimestamp(
+  options: RecordTimestampOptions,
+): DoseTimestampingResult {
+  const threshold = options.lateSyncThresholdMs ?? LATE_SYNC_THRESHOLD_MS;
+
+  const administeredMs = options.administeredAtUtc.getTime();
+  const recordedMs = options.serverReceivedAtUtc.getTime();
+  const syncLatencyMs = recordedMs - administeredMs;
+
+  const isLateSync = syncLatencyMs > threshold;
+  const clockSkewWarning = syncLatencyMs < -CLOCK_SKEW_TOLERANCE_MS;
+
+  return {
+    administeredAtUtc: new Date(administeredMs),
+    recordedAtUtc: new Date(recordedMs),
+    syncLatencyMs,
+    isLateSync,
+    clockSkewWarning,
+  };
+}

--- a/packages/domain/src/rules/rm15-idempotency.test.ts
+++ b/packages/domain/src/rules/rm15-idempotency.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+import { DomainError } from '../errors';
+import {
+  createEmptyIdempotencyRegistry,
+  decideIdempotency,
+  type IdempotencyRegistry,
+  type ProcessedEvent,
+  recordProcessedEvent,
+} from './rm15-idempotency';
+
+const VALID_UUID_V4_A = '550e8400-e29b-41d4-a716-446655440000';
+const VALID_UUID_V4_B = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const VALID_UUID_V4_C = '6ba7b810-9dad-41d1-80b4-00c04fd430c8';
+
+const BASE = new Date('2026-04-19T08:00:00Z');
+
+function makeEvent(overrides: Partial<ProcessedEvent> & { clientEventId: string }): ProcessedEvent {
+  return {
+    doseId: 'dose-default',
+    recordedAtUtc: BASE,
+    ...overrides,
+  };
+}
+
+describe('RM15 — createEmptyIdempotencyRegistry', () => {
+  it('construit un registre vide', () => {
+    const registry = createEmptyIdempotencyRegistry();
+    expect(registry.events.size).toBe(0);
+  });
+});
+
+describe('RM15 — decideIdempotency', () => {
+  it('retourne process quand le registre est vide', () => {
+    const registry = createEmptyIdempotencyRegistry();
+    const decision = decideIdempotency(registry, VALID_UUID_V4_A);
+    expect(decision).toEqual({ kind: 'process', clientEventId: VALID_UUID_V4_A });
+  });
+
+  it('retourne replay quand le clientEventId est déjà connu', () => {
+    let registry: IdempotencyRegistry = createEmptyIdempotencyRegistry();
+    const processed = makeEvent({ clientEventId: VALID_UUID_V4_A, doseId: 'dose-42' });
+    registry = recordProcessedEvent(registry, processed);
+
+    const decision = decideIdempotency(registry, VALID_UUID_V4_A);
+    expect(decision.kind).toBe('replay');
+    if (decision.kind === 'replay') {
+      expect(decision.existing.doseId).toBe('dose-42');
+      expect(decision.existing.clientEventId).toBe(VALID_UUID_V4_A);
+    }
+  });
+
+  it('retourne process pour un UUID différent', () => {
+    let registry: IdempotencyRegistry = createEmptyIdempotencyRegistry();
+    registry = recordProcessedEvent(
+      registry,
+      makeEvent({ clientEventId: VALID_UUID_V4_A, doseId: 'dose-42' }),
+    );
+
+    const decision = decideIdempotency(registry, VALID_UUID_V4_B);
+    expect(decision.kind).toBe('process');
+  });
+
+  it('lève RM15_INVALID_CLIENT_EVENT_ID sur une chaîne vide', () => {
+    const registry = createEmptyIdempotencyRegistry();
+    expect(() => decideIdempotency(registry, '')).toThrowError(DomainError);
+    try {
+      decideIdempotency(registry, '');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM15_INVALID_CLIENT_EVENT_ID');
+    }
+  });
+
+  it('lève RM15_INVALID_CLIENT_EVENT_ID sur du whitespace pur', () => {
+    const registry = createEmptyIdempotencyRegistry();
+    expect(() => decideIdempotency(registry, '   ')).toThrowError(DomainError);
+    try {
+      decideIdempotency(registry, '   ');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM15_INVALID_CLIENT_EVENT_ID');
+    }
+  });
+
+  it('lève RM15_INVALID_CLIENT_EVENT_ID sur un UUID malformé', () => {
+    const registry = createEmptyIdempotencyRegistry();
+    expect(() => decideIdempotency(registry, 'not-a-uuid')).toThrowError(DomainError);
+  });
+
+  it('lève RM15_INVALID_CLIENT_EVENT_ID sur un UUID v1 (mauvaise version)', () => {
+    const registry = createEmptyIdempotencyRegistry();
+    // UUID v1 : version = 1 (4ème bloc commence par 1)
+    expect(() => decideIdempotency(registry, '6ba7b810-9dad-11d1-80b4-00c04fd430c8')).toThrowError(
+      DomainError,
+    );
+  });
+
+  it('accepte un UUID v4 en majuscules', () => {
+    const registry = createEmptyIdempotencyRegistry();
+    const decision = decideIdempotency(registry, VALID_UUID_V4_A.toUpperCase());
+    expect(decision.kind).toBe('process');
+  });
+});
+
+describe('RM15 — recordProcessedEvent', () => {
+  it('enregistre un nouvel événement', () => {
+    const registry = createEmptyIdempotencyRegistry();
+    const event = makeEvent({ clientEventId: VALID_UUID_V4_A, doseId: 'dose-42' });
+    const next = recordProcessedEvent(registry, event);
+    expect(next.events.get(VALID_UUID_V4_A)).toEqual(event);
+  });
+
+  it('est idempotent : réenregistrer le même événement ne change rien', () => {
+    let registry: IdempotencyRegistry = createEmptyIdempotencyRegistry();
+    const event = makeEvent({ clientEventId: VALID_UUID_V4_A, doseId: 'dose-42' });
+    registry = recordProcessedEvent(registry, event);
+    const sizeAfterFirst = registry.events.size;
+    const afterSecond = recordProcessedEvent(registry, event);
+    expect(afterSecond.events.size).toBe(sizeAfterFirst);
+    expect(afterSecond.events.get(VALID_UUID_V4_A)).toEqual(event);
+  });
+
+  it('ne mute pas le registre source (pureté)', () => {
+    const registry = createEmptyIdempotencyRegistry();
+    const sourceSize = registry.events.size;
+    recordProcessedEvent(
+      registry,
+      makeEvent({ clientEventId: VALID_UUID_V4_A, doseId: 'dose-42' }),
+    );
+    expect(registry.events.size).toBe(sourceSize);
+  });
+
+  it('accumule plusieurs événements distincts', () => {
+    let registry: IdempotencyRegistry = createEmptyIdempotencyRegistry();
+    registry = recordProcessedEvent(
+      registry,
+      makeEvent({ clientEventId: VALID_UUID_V4_A, doseId: 'd1' }),
+    );
+    registry = recordProcessedEvent(
+      registry,
+      makeEvent({ clientEventId: VALID_UUID_V4_B, doseId: 'd2' }),
+    );
+    registry = recordProcessedEvent(
+      registry,
+      makeEvent({ clientEventId: VALID_UUID_V4_C, doseId: 'd3' }),
+    );
+    expect(registry.events.size).toBe(3);
+  });
+
+  it('lève RM15_INVALID_CLIENT_EVENT_ID sur clientEventId invalide', () => {
+    const registry = createEmptyIdempotencyRegistry();
+    expect(() =>
+      recordProcessedEvent(registry, makeEvent({ clientEventId: '', doseId: 'd1' })),
+    ).toThrowError(DomainError);
+  });
+
+  it('normalise la casse : le même UUID en majuscules déclenche la déduplication', () => {
+    let registry: IdempotencyRegistry = createEmptyIdempotencyRegistry();
+    registry = recordProcessedEvent(
+      registry,
+      makeEvent({ clientEventId: VALID_UUID_V4_A, doseId: 'd1' }),
+    );
+
+    const decision = decideIdempotency(registry, VALID_UUID_V4_A.toUpperCase());
+    expect(decision.kind).toBe('replay');
+    if (decision.kind === 'replay') {
+      expect(decision.existing.doseId).toBe('d1');
+    }
+  });
+});

--- a/packages/domain/src/rules/rm15-idempotency.ts
+++ b/packages/domain/src/rules/rm15-idempotency.ts
@@ -1,0 +1,112 @@
+import { DomainError } from '../errors';
+
+/**
+ * Enregistrement d'un événement client déjà traité par le serveur (RM15).
+ * Sert de mémoire à la déduplication : la clé est `clientEventId`, la valeur
+ * est la prise finale (ID + horodatage serveur) qui sera renvoyée au client
+ * lors d'un rejeu.
+ */
+export interface ProcessedEvent {
+  readonly clientEventId: string;
+  readonly doseId: string;
+  readonly recordedAtUtc: Date;
+}
+
+/**
+ * Registre d'idempotence — vue en lecture seule sur les `clientEventId` déjà
+ * traités. Côté domaine on modélise un `Map` immuable ; côté `apps/api`
+ * l'implémentation réelle s'appuie sur une contrainte d'unicité Postgres. Le
+ * domaine décrit la **décision** sans jamais persister.
+ */
+export interface IdempotencyRegistry {
+  readonly events: ReadonlyMap<string, ProcessedEvent>;
+}
+
+/**
+ * Décision renvoyée par {@link decideIdempotency} :
+ * - `process` : nouvel événement, à traiter normalement ;
+ * - `replay` : événement déjà traité, renvoyer la même réponse (pas de nouvelle
+ *   insertion, pas d'effet de bord).
+ */
+export type IdempotencyDecision =
+  | { readonly kind: 'process'; readonly clientEventId: string }
+  | { readonly kind: 'replay'; readonly existing: ProcessedEvent };
+
+/**
+ * Regex UUID v4 (8-4-4-4-12 hex, 13ème caractère = `4`, 17ème caractère dans
+ * `[8, 9, a, b]`). Insensible à la casse. On refuse explicitement les autres
+ * versions (v1, v3, v5) pour se prémunir d'identifiants prévisibles (v1 basé
+ * sur l'horloge + MAC) ou non aléatoires.
+ *
+ * Référence : RFC 4122 §4.4 (v4 = random).
+ */
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * RM15 — registre vide initial. Pure fabrique, ne mute rien, utile comme
+ * valeur de départ pour les tests et pour le code serveur qui rechargerait un
+ * cache en mémoire.
+ */
+export function createEmptyIdempotencyRegistry(): IdempotencyRegistry {
+  return { events: new Map<string, ProcessedEvent>() };
+}
+
+/**
+ * RM15 — décide si un `clientEventId` doit être traité (nouveau) ou rejoué
+ * (déjà vu). Pure fonction : ne mute rien, ne persiste rien. Le `clientEventId`
+ * est normalisé en minuscules avant recherche pour être robuste aux variations
+ * de casse émises par différents clients.
+ *
+ * @throws {DomainError} `RM15_INVALID_CLIENT_EVENT_ID` si l'ID est vide, du
+ *   whitespace pur ou n'est pas un UUID v4 conforme RFC 4122.
+ */
+export function decideIdempotency(
+  registry: IdempotencyRegistry,
+  clientEventId: string,
+): IdempotencyDecision {
+  const normalized = normalizeAndValidate(clientEventId);
+  const existing = registry.events.get(normalized);
+  if (existing !== undefined) {
+    return { kind: 'replay', existing };
+  }
+  return { kind: 'process', clientEventId: normalized };
+}
+
+/**
+ * RM15 — ajoute un `ProcessedEvent` au registre. Pure : renvoie un **nouveau**
+ * registre, ne mute jamais l'entrée. Idempotente — réenregistrer un événement
+ * déjà présent renvoie une copie équivalente (taille inchangée, même valeur).
+ *
+ * @throws {DomainError} `RM15_INVALID_CLIENT_EVENT_ID` si l'ID est invalide.
+ */
+export function recordProcessedEvent(
+  registry: IdempotencyRegistry,
+  event: ProcessedEvent,
+): IdempotencyRegistry {
+  const normalized = normalizeAndValidate(event.clientEventId);
+  const next = new Map(registry.events);
+  next.set(normalized, { ...event, clientEventId: normalized });
+  return { events: next };
+}
+
+function normalizeAndValidate(clientEventId: string): string {
+  if (typeof clientEventId !== 'string') {
+    throw invalidClientEventId(clientEventId);
+  }
+  const trimmed = clientEventId.trim();
+  if (trimmed.length === 0) {
+    throw invalidClientEventId(clientEventId);
+  }
+  if (!UUID_V4_REGEX.test(trimmed)) {
+    throw invalidClientEventId(clientEventId);
+  }
+  return trimmed.toLowerCase();
+}
+
+function invalidClientEventId(raw: unknown): DomainError {
+  return new DomainError(
+    'RM15_INVALID_CLIENT_EVENT_ID',
+    'clientEventId must be a non-empty UUID v4 string (RFC 4122).',
+    { clientEventId: raw },
+  );
+}

--- a/packages/domain/src/rules/rm17-backfill-window.test.ts
+++ b/packages/domain/src/rules/rm17-backfill-window.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from 'vitest';
+import { DomainError } from '../errors';
+import {
+  BACKFILL_MAX_WINDOW_HOURS,
+  type BackfillValidation,
+  ensureBackfillAllowed,
+  validateBackfillTiming,
+} from './rm17-backfill-window';
+
+const NOW = new Date('2026-04-19T12:00:00Z');
+
+function offsetMinutes(base: Date, minutes: number): Date {
+  return new Date(base.getTime() + minutes * 60_000);
+}
+
+describe('RM17 — constant', () => {
+  it('expose la fenêtre max de 24 h', () => {
+    expect(BACKFILL_MAX_WINDOW_HOURS).toBe(24);
+  });
+});
+
+describe('RM17 — validateBackfillTiming', () => {
+  it('on_time quand administered == recorded', () => {
+    const validation = validateBackfillTiming({
+      administeredAtUtc: NOW,
+      recordedAtUtc: NOW,
+    });
+    expect(validation.validity.kind).toBe('on_time');
+    expect(validation.requiresExplicitConfirmation).toBe(false);
+  });
+
+  it('on_time pour une saisie temps réel (< 5 s d écart)', () => {
+    const validation = validateBackfillTiming({
+      administeredAtUtc: new Date(NOW.getTime() - 3_000),
+      recordedAtUtc: NOW,
+    });
+    expect(validation.validity.kind).toBe('on_time');
+  });
+
+  it('within_window pour une saisie à -1 h (backfill 1 h passé)', () => {
+    const administered = offsetMinutes(NOW, -60);
+    const validation = validateBackfillTiming({
+      administeredAtUtc: administered,
+      recordedAtUtc: NOW,
+    });
+    expect(validation.validity.kind).toBe('within_window');
+    if (validation.validity.kind === 'within_window') {
+      expect(validation.validity.lateBy).toBe(60 * 60_000);
+    }
+    expect(validation.requiresExplicitConfirmation).toBe(false);
+  });
+
+  it('within_window à -23 h 59 min', () => {
+    const administered = offsetMinutes(NOW, -(23 * 60 + 59));
+    const validation = validateBackfillTiming({
+      administeredAtUtc: administered,
+      recordedAtUtc: NOW,
+    });
+    expect(validation.validity.kind).toBe('within_window');
+  });
+
+  it('within_window à -24 h pile (borne inclusive)', () => {
+    const administered = offsetMinutes(NOW, -24 * 60);
+    const validation = validateBackfillTiming({
+      administeredAtUtc: administered,
+      recordedAtUtc: NOW,
+    });
+    expect(validation.validity.kind).toBe('within_window');
+    if (validation.validity.kind === 'within_window') {
+      expect(validation.validity.lateBy).toBe(24 * 60 * 60_000);
+    }
+  });
+
+  it('too_old à -24 h 01 min (requiresExplicitConfirmation=true)', () => {
+    const administered = offsetMinutes(NOW, -(24 * 60 + 1));
+    const validation = validateBackfillTiming({
+      administeredAtUtc: administered,
+      recordedAtUtc: NOW,
+    });
+    expect(validation.validity.kind).toBe('too_old');
+    if (validation.validity.kind === 'too_old') {
+      expect(validation.validity.lateBy).toBe((24 * 60 + 1) * 60_000);
+    }
+    expect(validation.requiresExplicitConfirmation).toBe(true);
+  });
+
+  it('future_refused pour une prise 1 min dans le futur', () => {
+    const administered = offsetMinutes(NOW, 1);
+    const validation: BackfillValidation = validateBackfillTiming({
+      administeredAtUtc: administered,
+      recordedAtUtc: NOW,
+    });
+    expect(validation.validity.kind).toBe('future_refused');
+    if (validation.validity.kind === 'future_refused') {
+      expect(validation.validity.aheadBy).toBe(60_000);
+    }
+    expect(validation.requiresExplicitConfirmation).toBe(false);
+  });
+
+  it('ignore le flag explicitlyConfirmed (simple diagnostic)', () => {
+    const administered = offsetMinutes(NOW, -(25 * 60));
+    const validation = validateBackfillTiming({
+      administeredAtUtc: administered,
+      recordedAtUtc: NOW,
+      explicitlyConfirmed: true,
+    });
+    // La classification ne change pas : elle reste too_old.
+    expect(validation.validity.kind).toBe('too_old');
+  });
+
+  it('ne mute pas les dates fournies', () => {
+    const administered = offsetMinutes(NOW, -60);
+    const adminMs = administered.getTime();
+    const nowMs = NOW.getTime();
+    validateBackfillTiming({
+      administeredAtUtc: administered,
+      recordedAtUtc: NOW,
+    });
+    expect(administered.getTime()).toBe(adminMs);
+    expect(NOW.getTime()).toBe(nowMs);
+  });
+});
+
+describe('RM17 — ensureBackfillAllowed', () => {
+  it('passe pour une saisie on_time', () => {
+    expect(() =>
+      ensureBackfillAllowed({
+        administeredAtUtc: NOW,
+        recordedAtUtc: NOW,
+      }),
+    ).not.toThrow();
+  });
+
+  it('passe pour un backfill within_window sans confirmation', () => {
+    expect(() =>
+      ensureBackfillAllowed({
+        administeredAtUtc: offsetMinutes(NOW, -60),
+        recordedAtUtc: NOW,
+      }),
+    ).not.toThrow();
+  });
+
+  it('lève RM17_TOO_OLD_REQUIRES_CONFIRMATION à -25 h sans confirmation', () => {
+    expect(() =>
+      ensureBackfillAllowed({
+        administeredAtUtc: offsetMinutes(NOW, -(25 * 60)),
+        recordedAtUtc: NOW,
+      }),
+    ).toThrowError(DomainError);
+    try {
+      ensureBackfillAllowed({
+        administeredAtUtc: offsetMinutes(NOW, -(25 * 60)),
+        recordedAtUtc: NOW,
+      });
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM17_TOO_OLD_REQUIRES_CONFIRMATION');
+    }
+  });
+
+  it('passe à -25 h avec explicitlyConfirmed=true', () => {
+    expect(() =>
+      ensureBackfillAllowed({
+        administeredAtUtc: offsetMinutes(NOW, -(25 * 60)),
+        recordedAtUtc: NOW,
+        explicitlyConfirmed: true,
+      }),
+    ).not.toThrow();
+  });
+
+  it('lève RM17_FUTURE_ADMINISTRATION_REFUSED pour une saisie dans le futur', () => {
+    expect(() =>
+      ensureBackfillAllowed({
+        administeredAtUtc: offsetMinutes(NOW, 1),
+        recordedAtUtc: NOW,
+      }),
+    ).toThrowError(DomainError);
+    try {
+      ensureBackfillAllowed({
+        administeredAtUtc: offsetMinutes(NOW, 1),
+        recordedAtUtc: NOW,
+      });
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM17_FUTURE_ADMINISTRATION_REFUSED');
+    }
+  });
+
+  it('lève RM17_FUTURE_ADMINISTRATION_REFUSED même avec explicitlyConfirmed=true', () => {
+    // Le futur n'est JAMAIS acceptable, même confirmé : c'est une dérive
+    // d'horloge ou une tentative de falsification, pas un rattrapage.
+    expect(() =>
+      ensureBackfillAllowed({
+        administeredAtUtc: offsetMinutes(NOW, 1),
+        recordedAtUtc: NOW,
+        explicitlyConfirmed: true,
+      }),
+    ).toThrowError(/RM17_FUTURE_ADMINISTRATION_REFUSED|future/i);
+  });
+});

--- a/packages/domain/src/rules/rm17-backfill-window.ts
+++ b/packages/domain/src/rules/rm17-backfill-window.ts
@@ -1,0 +1,151 @@
+import { DomainError } from '../errors';
+
+/**
+ * Fenêtre maximale de rattrapage autorisée sans confirmation explicite (RM17).
+ * Au-delà, une saisie `backfill` reste possible mais nécessite un accusé de
+ * saisie explicite par l'aidant (« Je confirme cette prise à cette heure »).
+ */
+export const BACKFILL_MAX_WINDOW_HOURS = 24;
+
+const BACKFILL_MAX_WINDOW_MS = BACKFILL_MAX_WINDOW_HOURS * 60 * 60_000;
+
+/**
+ * Seuil en-dessous duquel un écart `|recorded - administered|` est considéré
+ * comme une saisie **temps réel** (pas un backfill). Exprimé en millisecondes.
+ *
+ * Valeur choisie : 5 s. Motivations :
+ * - couvre le RTT réseau d'une saisie en ligne normale ;
+ * - tolère une micro-désync d'horloge sans bruit de flag ;
+ * - strictement < à la borne RM6 (2 min), donc sans interférence.
+ *
+ * Un écart de 3 secondes (ou de 0) reste classé `on_time` ; un écart > 5 s
+ * bascule en `within_window` si le passé et dans la fenêtre des 24 h.
+ */
+const ON_TIME_TOLERANCE_MS = 5_000;
+
+/**
+ * Classification du timing d'une prise vs. le moment de saisie serveur (RM17).
+ *
+ * - `on_time` : saisie quasi temps réel (|Δ| ≤ 5 s).
+ * - `within_window` : backfill valide, `lateBy` = combien de ms dans le passé.
+ * - `future_refused` : saisie dans le futur strict (horloge client en avance
+ *   ou tentative de falsification). Jamais autorisée, même avec confirmation.
+ * - `too_old` : plus de 24 h dans le passé. Nécessite une confirmation
+ *   explicite (« Je confirme cette prise à cette heure ») pour passer.
+ */
+export type BackfillValidity =
+  | { readonly kind: 'on_time' }
+  | { readonly kind: 'within_window'; readonly lateBy: number }
+  | { readonly kind: 'future_refused'; readonly aheadBy: number }
+  | { readonly kind: 'too_old'; readonly lateBy: number };
+
+/** Résultat de la validation RM17 — purement informatif. */
+export interface BackfillValidation {
+  readonly validity: BackfillValidity;
+  /**
+   * `true` si la saisie dépasse 24 h dans le passé : l'UI doit exiger un
+   * accusé de saisie explicite avant d'envoyer la requête.
+   */
+  readonly requiresExplicitConfirmation: boolean;
+}
+
+/** Options communes à {@link validateBackfillTiming} et {@link ensureBackfillAllowed}. */
+export interface BackfillOptions {
+  /** Horodatage déclaré par le client — RM14 : client fait foi. */
+  readonly administeredAtUtc: Date;
+  /** Horodatage serveur de la saisie — RM14 : autoritaire. */
+  readonly recordedAtUtc: Date;
+  /**
+   * Accusé de saisie explicite de l'aidant. Pertinent uniquement quand la
+   * classification est `too_old` : il permet de passer le contrôle. Ignoré
+   * pour `future_refused` — le futur est toujours refusé.
+   */
+  readonly explicitlyConfirmed?: boolean;
+}
+
+/**
+ * RM17 — classe le timing d'une prise par rapport à la fenêtre de rattrapage.
+ *
+ * Convention de signe : `administeredAtUtc < recordedAtUtc` ⇒ `lateBy > 0`
+ * (saisie dans le passé, cas normal). `administeredAtUtc > recordedAtUtc` ⇒
+ * `aheadBy > 0` (futur, toujours refusé). Égalité ou écart ≤ 5 s ⇒ `on_time`.
+ *
+ * Pure fonction : ne mute pas `administeredAtUtc` ni `recordedAtUtc`. Ignore
+ * le flag `explicitlyConfirmed` — ce dernier n'est pris en compte que par
+ * {@link ensureBackfillAllowed} qui traduit la classification en décision.
+ */
+export function validateBackfillTiming(options: BackfillOptions): BackfillValidation {
+  const deltaMs = options.recordedAtUtc.getTime() - options.administeredAtUtc.getTime();
+
+  if (deltaMs < -ON_TIME_TOLERANCE_MS) {
+    // administered > recorded : futur
+    return {
+      validity: { kind: 'future_refused', aheadBy: -deltaMs },
+      requiresExplicitConfirmation: false,
+    };
+  }
+
+  if (deltaMs <= ON_TIME_TOLERANCE_MS) {
+    return {
+      validity: { kind: 'on_time' },
+      requiresExplicitConfirmation: false,
+    };
+  }
+
+  if (deltaMs <= BACKFILL_MAX_WINDOW_MS) {
+    return {
+      validity: { kind: 'within_window', lateBy: deltaMs },
+      requiresExplicitConfirmation: false,
+    };
+  }
+
+  return {
+    validity: { kind: 'too_old', lateBy: deltaMs },
+    requiresExplicitConfirmation: true,
+  };
+}
+
+/**
+ * RM17 — exige un timing acceptable : on_time, within_window, ou too_old avec
+ * `explicitlyConfirmed = true`. Lève sinon.
+ *
+ * @throws {DomainError} `RM17_FUTURE_ADMINISTRATION_REFUSED` si la saisie est
+ *   dans le futur — refus absolu, même avec `explicitlyConfirmed`.
+ * @throws {DomainError} `RM17_TOO_OLD_REQUIRES_CONFIRMATION` si la saisie est
+ *   au-delà de 24 h dans le passé ET `explicitlyConfirmed !== true`.
+ */
+export function ensureBackfillAllowed(options: BackfillOptions): void {
+  const validation = validateBackfillTiming(options);
+
+  switch (validation.validity.kind) {
+    case 'on_time':
+    case 'within_window':
+      return;
+
+    case 'future_refused':
+      throw new DomainError(
+        'RM17_FUTURE_ADMINISTRATION_REFUSED',
+        'administeredAtUtc cannot be in the future: refused regardless of confirmation.',
+        {
+          administeredAtUtc: options.administeredAtUtc.toISOString(),
+          recordedAtUtc: options.recordedAtUtc.toISOString(),
+          aheadByMs: validation.validity.aheadBy,
+        },
+      );
+
+    case 'too_old':
+      if (options.explicitlyConfirmed === true) {
+        return;
+      }
+      throw new DomainError(
+        'RM17_TOO_OLD_REQUIRES_CONFIRMATION',
+        `Backfill older than ${String(BACKFILL_MAX_WINDOW_HOURS)} h requires explicit confirmation.`,
+        {
+          administeredAtUtc: options.administeredAtUtc.toISOString(),
+          recordedAtUtc: options.recordedAtUtc.toISOString(),
+          lateByMs: validation.validity.lateBy,
+          maxWindowHours: BACKFILL_MAX_WINDOW_HOURS,
+        },
+      );
+  }
+}

--- a/packages/domain/src/rules/rm18-void-dose.test.ts
+++ b/packages/domain/src/rules/rm18-void-dose.test.ts
@@ -455,3 +455,69 @@ describe('RM18 — voidDose (transition)', () => {
     ).toThrowError(DomainError);
   });
 });
+
+// Cas local-first : une prise saisie hors-ligne n'a pas encore été horodatée
+// par le serveur (`recordedAtUtc = null`). La fenêtre libre doit alors se
+// calculer depuis `administeredAtUtc` pour ne pas bloquer un void légitime.
+describe('RM18 — fallback recordedAtUtc=null (dose hors-ligne non synchronisée)', () => {
+  it("autorise le void par l'auteur dans la fenêtre libre calculée sur administeredAtUtc", () => {
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'author-1',
+      recordedAtUtc: null,
+    });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('author-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 10),
+      }),
+    ).toBe(true);
+  });
+
+  it('refuse le void par un contributor non-auteur hors fenêtre même sans recordedAtUtc', () => {
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'author-1',
+      recordedAtUtc: null,
+    });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('other-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 45),
+      }),
+    ).toBe(false);
+  });
+
+  it('exige voidedReason pour un admin hors fenêtre calculée depuis administeredAtUtc', () => {
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'author-1',
+      recordedAtUtc: null,
+    });
+    expect(() =>
+      voidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 45),
+      }),
+    ).toThrowError(DomainError);
+  });
+
+  it('accepte le void admin hors fenêtre avec raison, dose non synchronisée', () => {
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'author-1',
+      recordedAtUtc: null,
+    });
+    const result = voidDose({
+      dose,
+      requester: requester('admin-1', 'admin'),
+      nowUtc: minutesAfter(RECORDED, 45),
+      voidedReason: 'correction post-sync',
+    });
+    expect(result.status).toBe('voided');
+    expect(result.voidedReason).toBe('correction post-sync');
+  });
+});

--- a/packages/domain/src/rules/rm18-void-dose.test.ts
+++ b/packages/domain/src/rules/rm18-void-dose.test.ts
@@ -1,0 +1,457 @@
+import { describe, expect, it } from 'vitest';
+import type { Dose } from '../entities/dose';
+import type { Role } from '../entities/role';
+import { DomainError } from '../errors';
+import {
+  canVoidDose,
+  ensureCanVoidDose,
+  VOID_FREE_WINDOW_MINUTES,
+  voidDose,
+} from './rm18-void-dose';
+
+const RECORDED = new Date('2026-04-19T08:00:00Z');
+
+function minutesAfter(base: Date, minutes: number): Date {
+  return new Date(base.getTime() + minutes * 60_000);
+}
+
+function makeDose(overrides: Partial<Dose> & { id: string }): Dose {
+  return {
+    householdId: 'h1',
+    childId: 'c1',
+    pumpId: 'p1',
+    caregiverId: 'author-1',
+    type: 'maintenance',
+    status: 'confirmed',
+    source: 'manual',
+    dosesAdministered: 1,
+    administeredAtUtc: RECORDED,
+    recordedAtUtc: RECORDED,
+    symptoms: [],
+    circumstances: [],
+    freeFormTag: null,
+    voidedReason: null,
+    ...overrides,
+  };
+}
+
+function requester(
+  caregiverId: string,
+  role: Role,
+): { readonly caregiverId: string; readonly role: Role } {
+  return { caregiverId, role };
+}
+
+describe('RM18 — constant', () => {
+  it('expose une fenêtre libre de 30 minutes', () => {
+    expect(VOID_FREE_WINDOW_MINUTES).toBe(30);
+  });
+});
+
+describe('RM18 — canVoidDose (auteur, dans la fenêtre libre)', () => {
+  it('auteur contributor dans la fenêtre libre : OK sans raison', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('author-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 5),
+      }),
+    ).toBe(true);
+  });
+
+  it('auteur contributor dans la fenêtre libre : OK avec raison fournie', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('author-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 5),
+        voidedReason: 'mauvaise pompe',
+      }),
+    ).toBe(true);
+  });
+
+  it('auteur contributor à 30 min pile (borne incluse) : OK', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('author-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, VOID_FREE_WINDOW_MINUTES),
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('RM18 — canVoidDose (admin dans la fenêtre libre)', () => {
+  it('admin non-auteur dans la fenêtre libre : OK sans raison', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 5),
+      }),
+    ).toBe(true);
+  });
+
+  it('admin non-auteur dans la fenêtre libre : OK avec raison', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 5),
+        voidedReason: 'correction',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('RM18 — canVoidDose (refus)', () => {
+  it('contributor non-auteur dans la fenêtre libre : KO', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('other-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 5),
+      }),
+    ).toBe(false);
+  });
+
+  it('restricted_contributor même auteur : KO', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('author-1', 'restricted_contributor'),
+        nowUtc: minutesAfter(RECORDED, 5),
+      }),
+    ).toBe(false);
+  });
+
+  it('auteur contributor hors fenêtre libre (31 min) : KO', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('author-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 31),
+      }),
+    ).toBe(false);
+  });
+
+  it('admin hors fenêtre libre sans raison : KO', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 60),
+      }),
+    ).toBe(false);
+  });
+
+  it('admin hors fenêtre libre raison vide : KO', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 60),
+        voidedReason: '',
+      }),
+    ).toBe(false);
+  });
+
+  it('admin hors fenêtre libre whitespace pur : KO', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 60),
+        voidedReason: '   ',
+      }),
+    ).toBe(false);
+  });
+
+  it('admin hors fenêtre libre avec raison valide : OK', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 60),
+        voidedReason: 'saisie erronée',
+      }),
+    ).toBe(true);
+  });
+
+  it('prise déjà voided : toujours KO', () => {
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'author-1',
+      status: 'voided',
+      voidedReason: 'déjà',
+    });
+    expect(
+      canVoidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 5),
+        voidedReason: 'nouvelle',
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('RM18 — ensureCanVoidDose (codes d erreur précis)', () => {
+  it('lève RM18_ALREADY_VOIDED sur prise déjà voidée', () => {
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'author-1',
+      status: 'voided',
+      voidedReason: 'déjà',
+    });
+    expect(() =>
+      ensureCanVoidDose({
+        dose,
+        requester: requester('author-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 5),
+      }),
+    ).toThrowError(DomainError);
+    try {
+      ensureCanVoidDose({
+        dose,
+        requester: requester('author-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 5),
+      });
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM18_ALREADY_VOIDED');
+    }
+  });
+
+  it('lève RM18_NOT_AUTHORIZED pour contributor non-auteur (fenêtre libre)', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    try {
+      ensureCanVoidDose({
+        dose,
+        requester: requester('other-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 5),
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM18_NOT_AUTHORIZED');
+    }
+  });
+
+  it('lève RM18_NOT_AUTHORIZED pour restricted_contributor même auteur', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    try {
+      ensureCanVoidDose({
+        dose,
+        requester: requester('author-1', 'restricted_contributor'),
+        nowUtc: minutesAfter(RECORDED, 5),
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM18_NOT_AUTHORIZED');
+    }
+  });
+
+  it('lève RM18_NOT_AUTHORIZED pour auteur contributor hors fenêtre libre', () => {
+    // Hors fenêtre libre, seul un admin peut voider. Un contributor n est plus autorisé.
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    try {
+      ensureCanVoidDose({
+        dose,
+        requester: requester('author-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 31),
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM18_NOT_AUTHORIZED');
+    }
+  });
+
+  it('lève RM18_VOIDED_REASON_REQUIRED pour admin hors fenêtre sans raison', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    try {
+      ensureCanVoidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 60),
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM18_VOIDED_REASON_REQUIRED');
+    }
+  });
+
+  it('lève RM18_VOIDED_REASON_REQUIRED pour admin hors fenêtre raison whitespace', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    try {
+      ensureCanVoidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 60),
+        voidedReason: '   \n\t',
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM18_VOIDED_REASON_REQUIRED');
+    }
+  });
+
+  it('ne lève pas pour admin hors fenêtre avec raison valide', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(() =>
+      ensureCanVoidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 60),
+        voidedReason: 'saisie erronée',
+      }),
+    ).not.toThrow();
+  });
+
+  it('ne lève pas pour auteur contributor dans la fenêtre libre', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(() =>
+      ensureCanVoidDose({
+        dose,
+        requester: requester('author-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 5),
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('RM18 — voidDose (transition)', () => {
+  it('retourne une nouvelle prise status=voided', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    const result = voidDose({
+      dose,
+      requester: requester('author-1', 'contributor'),
+      nowUtc: minutesAfter(RECORDED, 5),
+    });
+    expect(result.status).toBe('voided');
+    expect(result.id).toBe('d1');
+  });
+
+  it('ne mute pas la prise source (pureté)', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1', status: 'confirmed' });
+    voidDose({
+      dose,
+      requester: requester('author-1', 'contributor'),
+      nowUtc: minutesAfter(RECORDED, 5),
+    });
+    expect(dose.status).toBe('confirmed');
+    expect(dose.voidedReason).toBeNull();
+  });
+
+  it('stocke voidedReason trimé', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    const result = voidDose({
+      dose,
+      requester: requester('admin-1', 'admin'),
+      nowUtc: minutesAfter(RECORDED, 60),
+      voidedReason: '  saisie erronée  ',
+    });
+    expect(result.voidedReason).toBe('saisie erronée');
+  });
+
+  it('stocke voidedReason=null si non fourni (fenêtre libre)', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    const result = voidDose({
+      dose,
+      requester: requester('author-1', 'contributor'),
+      nowUtc: minutesAfter(RECORDED, 5),
+    });
+    expect(result.voidedReason).toBeNull();
+  });
+
+  it('stocke voidedReason=null si whitespace pur (fenêtre libre)', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    const result = voidDose({
+      dose,
+      requester: requester('author-1', 'contributor'),
+      nowUtc: minutesAfter(RECORDED, 5),
+      voidedReason: '   ',
+    });
+    expect(result.voidedReason).toBeNull();
+  });
+
+  it('préserve les autres champs de la prise', () => {
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'author-1',
+      symptoms: ['cough'],
+      circumstances: ['exercise'],
+      freeFormTag: 'sport',
+      dosesAdministered: 2,
+      source: 'reminder',
+      type: 'rescue',
+    });
+    const result = voidDose({
+      dose,
+      requester: requester('admin-1', 'admin'),
+      nowUtc: minutesAfter(RECORDED, 60),
+      voidedReason: 'erreur',
+    });
+    expect(result).toMatchObject({
+      id: 'd1',
+      caregiverId: 'author-1',
+      symptoms: ['cough'],
+      circumstances: ['exercise'],
+      freeFormTag: 'sport',
+      dosesAdministered: 2,
+      source: 'reminder',
+      type: 'rescue',
+      status: 'voided',
+      voidedReason: 'erreur',
+    });
+  });
+
+  it('lève RM18_ALREADY_VOIDED sur prise déjà voidée', () => {
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'author-1',
+      status: 'voided',
+      voidedReason: 'déjà',
+    });
+    expect(() =>
+      voidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 5),
+        voidedReason: 'nouvelle',
+      }),
+    ).toThrowError(DomainError);
+  });
+
+  it('lève RM18_NOT_AUTHORIZED sur contributor non-auteur', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(() =>
+      voidDose({
+        dose,
+        requester: requester('other-1', 'contributor'),
+        nowUtc: minutesAfter(RECORDED, 5),
+      }),
+    ).toThrowError(DomainError);
+  });
+
+  it('lève RM18_VOIDED_REASON_REQUIRED admin hors fenêtre sans raison', () => {
+    const dose = makeDose({ id: 'd1', caregiverId: 'author-1' });
+    expect(() =>
+      voidDose({
+        dose,
+        requester: requester('admin-1', 'admin'),
+        nowUtc: minutesAfter(RECORDED, 60),
+      }),
+    ).toThrowError(DomainError);
+  });
+});

--- a/packages/domain/src/rules/rm18-void-dose.ts
+++ b/packages/domain/src/rules/rm18-void-dose.ts
@@ -1,0 +1,189 @@
+import type { Dose } from '../entities/dose';
+import type { Role } from '../entities/role';
+import { DomainError } from '../errors';
+
+/**
+ * Fenêtre de grâce (en minutes) pendant laquelle l'auteur d'une prise peut
+ * l'annuler librement (sans raison écrite). Passé ce délai, seul un Admin peut
+ * voider, et `voidedReason` devient obligatoire.
+ *
+ * Borne **inclusive** : un void à 30 min 00 s pile reste dans la fenêtre
+ * libre. Choix cohérent avec la lecture littérale de la spec (« dans les
+ * 30 minutes suivant la saisie ») et moins surprenant pour l'utilisateur.
+ */
+export const VOID_FREE_WINDOW_MINUTES = 30;
+
+const VOID_FREE_WINDOW_MS = VOID_FREE_WINDOW_MINUTES * 60_000;
+
+/** Identité du demandeur d'une annulation (RM18). */
+export interface VoidRequester {
+  readonly caregiverId: string;
+  readonly role: Role;
+}
+
+/** Options d'annulation d'une prise (RM18). */
+export interface VoidDoseOptions {
+  /** La prise à voider. */
+  readonly dose: Dose;
+  /** Aidant qui tente l'annulation. */
+  readonly requester: VoidRequester;
+  /**
+   * Heure serveur courante (RM14). Toujours injectée — jamais `Date.now()`
+   * côté règle, pour garantir la déterminisme des tests.
+   */
+  readonly nowUtc: Date;
+  /**
+   * Motif d'annulation. Requis **strictement** quand la fenêtre libre est
+   * expirée. Une chaîne vide ou whitespace pur est considérée absente.
+   */
+  readonly voidedReason?: string;
+}
+
+/**
+ * Conteneur interne décrivant la décision RM18. Séparé pour factoriser la
+ * logique entre {@link canVoidDose}, {@link ensureCanVoidDose} et
+ * {@link voidDose} sans dupliquer les branches.
+ */
+type VoidAuthorization =
+  | { readonly ok: true; readonly normalizedReason: string | null }
+  | { readonly ok: false; readonly errorCode: VoidErrorCode; readonly detail: string };
+
+type VoidErrorCode = 'RM18_ALREADY_VOIDED' | 'RM18_NOT_AUTHORIZED' | 'RM18_VOIDED_REASON_REQUIRED';
+
+/**
+ * RM18 — prédicat : la demande d'annulation est-elle autorisée ? Retourne
+ * simplement `true`/`false`, sans jamais lever. Pour obtenir la raison d'un
+ * refus, utiliser {@link ensureCanVoidDose}.
+ */
+export function canVoidDose(options: VoidDoseOptions): boolean {
+  return authorizeVoid(options).ok;
+}
+
+/**
+ * RM18 — assertion : l'annulation est autorisée, sinon lève avec le code
+ * d'erreur approprié.
+ *
+ * @throws {DomainError} `RM18_ALREADY_VOIDED` si la prise est déjà voidée.
+ * @throws {DomainError} `RM18_NOT_AUTHORIZED` si le demandeur n'a pas les
+ *   droits (contributor non-auteur, restricted_contributor, auteur hors
+ *   fenêtre libre).
+ * @throws {DomainError} `RM18_VOIDED_REASON_REQUIRED` si l'admin tente une
+ *   annulation hors fenêtre libre sans raison écrite (vide ou whitespace).
+ */
+export function ensureCanVoidDose(options: VoidDoseOptions): void {
+  const decision = authorizeVoid(options);
+  if (decision.ok) {
+    return;
+  }
+  throw new DomainError(decision.errorCode, decision.detail, {
+    doseId: options.dose.id,
+    caregiverId: options.requester.caregiverId,
+    role: options.requester.role,
+    recordedAtUtc: options.dose.recordedAtUtc?.toISOString() ?? null,
+    nowUtc: options.nowUtc.toISOString(),
+  });
+}
+
+/**
+ * RM18 — applique l'annulation : retourne une **nouvelle** `Dose` avec
+ * `status = 'voided'` et `voidedReason` normalisé (trim, null si vide).
+ * Ne mute jamais la prise source.
+ *
+ * @throws {DomainError} Mêmes codes que {@link ensureCanVoidDose}.
+ */
+export function voidDose(options: VoidDoseOptions): Dose {
+  const decision = authorizeVoid(options);
+  if (!decision.ok) {
+    throw new DomainError(decision.errorCode, decision.detail, {
+      doseId: options.dose.id,
+      caregiverId: options.requester.caregiverId,
+      role: options.requester.role,
+      nowUtc: options.nowUtc.toISOString(),
+    });
+  }
+  return {
+    ...options.dose,
+    status: 'voided',
+    voidedReason: decision.normalizedReason,
+  };
+}
+
+function authorizeVoid(options: VoidDoseOptions): VoidAuthorization {
+  const { dose, requester, nowUtc } = options;
+
+  if (dose.status === 'voided') {
+    return {
+      ok: false,
+      errorCode: 'RM18_ALREADY_VOIDED',
+      detail: `Dose ${dose.id} is already voided.`,
+    };
+  }
+
+  const normalizedReason = normalizeReason(options.voidedReason);
+  const insideFreeWindow = isInsideFreeWindow(dose, nowUtc);
+  const isAuthor = requester.caregiverId === dose.caregiverId;
+  const isAdmin = requester.role === 'admin';
+
+  if (requester.role === 'restricted_contributor') {
+    return {
+      ok: false,
+      errorCode: 'RM18_NOT_AUTHORIZED',
+      detail: 'restricted_contributor cannot void doses.',
+    };
+  }
+
+  if (insideFreeWindow) {
+    // Dans la fenêtre libre : auteur OR admin. voidedReason optionnel.
+    if (isAuthor || isAdmin) {
+      return { ok: true, normalizedReason };
+    }
+    return {
+      ok: false,
+      errorCode: 'RM18_NOT_AUTHORIZED',
+      detail: 'Within free window, only the author or an admin can void the dose.',
+    };
+  }
+
+  // Hors fenêtre libre : admin seul, raison obligatoire non vide.
+  if (!isAdmin) {
+    return {
+      ok: false,
+      errorCode: 'RM18_NOT_AUTHORIZED',
+      detail: 'Free window expired; only an admin can void the dose after 30 minutes.',
+    };
+  }
+  if (normalizedReason === null) {
+    return {
+      ok: false,
+      errorCode: 'RM18_VOIDED_REASON_REQUIRED',
+      detail: 'Admin void after free window requires a non-empty voidedReason.',
+    };
+  }
+  return { ok: true, normalizedReason };
+}
+
+/**
+ * Détermine si la prise est encore dans la fenêtre libre de 30 min.
+ *
+ * Référence temporelle : `recordedAtUtc` (RM14 — horodatage serveur). Si
+ * absent (prise encore hors-ligne, jamais confirmée par le serveur), on
+ * retombe sur `administeredAtUtc` pour ne pas bloquer un cas dégradé. La
+ * borne est inclusive (`<= 30 min`).
+ */
+function isInsideFreeWindow(dose: Dose, nowUtc: Date): boolean {
+  const reference = dose.recordedAtUtc ?? dose.administeredAtUtc;
+  const elapsedMs = nowUtc.getTime() - reference.getTime();
+  return elapsedMs <= VOID_FREE_WINDOW_MS;
+}
+
+/**
+ * Normalise un `voidedReason` : `null` si absent, vide ou whitespace pur,
+ * sinon la chaîne trimée.
+ */
+function normalizeReason(reason: string | undefined): string | null {
+  if (reason === undefined) {
+    return null;
+  }
+  const trimmed = reason.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}


### PR DESCRIPTION
## Résumé

Cinquième vague de règles métier dans `@kinhale/domain`. Implémente en un lot cohérent **4 règles couplées autour de la traçabilité et de l'intégrité** des prises :

- **RM14** — Horodatage serveur autoritaire (`recordedAtUtc`)
- **RM15** — Idempotence des saisies via `clientEventId`
- **RM17** — Rattrapage borné (backfill ≤ 24h, futur refusé)
- **RM18** — Annulation (voided) avec fenêtre libre 30 min

Pur TypeScript, zéro I/O, **79 nouveaux tests** (75 implémentation + 4 fallback). Total package : **93 → 172 tests** tous verts.

## Revue pré-PR (kz-review)

Conforme au workflow formalisé dans `CLAUDE.md §Méthodologie` — kz-review passé sur le diff AVANT ouverture de PR. Les deux points MAJEUR relevés ont été corrigés dans le commit `e5381fd` :

1. Prettier sur `README.md` (colonnes de tableau mal alignées après ajout de 4 lignes) → `prettier --write` appliqué, CI `format:check` passera vert
2. Gap de test sur le fallback RM18 `recordedAtUtc = null` (dose hors-ligne non synchronisée) → 4 tests ajoutés

Revue complète attachée en commentaire à la PR si nécessaire. Verdict : **APPROUVÉ APRÈS CORRECTIONS**.

## API domaine exposée

### RM14 — `assignAuthoritativeTimestamp`
```ts
export const LATE_SYNC_THRESHOLD_MS = 60_000;
export function assignAuthoritativeTimestamp({
  administeredAtUtc, serverReceivedAtUtc, lateSyncThresholdMs?
}): {
  administeredAtUtc: Date;  // source client préservée
  recordedAtUtc: Date;      // heure serveur autoritaire
  syncLatencyMs: number;
  isLateSync: boolean;
  clockSkewWarning: boolean;
};
```

### RM15 — `decideIdempotency` / `recordProcessedEvent`
```ts
export type IdempotencyDecision =
  | { kind: 'process'; clientEventId: string }
  | { kind: 'replay'; existing: ProcessedEvent };
export function decideIdempotency(registry, clientEventId): IdempotencyDecision;
export function recordProcessedEvent(registry, event): IdempotencyRegistry;
```
Registre pur (`ReadonlyMap`), pas de persistance — `apps/api` utilisera une contrainte unique Postgres.

### RM17 — `validateBackfillTiming` / `ensureBackfillAllowed`
```ts
export const BACKFILL_MAX_WINDOW_HOURS = 24;
export type BackfillValidity =
  | { kind: 'on_time' }
  | { kind: 'within_window'; lateBy: number }
  | { kind: 'future_refused'; aheadBy: number }
  | { kind: 'too_old'; lateBy: number };
```

### RM18 — `canVoidDose` / `ensureCanVoidDose` / `voidDose`
```ts
export const VOID_FREE_WINDOW_MINUTES = 30;
export function voidDose({
  dose, requester, nowUtc, voidedReason?
}): Dose;
```
Matrice d'autorisation : auteur OU admin dans les 30 min (raison optionnelle) ; au-delà admin seul avec raison obligatoire.

## Codes d'erreur ajoutés (`DomainErrorCode`)

- `RM15_INVALID_CLIENT_EVENT_ID` — clientEventId vide ou non-UUID v4
- `RM17_FUTURE_ADMINISTRATION_REFUSED` — saisie dans le futur refusée (même avec confirmation)
- `RM17_TOO_OLD_REQUIRES_CONFIRMATION` — backfill > 24h sans confirmation explicite
- `RM18_ALREADY_VOIDED` — void idempotent refusé
- `RM18_NOT_AUTHORIZED` — rôle / auteur / fenêtre insuffisants
- `RM18_VOIDED_REASON_REQUIRED` — admin hors fenêtre sans raison non vide

## Choix sémantiques verrouillés par les tests

- **RM14 borne `isLateSync`** : stricte (`> 60 000 ms`)
- **RM14 tolérance d'horloge** : `CLOCK_SKEW_TOLERANCE_MS = 1 s` — bruit NTP/RTT toléré silencieusement, au-delà `clockSkewWarning = true` sans refus (RM14 est traçabilité pure)
- **RM15 UUID v4 uniquement** — v1 (horloge + MAC) refusés pour prévisibilité
- **RM17 borne 24h inclusive** — `-24h00min` OK, `-24h01s` → `too_old`
- **RM17 futur toujours refusé** — même avec `explicitlyConfirmed = true`, aucune confirmation ne débloque le futur
- **RM17 tolérance `on_time`** : 5 s (RTT normal, strictement < RM6 2 min, sans interférence)
- **RM18 borne 30 min inclusive** — `30 min` pile autorisé, `30 min 01s` rejeté
- **RM18 référence temporelle** : `recordedAtUtc` (RM14) avec **fallback `administeredAtUtc`** si `recordedAtUtc = null` (dose hors-ligne non synchronisée). 4 tests dédiés verrouillent ce chemin local-first.
- **RM18 whitespace = absence** — `voidedReason: '   \\t\\n'` traité comme null ; la chaîne stockée est toujours trimée

## Vérifications

- [x] `pnpm --filter @kinhale/domain typecheck` : vert
- [x] `pnpm --filter @kinhale/domain lint` : vert (0 warning)
- [x] `pnpm --filter @kinhale/domain test` : **172/172** en < 50 ms
- [x] `pnpm format:check` : vert (Prettier appliqué)
- [x] kz-review passé pré-PR, points MAJEUR corrigés
- [x] Ligne rouge dispositif médical préservée : aucun message « appelez votre médecin », aucune recommandation de dose, aucun diagnostic
- [x] Pas de `Date.now()`, `Math.random()`, `console.*` — horloge toujours injectée en paramètre
- [x] Entité `Dose` non modifiée — tous les champs nécessaires existaient déjà
- [x] Aucun test existant touché

## Taille de PR

1 633 insertions (dont ~550 lignes de prod et ~1 050 de tests, ratio test/prod ≈ 1.9x). Au-dessus du seuil indicatif de 400 lignes mais justifiée : **4 règles atomiques d'une même famille** (traçabilité/intégrité), un découpage en 4 PRs aurait multiplié les cycles de revue sans gain.

## Points de vigilance pour la revue humaine

1. **RM17 tolérance `on_time` 5 s** — légèrement plus permissif que la lecture littérale de la spec (« jamais dans le futur »). Cohérent avec la réalité NTP. Un ADR court pourrait tracer ce choix.
2. **RM18 fallback `recordedAtUtc=null`** — déblocage des doses hors-ligne. Cohérent architecture local-first mais à valider côté produit : est-ce le comportement attendu ou doit-on bloquer le void tant que le serveur n'a pas confirmé ?
3. **RM15 format UUID v4 strict** — refus des autres formats (UUID v7, ULID, ksuid). Si un futur client veut utiliser un autre format d'identifiant, il faudra ajuster la regex.
4. **RM14 `clockSkewWarning`** — produit un warning dans le résultat mais n'agit pas. Côté API, ce warning doit être journalisé pour détecter des devices à l'horloge dérivée.

## Ce qui arrive ensuite (domaine)

- **RM5** — notification aux pairs après saisie (sous 5 s en ligne)
- **RM8** — structuration des prises pour l'export PDF médecin
- **RM9-RM13** — suite règles métier
- **RM19-RM28** — deuxième moitié du backlog règles

## Test plan

- [ ] Cloner + `pnpm install` + `pnpm --filter @kinhale/domain test` → 172/172 vert
- [ ] `pnpm format:check` → vert
- [ ] Valider le choix de tolérance RM17 `on_time = 5 s`
- [ ] Valider le fallback RM18 `recordedAtUtc = null` pour doses hors-ligne
- [ ] Statuer sur la stricte conformité RM15 UUID v4 uniquement

---

Refs : KIN-009

🤖 Generated with [Claude Code](https://claude.com/claude-code)