### PR TITLE
feat(KIN-010): RM5/RM25/RM26 notifications (pairs, rappels, regroupement)

### DIFF
--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -27,14 +27,17 @@ src/
 | **RM2** | Fenêtre de confirmation \[10-120 min\] + rattrapage borné à 24 h    | §4, RM2      |
 | **RM3** | Pas de plan de traitement sur une pompe `rescue`                   | §4, RM3      |
 | **RM4** | Prise `rescue` exige symptôme, circonstance ou tag libre           | §4, RM4      |
+| **RM5** | Notification croisée aux autres aidants actifs non-restricted      | §4, RM5      |
 | **RM6** | Détection double saisie : même pompe + type à moins de 2 min       | §4, RM6      |
 | **RM7** | Décompte doses pompe + alertes `pump_low` / `pump_emptied`         | §4, RM7      |
 | **RM14**| Horodatage serveur autoritaire (`recordedAtUtc`) + flag sync tardive | §4, RM14     |
 | **RM15**| Idempotence des saisies via `clientEventId` (UUID v4)              | §4, RM15     |
 | **RM17**| Rattrapage borné : backfill ≤ 24 h, futur refusé, confirmation au-delà | §4, RM17 |
 | **RM18**| Annulation : 30 min libres pour l'auteur ou un Admin, puis Admin + raison | §4, RM18 |
+| **RM25**| Rappels bornés : 2 relances max (push T+15 min, e-mail T+30 min)   | §4, RM25     |
+| **RM26**| Regroupement notifications peer : ≥ 3 prises/h + cap 15 notif/jour | §4, RM26     |
 
-Les règles RM5, RM8-RM13, RM16, RM19-RM28 arrivent dans les PRs suivantes.
+Les règles RM8-RM13, RM16, RM19-RM24, RM27, RM28 arrivent dans les PRs suivantes.
 
 ## Usage
 

--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -51,4 +51,6 @@ export type DomainErrorCode =
   /** RM18 — le demandeur n'est ni l'auteur dans la fenêtre libre, ni admin. */
   | 'RM18_NOT_AUTHORIZED'
   /** RM18 — hors fenêtre libre : `voidedReason` non vide obligatoire. */
-  | 'RM18_VOIDED_REASON_REQUIRED';
+  | 'RM18_VOIDED_REASON_REQUIRED'
+  /** RM25 — `alreadySentSteps` contient une valeur hors {1, 2}. */
+  | 'RM25_INVALID_STEP';

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -9,6 +9,8 @@ export {
 export type { DoseTiming } from './rm2-confirmation-window';
 export { ensureCanAttachPlanToPump } from './rm3-no-plan-for-rescue';
 export { ensureRescueDocumented } from './rm4-rescue-documented';
+export { PEER_SYNC_OFFSET_THRESHOLD_MS, planPeerNotification } from './rm5-peer-notification';
+export type { PeerNotificationEvent, PeerNotificationRecipient } from './rm5-peer-notification';
 export {
   DUPLICATE_DETECTION_WINDOW_MINUTES,
   findDuplicateCandidates,
@@ -44,3 +46,21 @@ export {
   voidDose,
 } from './rm18-void-dose';
 export type { VoidDoseOptions, VoidRequester } from './rm18-void-dose';
+export {
+  nextReminderRetry,
+  planReminderRetries,
+  REMINDER_RETRY_DELAYS_MS,
+} from './rm25-reminder-retries';
+export type {
+  ReminderRetryChannel,
+  ReminderRetryPlan,
+  ReminderRetryStep,
+  ReminderRetryStepIndex,
+} from './rm25-reminder-retries';
+export {
+  DAILY_NOTIFICATION_HARD_CAP,
+  decidePeerNotification,
+  PEER_GROUPING_THRESHOLD_COUNT,
+  PEER_GROUPING_WINDOW_MS,
+} from './rm26-peer-grouping';
+export type { PeerNotificationDecision, RecentPeerEvent } from './rm26-peer-grouping';

--- a/packages/domain/src/rules/rm25-reminder-retries.test.ts
+++ b/packages/domain/src/rules/rm25-reminder-retries.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from 'vitest';
+import { DomainError } from '../errors';
+import {
+  nextReminderRetry,
+  planReminderRetries,
+  REMINDER_RETRY_DELAYS_MS,
+} from './rm25-reminder-retries';
+
+const INITIAL = new Date('2026-04-19T08:00:00Z');
+
+function minutesAfter(base: Date, minutes: number): Date {
+  return new Date(base.getTime() + minutes * 60_000);
+}
+
+describe('RM25 — constantes', () => {
+  it('deux relances : T+15 min push local, T+30 min e-mail', () => {
+    expect(REMINDER_RETRY_DELAYS_MS).toEqual([15 * 60_000, 30 * 60_000]);
+  });
+});
+
+describe('RM25 — planReminderRetries', () => {
+  it('construit un plan à 2 relances (push local puis e-mail)', () => {
+    const plan = planReminderRetries({
+      reminderId: 'r1',
+      initialNotifiedAtUtc: INITIAL,
+    });
+    expect(plan.reminderId).toBe('r1');
+    expect(plan.initialNotifiedAtUtc).toEqual(INITIAL);
+    expect(plan.retries).toHaveLength(2);
+    expect(plan.retries[0]).toEqual({
+      step: 1,
+      channel: 'local_push',
+      scheduledAtUtc: minutesAfter(INITIAL, 15),
+    });
+    expect(plan.retries[1]).toEqual({
+      step: 2,
+      channel: 'email_fallback',
+      scheduledAtUtc: minutesAfter(INITIAL, 30),
+    });
+  });
+
+  it('finalMissedAtUtc = instant de la dernière relance (T+30 min)', () => {
+    const plan = planReminderRetries({
+      reminderId: 'r1',
+      initialNotifiedAtUtc: INITIAL,
+    });
+    expect(plan.finalMissedAtUtc).toEqual(minutesAfter(INITIAL, 30));
+  });
+
+  it('ne mute pas la Date fournie', () => {
+    const source = new Date(INITIAL.getTime());
+    const originalMs = source.getTime();
+    planReminderRetries({ reminderId: 'r1', initialNotifiedAtUtc: source });
+    expect(source.getTime()).toBe(originalMs);
+  });
+});
+
+describe('RM25 — nextReminderRetry (déclenchement sur le temps)', () => {
+  const plan = planReminderRetries({
+    reminderId: 'r1',
+    initialNotifiedAtUtc: INITIAL,
+  });
+
+  it('nowUtc < T+15 min : rien à faire', () => {
+    const step = nextReminderRetry({
+      plan,
+      alreadySentSteps: [],
+      nowUtc: minutesAfter(INITIAL, 5),
+      doseConfirmed: false,
+    });
+    expect(step).toBeNull();
+  });
+
+  it('borne exacte T+15:00.000 (inclusive) : déclenche step 1', () => {
+    const step = nextReminderRetry({
+      plan,
+      alreadySentSteps: [],
+      nowUtc: minutesAfter(INITIAL, 15),
+      doseConfirmed: false,
+    });
+    expect(step?.step).toBe(1);
+    expect(step?.channel).toBe('local_push');
+  });
+
+  it('T+14:59.999 : pas encore (borne exclusive à l arrière)', () => {
+    const step = nextReminderRetry({
+      plan,
+      alreadySentSteps: [],
+      nowUtc: new Date(INITIAL.getTime() + 15 * 60_000 - 1),
+      doseConfirmed: false,
+    });
+    expect(step).toBeNull();
+  });
+
+  it('T+16 min, aucune relance envoyée : step 1', () => {
+    const step = nextReminderRetry({
+      plan,
+      alreadySentSteps: [],
+      nowUtc: minutesAfter(INITIAL, 16),
+      doseConfirmed: false,
+    });
+    expect(step?.step).toBe(1);
+  });
+
+  it('T+31 min, step 1 déjà envoyé : step 2 (e-mail)', () => {
+    const step = nextReminderRetry({
+      plan,
+      alreadySentSteps: [1],
+      nowUtc: minutesAfter(INITIAL, 31),
+      doseConfirmed: false,
+    });
+    expect(step?.step).toBe(2);
+    expect(step?.channel).toBe('email_fallback');
+  });
+
+  it('borne exacte T+30:00.000 (inclusive) avec step 1 envoyé : step 2', () => {
+    const step = nextReminderRetry({
+      plan,
+      alreadySentSteps: [1],
+      nowUtc: minutesAfter(INITIAL, 30),
+      doseConfirmed: false,
+    });
+    expect(step?.step).toBe(2);
+  });
+
+  it('T+29:59.999 avec step 1 envoyé : pas encore step 2', () => {
+    const step = nextReminderRetry({
+      plan,
+      alreadySentSteps: [1],
+      nowUtc: new Date(INITIAL.getTime() + 30 * 60_000 - 1),
+      doseConfirmed: false,
+    });
+    expect(step).toBeNull();
+  });
+});
+
+describe('RM25 — nextReminderRetry (états terminaux)', () => {
+  const plan = planReminderRetries({
+    reminderId: 'r1',
+    initialNotifiedAtUtc: INITIAL,
+  });
+
+  it('les 2 relances déjà envoyées : null (épuisé)', () => {
+    const step = nextReminderRetry({
+      plan,
+      alreadySentSteps: [1, 2],
+      nowUtc: minutesAfter(INITIAL, 60),
+      doseConfirmed: false,
+    });
+    expect(step).toBeNull();
+  });
+
+  it('dose confirmée entre temps : null même si retry pas encore envoyé', () => {
+    const step = nextReminderRetry({
+      plan,
+      alreadySentSteps: [],
+      nowUtc: minutesAfter(INITIAL, 16),
+      doseConfirmed: true,
+    });
+    expect(step).toBeNull();
+  });
+
+  it('dose confirmée après step 1 : plus de step 2', () => {
+    const step = nextReminderRetry({
+      plan,
+      alreadySentSteps: [1],
+      nowUtc: minutesAfter(INITIAL, 35),
+      doseConfirmed: true,
+    });
+    expect(step).toBeNull();
+  });
+
+  it('tolérant hors ordre : alreadySentSteps=[2] + temps écoulé => step 1 récupéré', () => {
+    const step = nextReminderRetry({
+      plan,
+      alreadySentSteps: [2],
+      nowUtc: minutesAfter(INITIAL, 20),
+      doseConfirmed: false,
+    });
+    expect(step?.step).toBe(1);
+  });
+});
+
+describe('RM25 — nextReminderRetry (validation entrée)', () => {
+  const plan = planReminderRetries({
+    reminderId: 'r1',
+    initialNotifiedAtUtc: INITIAL,
+  });
+
+  it('lève RM25_INVALID_STEP si alreadySentSteps contient une autre valeur', () => {
+    expect(() =>
+      nextReminderRetry({
+        plan,
+        // @ts-expect-error test d'une entrée invalide volontairement
+        alreadySentSteps: [3],
+        nowUtc: minutesAfter(INITIAL, 20),
+        doseConfirmed: false,
+      }),
+    ).toThrowError(DomainError);
+    try {
+      nextReminderRetry({
+        plan,
+        // @ts-expect-error test d'une entrée invalide volontairement
+        alreadySentSteps: [0],
+        nowUtc: minutesAfter(INITIAL, 20),
+        doseConfirmed: false,
+      });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM25_INVALID_STEP');
+    }
+  });
+
+  it('accepte alreadySentSteps=[] ou duplicatas (idempotence)', () => {
+    const empty = nextReminderRetry({
+      plan,
+      alreadySentSteps: [],
+      nowUtc: minutesAfter(INITIAL, 16),
+      doseConfirmed: false,
+    });
+    expect(empty?.step).toBe(1);
+    const dup = nextReminderRetry({
+      plan,
+      alreadySentSteps: [1, 1],
+      nowUtc: minutesAfter(INITIAL, 31),
+      doseConfirmed: false,
+    });
+    expect(dup?.step).toBe(2);
+  });
+});

--- a/packages/domain/src/rules/rm25-reminder-retries.ts
+++ b/packages/domain/src/rules/rm25-reminder-retries.ts
@@ -1,0 +1,132 @@
+import { DomainError } from '../errors';
+
+/**
+ * Délais (ms) depuis la notification initiale pour les deux relances d'un
+ * rappel manqué (SPECS RM25) :
+ * - T+15 min → push local (step 1)
+ * - T+30 min → e-mail fallback (step 2)
+ *
+ * Au-delà de T+30 min, le rappel est définitivement `missed` : plus aucune
+ * relance automatique, seule une saisie backfill manuelle (RM17) peut encore
+ * documenter la prise.
+ *
+ * Les bornes de déclenchement sont **inclusives** : à T+15:00.000 pile, la
+ * step 1 est due. Choix cohérent avec RM2/RM18 (bornes inclusives) et moins
+ * surprenant pour l'opérateur.
+ */
+export const REMINDER_RETRY_DELAYS_MS: ReadonlyArray<number> = [15 * 60_000, 30 * 60_000] as const;
+
+/** Canal d'acheminement d'une relance — mappé côté infra vers le service idoine. */
+export type ReminderRetryChannel = 'local_push' | 'email_fallback';
+
+/** Index de relance dans le plan (1 = push local T+15, 2 = e-mail T+30). */
+export type ReminderRetryStepIndex = 1 | 2;
+
+/**
+ * Étape planifiée d'une relance : canal + instant prévu. Consommé par le
+ * scheduler applicatif qui appelle le service de notification au moment venu.
+ */
+export interface ReminderRetryStep {
+  readonly step: ReminderRetryStepIndex;
+  readonly channel: ReminderRetryChannel;
+  readonly scheduledAtUtc: Date;
+}
+
+/**
+ * Plan complet des relances pour un rappel manqué donné. Immuable ; tous les
+ * instants sont dérivés de `initialNotifiedAtUtc`.
+ */
+export interface ReminderRetryPlan {
+  readonly reminderId: string;
+  readonly initialNotifiedAtUtc: Date;
+  readonly retries: ReadonlyArray<ReminderRetryStep>;
+  /**
+   * Instant au-delà duquel plus aucune relance n'est due : `initial +
+   * dernier délai`. Le rappel peut être marqué `missed` définitivement dès
+   * cet instant.
+   */
+  readonly finalMissedAtUtc: Date;
+}
+
+/**
+ * RM25 — construit le plan de relances pour un rappel initial donné.
+ *
+ * Fonction **pure** : ne fait que calculer les instants. Ne programme rien
+ * réellement ; c'est au scheduler applicatif de consommer ce plan.
+ */
+export function planReminderRetries(options: {
+  readonly reminderId: string;
+  readonly initialNotifiedAtUtc: Date;
+}): ReminderRetryPlan {
+  const base = options.initialNotifiedAtUtc.getTime();
+
+  const retries: ReminderRetryStep[] = REMINDER_RETRY_DELAYS_MS.map((delay, index) => ({
+    step: (index + 1) as ReminderRetryStepIndex,
+    channel: index === 0 ? 'local_push' : 'email_fallback',
+    scheduledAtUtc: new Date(base + delay),
+  }));
+
+  const lastDelay = REMINDER_RETRY_DELAYS_MS[REMINDER_RETRY_DELAYS_MS.length - 1] ?? 0;
+
+  return {
+    reminderId: options.reminderId,
+    initialNotifiedAtUtc: new Date(base),
+    retries,
+    finalMissedAtUtc: new Date(base + lastDelay),
+  };
+}
+
+/**
+ * RM25 — détermine la prochaine relance due, étant donné l'état courant du
+ * plan (relances déjà envoyées, heure actuelle, confirmation éventuelle de
+ * la dose).
+ *
+ * Règles :
+ * - Si `doseConfirmed`, on arrête tout : la dose a été prise, plus de relance.
+ * - On cherche la première relance du plan dont `scheduledAtUtc <= nowUtc`
+ *   (borne inclusive) qui n'est pas déjà listée dans `alreadySentSteps`.
+ * - Si toutes les relances dues sont déjà envoyées → `null`.
+ * - Si aucune relance n'est encore due → `null`.
+ *
+ * Tolérance à l'ordre : `alreadySentSteps` peut contenir des indices dans
+ * n'importe quel ordre ou des duplicatas. Seul le **set** des indices compte.
+ * Un indice manquant (ex. `[2]` sans `1`) est récupérable : la step 1 reste
+ * due si le temps est écoulé. Cela permet au scheduler de rattraper un état
+ * incohérent sans perdre une relance.
+ *
+ * @throws {DomainError} `RM25_INVALID_STEP` si `alreadySentSteps` contient un
+ *   entier hors {1, 2}.
+ */
+export function nextReminderRetry(options: {
+  readonly plan: ReminderRetryPlan;
+  readonly alreadySentSteps: ReadonlyArray<ReminderRetryStepIndex>;
+  readonly nowUtc: Date;
+  readonly doseConfirmed: boolean;
+}): ReminderRetryStep | null {
+  if (options.doseConfirmed) {
+    return null;
+  }
+
+  for (const raw of options.alreadySentSteps) {
+    if (raw !== 1 && raw !== 2) {
+      throw new DomainError(
+        'RM25_INVALID_STEP',
+        `alreadySentSteps values must be in {1, 2}, got ${String(raw)}.`,
+        { invalidStep: raw },
+      );
+    }
+  }
+
+  const sent = new Set<ReminderRetryStepIndex>(options.alreadySentSteps);
+  const nowMs = options.nowUtc.getTime();
+
+  for (const retry of options.plan.retries) {
+    if (sent.has(retry.step)) {
+      continue;
+    }
+    if (retry.scheduledAtUtc.getTime() <= nowMs) {
+      return retry;
+    }
+  }
+  return null;
+}

--- a/packages/domain/src/rules/rm26-peer-grouping.test.ts
+++ b/packages/domain/src/rules/rm26-peer-grouping.test.ts
@@ -1,0 +1,315 @@
+import { describe, expect, it } from 'vitest';
+import type { PeerNotificationEvent, PeerNotificationRecipient } from './rm5-peer-notification';
+import {
+  DAILY_NOTIFICATION_HARD_CAP,
+  PEER_GROUPING_THRESHOLD_COUNT,
+  PEER_GROUPING_WINDOW_MS,
+  decidePeerNotification,
+} from './rm26-peer-grouping';
+
+const NOW = new Date('2026-04-19T09:30:00Z');
+
+function minutesBefore(base: Date, minutes: number): Date {
+  return new Date(base.getTime() - minutes * 60_000);
+}
+
+function makeRecipient(caregiverId: string): PeerNotificationRecipient {
+  return { caregiverId, role: 'contributor' };
+}
+
+function makeEvent(
+  overrides: Partial<PeerNotificationEvent> & { doseId: string },
+): PeerNotificationEvent {
+  return {
+    kind: 'peer_dose_recorded',
+    doseId: overrides.doseId,
+    pumpId: 'p1',
+    doseType: 'maintenance',
+    authorCaregiverId: 'author-1',
+    recipients: [makeRecipient('r1'), makeRecipient('r2')],
+    ...overrides,
+  };
+}
+
+describe('RM26 — constantes', () => {
+  it('fenêtre de regroupement = 60 min, seuil = 3 prises, cap quotidien = 15', () => {
+    expect(PEER_GROUPING_WINDOW_MS).toBe(60 * 60_000);
+    expect(PEER_GROUPING_THRESHOLD_COUNT).toBe(3);
+    expect(DAILY_NOTIFICATION_HARD_CAP).toBe(15);
+  });
+});
+
+describe('RM26 — decidePeerNotification (individuel vs regroupé)', () => {
+  it('1ère prise de l auteur (aucun historique) : individual', () => {
+    const event = makeEvent({ doseId: 'd1' });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [],
+      dailyNotificationCountByRecipient: new Map(),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('individual');
+    if (decision.kind === 'individual') {
+      expect(decision.event).toEqual(event);
+    }
+  });
+
+  it('2e prise dans l heure : individual (seuil non atteint)', () => {
+    const event = makeEvent({ doseId: 'd2' });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [{ doseId: 'd1', recordedAtUtc: minutesBefore(NOW, 20) }],
+      dailyNotificationCountByRecipient: new Map(),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('individual');
+  });
+
+  it('3e prise dans l heure : grouped avec countInWindow=3', () => {
+    const event = makeEvent({ doseId: 'd3' });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [
+        { doseId: 'd1', recordedAtUtc: minutesBefore(NOW, 40) },
+        { doseId: 'd2', recordedAtUtc: minutesBefore(NOW, 15) },
+      ],
+      dailyNotificationCountByRecipient: new Map(),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('grouped');
+    if (decision.kind === 'grouped') {
+      expect(decision.countInWindow).toBe(3);
+      expect(decision.authorCaregiverId).toBe('author-1');
+      expect(decision.recipients.map((r) => r.caregiverId).sort()).toEqual(['r1', 'r2']);
+      expect(decision.windowStartUtc.getTime()).toBe(NOW.getTime() - PEER_GROUPING_WINDOW_MS);
+      expect(decision.windowEndUtc.getTime()).toBe(NOW.getTime());
+    }
+  });
+
+  it('6e prise dans l heure : grouped avec countInWindow=6', () => {
+    const event = makeEvent({ doseId: 'd6' });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [
+        { doseId: 'd1', recordedAtUtc: minutesBefore(NOW, 55) },
+        { doseId: 'd2', recordedAtUtc: minutesBefore(NOW, 45) },
+        { doseId: 'd3', recordedAtUtc: minutesBefore(NOW, 30) },
+        { doseId: 'd4', recordedAtUtc: minutesBefore(NOW, 20) },
+        { doseId: 'd5', recordedAtUtc: minutesBefore(NOW, 10) },
+      ],
+      dailyNotificationCountByRecipient: new Map(),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('grouped');
+    if (decision.kind === 'grouped') {
+      expect(decision.countInWindow).toBe(6);
+    }
+  });
+
+  it('prises de plus d une heure : individual (fenêtre expirée)', () => {
+    const event = makeEvent({ doseId: 'd3' });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [
+        { doseId: 'd1', recordedAtUtc: minutesBefore(NOW, 70) },
+        { doseId: 'd2', recordedAtUtc: minutesBefore(NOW, 65) },
+      ],
+      dailyNotificationCountByRecipient: new Map(),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('individual');
+  });
+
+  it('borne exacte 60 min (inclusive) : comptée dans la fenêtre', () => {
+    const event = makeEvent({ doseId: 'd3' });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [
+        { doseId: 'd1', recordedAtUtc: minutesBefore(NOW, 60) },
+        { doseId: 'd2', recordedAtUtc: minutesBefore(NOW, 10) },
+      ],
+      dailyNotificationCountByRecipient: new Map(),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('grouped');
+  });
+
+  it('borne 60 min 00 s 001 ms : hors fenêtre', () => {
+    const event = makeEvent({ doseId: 'd3' });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [
+        { doseId: 'd1', recordedAtUtc: new Date(NOW.getTime() - 60 * 60_000 - 1) },
+        { doseId: 'd2', recordedAtUtc: minutesBefore(NOW, 10) },
+      ],
+      dailyNotificationCountByRecipient: new Map(),
+      nowUtc: NOW,
+    });
+    // Seule 1 prise précédente dans la fenêtre + nouvelle = 2 → pas encore grouped
+    expect(decision.kind).toBe('individual');
+  });
+});
+
+describe('RM26 — cap quotidien 15 notifications', () => {
+  it('destinataire au cap : filtré de la liste', () => {
+    const event = makeEvent({
+      doseId: 'd1',
+      recipients: [makeRecipient('r1'), makeRecipient('r2')],
+    });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [],
+      dailyNotificationCountByRecipient: new Map([['r1', 15]]),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('individual');
+    if (decision.kind === 'individual') {
+      expect(decision.event.recipients.map((r) => r.caregiverId)).toEqual(['r2']);
+    }
+  });
+
+  it('tous les destinataires au cap : suppressed (daily_cap_reached)', () => {
+    const event = makeEvent({
+      doseId: 'd1',
+      recipients: [makeRecipient('r1'), makeRecipient('r2')],
+    });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [],
+      dailyNotificationCountByRecipient: new Map([
+        ['r1', 15],
+        ['r2', 20],
+      ]),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('suppressed');
+    if (decision.kind === 'suppressed') {
+      expect(decision.reason).toBe('daily_cap_reached');
+    }
+  });
+
+  it('cap appliqué aussi au regroupement : filtre les destinataires au cap', () => {
+    const event = makeEvent({
+      doseId: 'd3',
+      recipients: [makeRecipient('r1'), makeRecipient('r2')],
+    });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [
+        { doseId: 'd1', recordedAtUtc: minutesBefore(NOW, 30) },
+        { doseId: 'd2', recordedAtUtc: minutesBefore(NOW, 15) },
+      ],
+      dailyNotificationCountByRecipient: new Map([['r1', 15]]),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('grouped');
+    if (decision.kind === 'grouped') {
+      expect(decision.recipients.map((r) => r.caregiverId)).toEqual(['r2']);
+    }
+  });
+
+  it('regroupement avec tous destinataires au cap : suppressed (daily_cap_reached)', () => {
+    const event = makeEvent({
+      doseId: 'd3',
+      recipients: [makeRecipient('r1'), makeRecipient('r2')],
+    });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [
+        { doseId: 'd1', recordedAtUtc: minutesBefore(NOW, 30) },
+        { doseId: 'd2', recordedAtUtc: minutesBefore(NOW, 15) },
+      ],
+      dailyNotificationCountByRecipient: new Map([
+        ['r1', 16],
+        ['r2', 15],
+      ]),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('suppressed');
+    if (decision.kind === 'suppressed') {
+      expect(decision.reason).toBe('daily_cap_reached');
+    }
+  });
+
+  it('cap non atteint (14 notif) : destinataire conservé', () => {
+    const event = makeEvent({
+      doseId: 'd1',
+      recipients: [makeRecipient('r1')],
+    });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [],
+      dailyNotificationCountByRecipient: new Map([['r1', 14]]),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('individual');
+  });
+});
+
+describe('RM26 — suppressed.already_grouped_in_window', () => {
+  it('hasActiveGroupedNotification=true : suppressed (mise à jour infra)', () => {
+    // Un regroupement a déjà été émis pour la fenêtre ; la nouvelle prise
+    // ne doit pas déclencher une nouvelle notification OS. L'infra met à
+    // jour le regroupement existant (compteur incrémenté « 3 → 4 prises »).
+    const event = makeEvent({ doseId: 'd4' });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [
+        { doseId: 'd1', recordedAtUtc: minutesBefore(NOW, 50) },
+        { doseId: 'd2', recordedAtUtc: minutesBefore(NOW, 30) },
+        { doseId: 'd3', recordedAtUtc: minutesBefore(NOW, 10) },
+      ],
+      dailyNotificationCountByRecipient: new Map(),
+      nowUtc: NOW,
+      hasActiveGroupedNotification: true,
+    });
+    expect(decision.kind).toBe('suppressed');
+    if (decision.kind === 'suppressed') {
+      expect(decision.reason).toBe('already_grouped_in_window');
+    }
+  });
+
+  it('hasActiveGroupedNotification=true ET tous dest. au cap : daily_cap_reached prime', () => {
+    // Ordre des priorités : cap journalier > regroupement actif.
+    // L'absence de destinataire éligible rend toute décision moot ;
+    // on remonte la raison la plus fondamentale (aucun destinataire).
+    const event = makeEvent({
+      doseId: 'd4',
+      recipients: [makeRecipient('r1')],
+    });
+    const decision = decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: [
+        { doseId: 'd1', recordedAtUtc: minutesBefore(NOW, 50) },
+        { doseId: 'd2', recordedAtUtc: minutesBefore(NOW, 30) },
+        { doseId: 'd3', recordedAtUtc: minutesBefore(NOW, 10) },
+      ],
+      dailyNotificationCountByRecipient: new Map([['r1', 15]]),
+      nowUtc: NOW,
+      hasActiveGroupedNotification: true,
+    });
+    expect(decision.kind).toBe('suppressed');
+    if (decision.kind === 'suppressed') {
+      expect(decision.reason).toBe('daily_cap_reached');
+    }
+  });
+});
+
+describe('RM26 — pureté', () => {
+  it('ne mute ni le newEvent ni la map/le tableau', () => {
+    const recentEvents = [{ doseId: 'd1', recordedAtUtc: minutesBefore(NOW, 20) }];
+    const originalLength = recentEvents.length;
+    const counts = new Map<string, number>([['r1', 5]]);
+    const originalR1 = counts.get('r1');
+    const event = makeEvent({ doseId: 'd2' });
+    decidePeerNotification({
+      newEvent: event,
+      recentPeerEventsByAuthor: recentEvents,
+      dailyNotificationCountByRecipient: counts,
+      nowUtc: NOW,
+    });
+    expect(recentEvents.length).toBe(originalLength);
+    expect(counts.get('r1')).toBe(originalR1);
+    expect(event.recipients).toHaveLength(2);
+  });
+});

--- a/packages/domain/src/rules/rm26-peer-grouping.ts
+++ b/packages/domain/src/rules/rm26-peer-grouping.ts
@@ -1,0 +1,158 @@
+import type { PeerNotificationEvent, PeerNotificationRecipient } from './rm5-peer-notification';
+
+/**
+ * Fenêtre glissante (ms) pendant laquelle plusieurs prises d'un même auteur
+ * sont regroupées en une seule notification (RM26, SPECS §9 ligne 812).
+ *
+ * Borne **inclusive** : une prise à exactement 60 min de `nowUtc` est encore
+ * comptée dans la fenêtre. Choix cohérent avec RM2/RM18.
+ */
+export const PEER_GROUPING_WINDOW_MS = 60 * 60_000;
+
+/**
+ * Seuil de prises (prises précédentes + nouvelle) à partir duquel on bascule
+ * sur une notification groupée au lieu d'émettre N notifications
+ * individuelles. Le texte cible est « 3 prises enregistrées par [Aidant]
+ * dans la dernière heure ».
+ */
+export const PEER_GROUPING_THRESHOLD_COUNT = 3;
+
+/**
+ * Cap quotidien de notifications par destinataire (toutes catégories
+ * confondues). Au-delà, la notification est **supprimée** côté domaine — le
+ * regroupement existant peut être mis à jour côté infra pour refléter le
+ * comptage sans nouvel envoi OS (SPECS §9 ligne 811).
+ *
+ * La comparaison est « >= cap » : au 15e envoi effectif déjà compté, le 16e
+ * candidat est filtré.
+ */
+export const DAILY_NOTIFICATION_HARD_CAP = 15;
+
+/** Signature minimale d'une prise peer déjà vue dans la fenêtre glissante. */
+export interface RecentPeerEvent {
+  readonly doseId: string;
+  readonly recordedAtUtc: Date;
+}
+
+/**
+ * Résultat de la décision RM26. Trois cas :
+ * - `individual` : émettre l'événement tel quel (éventuellement avec une
+ *   liste de destinataires filtrée si certains ont atteint le cap).
+ * - `grouped` : émettre (ou mettre à jour) un regroupement couvrant la
+ *   fenêtre glissante. `countInWindow` inclut la nouvelle prise.
+ * - `suppressed` : ne rien émettre. Deux raisons possibles — voir `reason`.
+ */
+export type PeerNotificationDecision =
+  | {
+      readonly kind: 'individual';
+      readonly event: PeerNotificationEvent;
+    }
+  | {
+      readonly kind: 'grouped';
+      readonly authorCaregiverId: string;
+      readonly recipients: ReadonlyArray<PeerNotificationRecipient>;
+      readonly countInWindow: number;
+      readonly windowStartUtc: Date;
+      readonly windowEndUtc: Date;
+    }
+  | {
+      readonly kind: 'suppressed';
+      readonly reason: 'daily_cap_reached' | 'already_grouped_in_window';
+    };
+
+/**
+ * RM26 — décide, pour un événement peer donné, s'il faut émettre
+ * individuellement, regrouper ou supprimer.
+ *
+ * Fonction **pure** : ne mute aucun argument. Reçoit en entrée l'état
+ * observé (prises précédentes du même auteur dans la fenêtre + comptage
+ * journalier des destinataires + indicateur d'un regroupement actif) et
+ * retourne une décision immuable.
+ *
+ * Logique :
+ * 1. Compte les prises précédentes du même auteur dont `recordedAtUtc` est
+ *    dans `[now - PEER_GROUPING_WINDOW_MS, now]` (bornes inclusives). Ajoute
+ *    1 pour la nouvelle prise → `countInWindow`.
+ * 2. Filtre les destinataires dont le comptage journalier atteint
+ *    {@link DAILY_NOTIFICATION_HARD_CAP} ou plus.
+ * 3. Si la liste de destinataires est vide → `suppressed` / `daily_cap_reached`.
+ * 4. Si `hasActiveGroupedNotification === true` → `suppressed` /
+ *    `already_grouped_in_window` : un regroupement précédent couvre déjà la
+ *    fenêtre, l'infra se charge de mettre à jour le compteur sans nouvel
+ *    envoi OS. Le domaine ne juge pas pur-compte (incrément « 3 → 4 prises »
+ *    reste un regroupement), il s'appuie sur l'état passé par l'appelant.
+ * 5. Si `countInWindow >= PEER_GROUPING_THRESHOLD_COUNT` → `grouped` : c'est
+ *    le passage (ou la ré-évaluation) du regroupement.
+ * 6. Sinon → `individual`.
+ *
+ * Cette règle ne prend **aucune** décision sur le contenu textuel : le
+ * template « N prises enregistrées par … » est construit côté UI/infra à
+ * partir de `countInWindow` + `authorCaregiverId` (reconstruit via appel
+ * authentifié, cf. RM16 — jamais dans le payload push).
+ */
+export function decidePeerNotification(options: {
+  readonly newEvent: PeerNotificationEvent;
+  readonly recentPeerEventsByAuthor: ReadonlyArray<RecentPeerEvent>;
+  readonly dailyNotificationCountByRecipient: ReadonlyMap<string, number>;
+  readonly nowUtc: Date;
+  /**
+   * `true` si une notification groupée pour cet auteur couvre déjà la
+   * fenêtre glissante. L'appelant passe cette information lorsqu'une
+   * `peer_dose_recorded` groupée a déjà été émise : le domaine répond alors
+   * `suppressed/already_grouped_in_window` pour que l'infra mette à jour
+   * le regroupement existant au lieu d'envoyer une nouvelle notification.
+   *
+   * Par défaut `false` (aucun regroupement actif connu).
+   */
+  readonly hasActiveGroupedNotification?: boolean;
+}): PeerNotificationDecision {
+  const {
+    newEvent,
+    recentPeerEventsByAuthor,
+    dailyNotificationCountByRecipient,
+    nowUtc,
+    hasActiveGroupedNotification = false,
+  } = options;
+
+  const windowEndMs = nowUtc.getTime();
+  const windowStartMs = windowEndMs - PEER_GROUPING_WINDOW_MS;
+
+  const priorInWindow = recentPeerEventsByAuthor.filter((e) => {
+    const t = e.recordedAtUtc.getTime();
+    return t >= windowStartMs && t <= windowEndMs;
+  });
+  const countInWindow = priorInWindow.length + 1;
+
+  const filteredRecipients = newEvent.recipients.filter((r) => {
+    const count = dailyNotificationCountByRecipient.get(r.caregiverId) ?? 0;
+    return count < DAILY_NOTIFICATION_HARD_CAP;
+  });
+
+  if (filteredRecipients.length === 0) {
+    return { kind: 'suppressed', reason: 'daily_cap_reached' };
+  }
+
+  if (hasActiveGroupedNotification) {
+    return { kind: 'suppressed', reason: 'already_grouped_in_window' };
+  }
+
+  if (countInWindow >= PEER_GROUPING_THRESHOLD_COUNT) {
+    return {
+      kind: 'grouped',
+      authorCaregiverId: newEvent.authorCaregiverId,
+      recipients: filteredRecipients,
+      countInWindow,
+      windowStartUtc: new Date(windowStartMs),
+      windowEndUtc: new Date(windowEndMs),
+    };
+  }
+
+  // < seuil : notification individuelle — on réutilise l'event mais avec la
+  // liste de destinataires filtrée (cap journalier).
+  const event: PeerNotificationEvent =
+    filteredRecipients.length === newEvent.recipients.length
+      ? newEvent
+      : { ...newEvent, recipients: filteredRecipients };
+
+  return { kind: 'individual', event };
+}

--- a/packages/domain/src/rules/rm5-peer-notification.test.ts
+++ b/packages/domain/src/rules/rm5-peer-notification.test.ts
@@ -1,0 +1,374 @@
+import { describe, expect, it } from 'vitest';
+import type { Caregiver } from '../entities/caregiver';
+import type { Dose } from '../entities/dose';
+import type { Household } from '../entities/household';
+import type { Role } from '../entities/role';
+import { planPeerNotification } from './rm5-peer-notification';
+
+const ADMINISTERED = new Date('2026-04-19T08:00:00Z');
+const SERVER_RECEIVED = new Date('2026-04-19T08:00:03Z');
+
+function makeCaregiver(overrides: Partial<Caregiver> & { id: string; role: Role }): Caregiver {
+  return {
+    householdId: 'h1',
+    status: 'active',
+    displayName: overrides.id,
+    invitedAt: new Date('2026-01-01T00:00:00Z'),
+    activatedAt: new Date('2026-01-01T12:00:00Z'),
+    revokedAt: null,
+    ...overrides,
+  };
+}
+
+function makeHousehold(caregivers: ReadonlyArray<Caregiver>): Household {
+  return {
+    id: 'h1',
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    timezone: 'America/Toronto',
+    locale: 'fr',
+    caregivers,
+  };
+}
+
+function makeDose(overrides: Partial<Dose> & { id: string; caregiverId: string }): Dose {
+  return {
+    householdId: 'h1',
+    childId: 'c1',
+    pumpId: 'p1',
+    type: 'maintenance',
+    status: 'confirmed',
+    source: 'manual',
+    dosesAdministered: 1,
+    administeredAtUtc: ADMINISTERED,
+    recordedAtUtc: SERVER_RECEIVED,
+    symptoms: [],
+    circumstances: [],
+    freeFormTag: null,
+    voidedReason: null,
+    ...overrides,
+  };
+}
+
+describe('RM5 — planPeerNotification (cas nominal)', () => {
+  it('auteur admin + 2 contributors actifs : 2 destinataires, auteur exclu', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+      makeCaregiver({ id: 'contrib-2', role: 'contributor' }),
+    ]);
+    const dose = makeDose({ id: 'd1', caregiverId: 'admin-1' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event).not.toBeNull();
+    expect(event?.kind).toBe('peer_dose_recorded');
+    expect(event?.doseId).toBe('d1');
+    expect(event?.pumpId).toBe('p1');
+    expect(event?.doseType).toBe('maintenance');
+    expect(event?.authorCaregiverId).toBe('admin-1');
+    expect(event?.recipients.map((r) => r.caregiverId).sort()).toEqual(['contrib-1', 'contrib-2']);
+  });
+
+  it('auteur contributor : admin + autre contributor reçoivent', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+      makeCaregiver({ id: 'contrib-2', role: 'contributor' }),
+    ]);
+    const dose = makeDose({ id: 'd1', caregiverId: 'contrib-1' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event?.recipients.map((r) => r.caregiverId).sort()).toEqual(['admin-1', 'contrib-2']);
+  });
+
+  it('dose rescue : kind=peer_dose_recorded, doseType=rescue', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+    ]);
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'admin-1',
+      type: 'rescue',
+      symptoms: ['cough'],
+    });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event?.doseType).toBe('rescue');
+  });
+});
+
+describe('RM5 — planPeerNotification (exclusions)', () => {
+  it('exclut les aidants invited (non actifs)', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+      makeCaregiver({ id: 'invited-1', role: 'contributor', status: 'invited', activatedAt: null }),
+    ]);
+    const dose = makeDose({ id: 'd1', caregiverId: 'admin-1' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event?.recipients.map((r) => r.caregiverId)).toEqual(['contrib-1']);
+  });
+
+  it('exclut les aidants revoked', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+      makeCaregiver({
+        id: 'revoked-1',
+        role: 'contributor',
+        status: 'revoked',
+        revokedAt: new Date('2026-03-01T00:00:00Z'),
+      }),
+    ]);
+    const dose = makeDose({ id: 'd1', caregiverId: 'admin-1' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event?.recipients.map((r) => r.caregiverId)).toEqual(['contrib-1']);
+  });
+
+  it('exclut les restricted_contributor (SPECS ligne 450)', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+      makeCaregiver({ id: 'nanny-1', role: 'restricted_contributor' }),
+    ]);
+    const dose = makeDose({ id: 'd1', caregiverId: 'admin-1' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event?.recipients.map((r) => r.caregiverId)).toEqual(['contrib-1']);
+  });
+
+  it("auteur = restricted_contributor : les autres actifs non-restricted reçoivent l'info", () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+      makeCaregiver({ id: 'nanny-1', role: 'restricted_contributor' }),
+    ]);
+    const dose = makeDose({ id: 'd1', caregiverId: 'nanny-1' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event?.authorCaregiverId).toBe('nanny-1');
+    expect(event?.recipients.map((r) => r.caregiverId).sort()).toEqual(['admin-1', 'contrib-1']);
+  });
+
+  it("foyer solo (seul l'auteur actif) : null", () => {
+    const household = makeHousehold([makeCaregiver({ id: 'admin-1', role: 'admin' })]);
+    const dose = makeDose({ id: 'd1', caregiverId: 'admin-1' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event).toBeNull();
+  });
+
+  it('aucun destinataire après filtrage (tous restricted ou inactifs) : null', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'nanny-1', role: 'restricted_contributor' }),
+      makeCaregiver({
+        id: 'invited-1',
+        role: 'contributor',
+        status: 'invited',
+        activatedAt: null,
+      }),
+    ]);
+    const dose = makeDose({ id: 'd1', caregiverId: 'admin-1' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event).toBeNull();
+  });
+});
+
+describe('RM5 — planPeerNotification (statut de la dose)', () => {
+  it('dose voided : null (pas de notification peer sur void)', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+    ]);
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'admin-1',
+      status: 'voided',
+      voidedReason: 'erreur',
+    });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event).toBeNull();
+  });
+
+  it('dose pending_review : null (flux dispute_detected, pas RM5)', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+    ]);
+    const dose = makeDose({ id: 'd1', caregiverId: 'admin-1', status: 'pending_review' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event).toBeNull();
+  });
+});
+
+describe('RM5 — planPeerNotification (syncOffsetMs)', () => {
+  it('décalage < 5 min : champ absent (pas de mention « synchronisée à »)', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+    ]);
+    // 3 s d'écart client/serveur (saisie en ligne normale).
+    const dose = makeDose({ id: 'd1', caregiverId: 'admin-1' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(event?.syncOffsetMs).toBeUndefined();
+  });
+
+  it('décalage = 5 min pile (borne inclusive) : champ absent', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+    ]);
+    const administered = new Date('2026-04-19T08:00:00Z');
+    const received = new Date('2026-04-19T08:05:00Z'); // +5 min pile
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'admin-1',
+      administeredAtUtc: administered,
+      recordedAtUtc: received,
+    });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: received,
+    });
+    expect(event?.syncOffsetMs).toBeUndefined();
+  });
+
+  it('décalage > 5 min : champ présent en ms (déclenche mention synchronisée)', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+    ]);
+    const administered = new Date('2026-04-19T08:00:00Z');
+    const received = new Date('2026-04-19T08:12:34Z'); // +12 min 34 s
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'admin-1',
+      administeredAtUtc: administered,
+      recordedAtUtc: received,
+    });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: received,
+    });
+    expect(event?.syncOffsetMs).toBe(12 * 60_000 + 34_000);
+  });
+
+  it('décalage négatif (horloge client en avance) : champ absent', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+    ]);
+    const administered = new Date('2026-04-19T08:05:00Z');
+    const received = new Date('2026-04-19T08:00:00Z');
+    const dose = makeDose({
+      id: 'd1',
+      caregiverId: 'admin-1',
+      administeredAtUtc: administered,
+      recordedAtUtc: received,
+    });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: received,
+    });
+    expect(event?.syncOffsetMs).toBeUndefined();
+  });
+});
+
+describe('RM5 — planPeerNotification (défensif / pureté)', () => {
+  it('auteur absent du foyer : null (défensif, pas de lever)', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+    ]);
+    const dose = makeDose({ id: 'd1', caregiverId: 'ghost-99' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    // Aucun matching caregiverId : tous les aidants actifs non-restricted
+    // deviennent destinataires car l'auteur « n'existe » pas côté foyer.
+    // Choix défensif : on n'exclut rien et on laisse émettre l'event.
+    expect(event).not.toBeNull();
+    expect(event?.recipients.map((r) => r.caregiverId).sort()).toEqual(['admin-1', 'contrib-1']);
+  });
+
+  it('ne mute pas le household ni la dose', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+    ]);
+    const originalCaregivers = household.caregivers;
+    const dose = makeDose({ id: 'd1', caregiverId: 'admin-1' });
+    planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    expect(household.caregivers).toBe(originalCaregivers);
+    expect(dose.status).toBe('confirmed');
+  });
+
+  it('recipients exposent le rôle de l aidant', () => {
+    const household = makeHousehold([
+      makeCaregiver({ id: 'admin-1', role: 'admin' }),
+      makeCaregiver({ id: 'contrib-1', role: 'contributor' }),
+      makeCaregiver({ id: 'contrib-2', role: 'contributor' }),
+    ]);
+    const dose = makeDose({ id: 'd1', caregiverId: 'contrib-1' });
+    const event = planPeerNotification({
+      household,
+      dose,
+      serverReceivedAtUtc: SERVER_RECEIVED,
+    });
+    const byId = new Map(event?.recipients.map((r) => [r.caregiverId, r.role]));
+    expect(byId.get('admin-1')).toBe('admin');
+    expect(byId.get('contrib-2')).toBe('contributor');
+  });
+});

--- a/packages/domain/src/rules/rm5-peer-notification.test.ts
+++ b/packages/domain/src/rules/rm5-peer-notification.test.ts
@@ -321,7 +321,7 @@ describe('RM5 — planPeerNotification (syncOffsetMs)', () => {
 });
 
 describe('RM5 — planPeerNotification (défensif / pureté)', () => {
-  it('auteur absent du foyer : null (défensif, pas de lever)', () => {
+  it('auteur absent du foyer : event émis avec tous les actifs non-restricted (défensif, pas de lever)', () => {
     const household = makeHousehold([
       makeCaregiver({ id: 'admin-1', role: 'admin' }),
       makeCaregiver({ id: 'contrib-1', role: 'contributor' }),

--- a/packages/domain/src/rules/rm5-peer-notification.ts
+++ b/packages/domain/src/rules/rm5-peer-notification.ts
@@ -1,0 +1,118 @@
+import type { Dose, DoseType } from '../entities/dose';
+import type { Household } from '../entities/household';
+import { activeCaregivers } from '../entities/household';
+import type { Role } from '../entities/role';
+
+/**
+ * Seuil au-delà duquel le décalage entre `administeredAtUtc` et l'horodatage
+ * serveur doit être exposé aux destinataires (UI affichera « synchronisée à
+ * HH:MM »). La borne est **inclusive** : à 5 min 00 s pile, le champ
+ * `syncOffsetMs` reste absent.
+ *
+ * Référence : SPECS §W8, RM14/RM5 — alignement avec le flux de sync.
+ */
+export const PEER_SYNC_OFFSET_THRESHOLD_MS = 5 * 60_000;
+
+/**
+ * Destinataire d'une notification peer, exposé avec son rôle pour permettre
+ * à l'appelant (infra push/email) de filtrer encore en aval — notamment pour
+ * ne cibler que les Admins sur certains événements (RM7 `pump_low`, etc.).
+ */
+export interface PeerNotificationRecipient {
+  readonly caregiverId: string;
+  readonly role: Role;
+}
+
+/**
+ * Événement métier `peer_dose_recorded` — décrit la décision d'émettre une
+ * notification informative aux autres aidants suite à une nouvelle prise.
+ *
+ * **Pas de donnée santé dans le payload** : ni dose, ni nom de pompe, ni
+ * prénom. Seuls des identifiants opaques et des horodatages transitent par
+ * le relais (RM16). Le contenu lisible est reconstruit côté client à
+ * l'ouverture via appel authentifié.
+ */
+export interface PeerNotificationEvent {
+  readonly kind: 'peer_dose_recorded';
+  readonly doseId: string;
+  readonly pumpId: string;
+  readonly doseType: DoseType;
+  readonly authorCaregiverId: string;
+  readonly recipients: ReadonlyArray<PeerNotificationRecipient>;
+  /**
+   * Décalage en ms entre `administeredAtUtc` et l'horodatage serveur — exposé
+   * **uniquement** si strictement supérieur à {@link PEER_SYNC_OFFSET_THRESHOLD_MS}
+   * (SPECS §W8 : « mention synchronisée à [heure] si décalage > 5 min »). En
+   * dessous du seuil ou si le décalage est négatif (client en avance), le
+   * champ est absent.
+   */
+  readonly syncOffsetMs?: number;
+}
+
+/**
+ * RM5 — calcule les destinataires et l'événement de notification croisée à
+ * émettre suite à l'enregistrement d'une prise par un aidant.
+ *
+ * Fonction **pure** : aucun I/O, aucune lecture d'horloge, aucun envoi réel.
+ * Elle décrit la **décision** ; l'émission effective (push, local, email)
+ * est portée par `apps/api`.
+ *
+ * Règles d'inclusion (cf. SPECS RM5 + W6 ligne 450) :
+ * - L'auteur (`dose.caregiverId`) est toujours **exclu** des destinataires.
+ * - Seuls les aidants `status === 'active'` sont inclus.
+ * - Les aidants de rôle `restricted_contributor` sont **exclus** (session
+ *   éphémère sans push — SPECS W6).
+ *
+ * Règles de déclenchement :
+ * - Prise `voided` → aucune notification peer (retour `null`) ; le flux de
+ *   void est un autre parcours.
+ * - Prise `pending_review` → aucune notification peer (retour `null`) ; le
+ *   flux de double-saisie émet `dispute_detected`, pas `peer_dose_recorded`.
+ * - Aucun destinataire après filtrage → retour `null` (rien à émettre).
+ *
+ * Défensif sur les incohérences :
+ * - Si `dose.caregiverId` n'apparaît pas dans le foyer (cas aberrant en
+ *   pratique, ex. race condition d'ingestion), on **n'échoue pas** : on
+ *   retourne simplement l'événement avec tous les aidants actifs
+ *   non-restricted comme destinataires. Ce choix privilégie la robustesse
+ *   du flux d'ingestion ; la cohérence référentielle est contrôlée ailleurs
+ *   (validation API, intégrité du document Automerge).
+ */
+export function planPeerNotification(options: {
+  readonly household: Household;
+  readonly dose: Dose;
+  readonly serverReceivedAtUtc: Date;
+}): PeerNotificationEvent | null {
+  const { household, dose, serverReceivedAtUtc } = options;
+
+  // RM5 ne traite que les prises `confirmed` (voided / pending_review sont
+  // portés par d'autres flux notifications).
+  if (dose.status !== 'confirmed') {
+    return null;
+  }
+
+  const recipients: PeerNotificationRecipient[] = activeCaregivers(household)
+    .filter((c) => c.role !== 'restricted_contributor')
+    .filter((c) => c.id !== dose.caregiverId)
+    .map((c) => ({ caregiverId: c.id, role: c.role }));
+
+  if (recipients.length === 0) {
+    return null;
+  }
+
+  const syncOffsetMs = serverReceivedAtUtc.getTime() - dose.administeredAtUtc.getTime();
+
+  const base: PeerNotificationEvent = {
+    kind: 'peer_dose_recorded',
+    doseId: dose.id,
+    pumpId: dose.pumpId,
+    doseType: dose.type,
+    authorCaregiverId: dose.caregiverId,
+    recipients,
+  };
+
+  if (syncOffsetMs > PEER_SYNC_OFFSET_THRESHOLD_MS) {
+    return { ...base, syncOffsetMs };
+  }
+  return base;
+}

--- a/packages/domain/src/rules/rm5-peer-notification.ts
+++ b/packages/domain/src/rules/rm5-peer-notification.ts
@@ -6,8 +6,9 @@ import type { Role } from '../entities/role';
 /**
  * Seuil au-delà duquel le décalage entre `administeredAtUtc` et l'horodatage
  * serveur doit être exposé aux destinataires (UI affichera « synchronisée à
- * HH:MM »). La borne est **inclusive** : à 5 min 00 s pile, le champ
- * `syncOffsetMs` reste absent.
+ * HH:MM »). Comparaison **strictement supérieure** (`> 5 min`) — à 5 min 00 s
+ * pile le champ `syncOffsetMs` reste absent. Même convention que RM2
+ * (confirmation window) et RM6 (duplicate detection).
  *
  * Référence : SPECS §W8, RM14/RM5 — alignement avec le flux de sync.
  */


### PR DESCRIPTION
## Résumé

Sixième lot de règles métier dans `@kinhale/domain`. Implémente le cœur de la promesse « coordination temps réel » — trois règles autour des notifications :

- **RM5** — Notification croisée aux pairs actifs (exclut l'auteur et les `restricted_contributor`)
- **RM25** — Rappels bornés (T+15 push local, T+30 email, puis `missed`)
- **RM26** — Regroupement peer (≥ 3 prises/1h) + cap journalier 15 notif/aidant

Pur TypeScript, zéro I/O, **51 nouveaux tests**. Total package : **172 → 223 tests** tous verts.

## Workflow pré-PR appliqué

Conforme à `CLAUDE.md §Méthodologie` — kz-review passé sur le diff AVANT ouverture de PR. **0 MAJEUR**, 2 MINEUR corrigés dans le commit `9d4d821` :

1. Titre de test trompeur `rm5-*.test.ts:324` (« null » alors que l'event est émis) → corrigé
2. Vocabulaire JSDoc incohérent sur `PEER_SYNC_OFFSET_THRESHOLD_MS` (« inclusive » au lieu de « strictement supérieur ») → aligné avec la convention RM2/RM6/RM18

## API domaine exposée

### RM5 — `planPeerNotification`
```ts
export const PEER_SYNC_OFFSET_THRESHOLD_MS = 5 * 60_000;

export function planPeerNotification({
  household, dose, serverReceivedAtUtc
}): PeerNotificationEvent | null;  // null si aucun destinataire éligible
```
Exclut l'auteur, filtre les `restricted_contributor` et les aidants inactifs. Expose `syncOffsetMs` uniquement si > 5 min (UI affichera « synchronisée à HH:MM »).

### RM25 — `planReminderRetries` / `nextReminderRetry`
```ts
export const REMINDER_RETRY_DELAYS_MS = [15*60_000, 30*60_000] as const;

export function planReminderRetries({ reminderId, initialNotifiedAtUtc }): ReminderRetryPlan;
export function nextReminderRetry({
  plan, alreadySentSteps, nowUtc, doseConfirmed
}): ReminderRetryStep | null;
```
Exactement 2 relances. Arrêt immédiat si `doseConfirmed = true`. Tolérance à l'ordre (`alreadySentSteps=[2]` seul accepté).

### RM26 — `decidePeerNotification`
```ts
export const PEER_GROUPING_WINDOW_MS = 60 * 60_000;
export const PEER_GROUPING_THRESHOLD_COUNT = 3;
export const DAILY_NOTIFICATION_HARD_CAP = 15;

export type PeerNotificationDecision =
  | { kind: 'individual'; event: PeerNotificationEvent }
  | { kind: 'grouped'; authorCaregiverId; recipients; countInWindow; windowStartUtc; windowEndUtc }
  | { kind: 'suppressed'; reason: 'daily_cap_reached' | 'already_grouped_in_window' };
```
Règle externalisée : la mémoire du regroupement (`hasActiveGroupedNotification`) est passée par l'appelant depuis l'infra, pas déduite par le domaine.

## Codes d'erreur ajoutés

- `RM25_INVALID_STEP` — `alreadySentSteps` contient autre chose que 1 ou 2 (protection contre corruption d'état scheduler).

Aucun code pour RM5 / RM26 : ce sont des règles de décision pure, jamais de rejet.

## Choix sémantiques verrouillés par les tests

- **RM5 auteur absent du foyer** → event émis avec tous les actifs non-restricted (défensif, pas de lever). Hypothèse : cohérence référentielle contrôlée côté API/Automerge.
- **RM5 syncOffsetMs** : seuil `> 5 min` strict. À 5 min 00 s pile → champ absent. Aligné avec RM2/RM6/RM18.
- **RM25 bornes 15/30 min inclusives** : `T+15:00.000` déclenche step 1.
- **RM25 tolérance ordre** : `alreadySentSteps=[2]` seul + temps écoulé → retourne step 1. Pragmatique pour ne pas perdre une relance.
- **RM26 priorité `daily_cap_reached` > `already_grouped_in_window`** : si aucun destinataire éligible, on remonte `daily_cap_reached` même si un regroupement est actif.
- **RM26 cap 15 strict** : comparaison `count >= 15` → au 15ème envoi, le 16ème candidat est filtré.

## Vérifications

- [x] `pnpm --filter @kinhale/domain typecheck` : vert
- [x] `pnpm --filter @kinhale/domain lint` : vert (0 warning)
- [x] `pnpm --filter @kinhale/domain test` : **223/223** en < 60 ms
- [x] `pnpm format:check` : vert (Prettier appliqué)
- [x] kz-review passé pré-PR, 2 MINEUR corrigés
- [x] **Ligne rouge dispositif médical préservée** : aucun texte de notification pré-rédigé dans le domaine, les templates se construisent côté UI depuis les métadonnées (`countInWindow`, `authorCaregiverId`). Aucune alerte santé auto-générée.
- [x] **Aucune donnée santé dans les events** : ni symptômes, ni circonstances, ni `dosesAdministered`, ni `freeFormTag`. Seulement IDs, compteurs, dates.
- [x] Pas de `Date.now()`, `Math.random()`, `console.*` — horloge toujours injectée
- [x] Aucun test existant touché, aucune règle existante modifiée

## Taille de PR

1 358 insertions (434 lignes de prod + 919 de tests — ratio test/prod **2.1x**). Au-dessus du seuil indicatif 400 lignes mais justifiée : **3 règles cohérentes d'une même famille** (notifications peer et rappels). Un découpage aurait multiplié les cycles de revue sans gain. La majorité du diff est test.

## Points de vigilance pour la revue humaine

1. **RM5 défensif sur auteur absent** — retourne event avec tous les actifs, ne lève pas. Sécurité : acceptable ou doit-on journaliser un incident Sentry côté API ?
2. **RM26 `hasActiveGroupedNotification`** externalisé — l'infra doit tenir un état « regroupement actif par auteur/fenêtre ». Est-ce clair pour l'équipe qui consommera côté `apps/api` ?
3. **`DAILY_NOTIFICATION_HARD_CAP = 15`** : SPECS ligne 811 énonce 15/jour toutes catégories confondues. RM26 ne sait pas compter les autres catégories (RM7 `pump_low`, RM28 `admin_handover`, etc.). L'infra devra agréger le compte AVANT d'appeler RM26. À documenter dans une ADR prochaine ?
4. **Texte « 3 prises enregistrées par [Aidant] »** : construit côté UI. Aucune chaîne n'est exposée par le domaine — l'UI utilisera i18next avec placeholders. Cohérent avec la règle i18n de CLAUDE.md.

## Ce qui arrive ensuite (domaine)

- **Lot B — Partage & sécurité** : RM21 (limite invitations), RM22 (consentement aidant), RM28 (purge expirations)
- **Lot C — Compliance UI** : RM27 (disclaimer omniprésent) + RM24 (hash PDF)
- **Règles unitaires restantes** : RM8, RM9, RM10, RM11, RM12, RM13, RM16, RM19, RM20, RM23

## Test plan

- [ ] Cloner + `pnpm install` + `pnpm --filter @kinhale/domain test` → 223/223
- [ ] `pnpm format:check` → vert
- [ ] Valider le comportement défensif RM5 sur auteur absent
- [ ] Valider l'externalisation `hasActiveGroupedNotification`
- [ ] Statuer sur l'agrégation multi-catégories pour le cap 15/jour

---

Refs : KIN-010

🤖 Generated with [Claude Code](https://claude.com/claude-code)