### PR TITLE
feat(KIN-012): @kinhale/crypto scaffold + RM24 intégrité rapport + RM27 disclaimer

### DIFF
--- a/packages/crypto/README.md
+++ b/packages/crypto/README.md
@@ -1,0 +1,49 @@
+# @kinhale/crypto
+
+Primitives cryptographiques du projet Kinhale. **Web Crypto API native, zéro dépendance externe.** Aucun polyfill, aucune implémentation logicielle : si l'environnement ne fournit pas `globalThis.crypto.subtle`, le package lève `CRYPTO_UNAVAILABLE` plutôt que de dégrader vers un algorithme plus faible.
+
+## Règle d'usage dans le monorepo
+
+> **Toutes les opérations cryptographiques du projet passent par `@kinhale/crypto`.**
+> Aucun autre package ne doit importer `libsodium-wrappers`, `crypto-js`, `js-sha256`, ni accéder directement à `globalThis.crypto` ou `node:crypto`. La règle ESLint `no-restricted-imports` bloque les premières ; la revue (`kz-securite`) bloque les secondes.
+
+Motivation : auditabilité. Une fuite de primitive crypto faible ou une mauvaise utilisation d'un AEAD est un incident P0 — cf. `CLAUDE.md`. Concentrer toutes les opérations sensibles ici permet de cibler l'audit et de tester collectivement les cas limites (déterminisme, encodage, tolérances NTP).
+
+## Runtime supporté
+
+- **Node 20 LTS** : `globalThis.crypto` est globalement exposé depuis Node 19.0. Aucun import de `node:crypto` requis.
+- **Navigateurs modernes** : Chrome 67+, Firefox 57+, Safari 11+.
+- **React Native 0.74+ / Expo SDK 52** : fourni via polyfill du runtime Hermes (à vérifier côté `apps/mobile`).
+
+## Structure
+
+```text
+src/
+├── hash/
+│   └── sha256.ts     SHA-256 via SubtleCrypto
+└── index.ts          Barrel export
+```
+
+## API actuelle (v0.1.0)
+
+```ts
+import { sha256Hex, sha256HexFromString } from '@kinhale/crypto';
+
+await sha256HexFromString(''); // "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+await sha256Hex(new Uint8Array([0xff])); // "a8100ae6..."
+```
+
+Les digests sont retournés en **hex minuscule, 64 caractères** (format stable, testable par regex `^[0-9a-f]{64}$`).
+
+## Extensions à venir
+
+Ce scaffold minimal cible RM24 (intégrité rapport). Les primitives suivantes seront ajoutées dans des PRs dédiées, toujours via ce package :
+
+- Argon2id (KDF recovery seed)
+- XChaCha20-Poly1305 AEAD
+- Ed25519 / X25519 (libsodium)
+- MLS (openmls) + fallback Double Ratchet
+
+## Licence
+
+AGPL-3.0-only — voir `LICENSE` à la racine du monorepo.

--- a/packages/crypto/eslint.config.js
+++ b/packages/crypto/eslint.config.js
@@ -1,0 +1,17 @@
+import kinhale from '@kinhale/eslint-config';
+
+export default [
+  ...kinhale,
+  {
+    files: ['src/**/*.ts'],
+    rules: {
+      'no-console': 'error',
+    },
+  },
+  {
+    files: ['src/**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+];

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -1,26 +1,21 @@
 {
-  "name": "@kinhale/domain",
+  "name": "@kinhale/crypto",
   "version": "0.1.0",
   "private": true,
   "license": "AGPL-3.0-only",
-  "description": "Entités métier et règles (RM1-RM9) de Kinhale — pure TypeScript, aucun I/O.",
+  "description": "Primitives cryptographiques de Kinhale — Web Crypto API native, zéro dépendance externe.",
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./entities": "./src/entities/index.ts",
-    "./rules": "./src/rules/index.ts",
-    "./errors": "./src/errors.ts"
+    "./hash": "./src/hash/sha256.ts"
   },
   "scripts": {
     "lint": "eslint --max-warnings=0 .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
-  },
-  "dependencies": {
-    "@kinhale/crypto": "workspace:*"
   },
   "devDependencies": {
     "@kinhale/eslint-config": "workspace:*",

--- a/packages/crypto/src/hash/sha256.test.ts
+++ b/packages/crypto/src/hash/sha256.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { sha256Hex, sha256HexFromString } from './sha256';
+
+/**
+ * Vecteurs officiels SHA-256 (FIPS 180-4 / RFC 6234) utilisés pour
+ * verrouiller la conformité de l'implémentation. Toute régression ici
+ * signifie que @kinhale/crypto n'est plus aligné avec la norme —
+ * incident de confiance P0.
+ */
+const HEX_REGEX = /^[0-9a-f]{64}$/;
+
+describe('sha256Hex — vecteurs officiels FIPS 180-4', () => {
+  it('retourne le digest de la chaîne vide', async () => {
+    const digest = await sha256HexFromString('');
+    expect(digest).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  });
+
+  it('retourne le digest de "abc"', async () => {
+    const digest = await sha256HexFromString('abc');
+    expect(digest).toBe('ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad');
+  });
+
+  it('retourne le digest de "The quick brown fox jumps over the lazy dog"', async () => {
+    const digest = await sha256HexFromString('The quick brown fox jumps over the lazy dog');
+    expect(digest).toBe('d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592');
+  });
+
+  it("retourne le digest connu d'un octet 0xff", async () => {
+    // Vecteur : SHA-256(0xff) = a8100ae6...
+    const digest = await sha256Hex(new Uint8Array([0xff]));
+    expect(digest).toBe('a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89');
+  });
+
+  it('accepte un ArrayBuffer en entrée', async () => {
+    const buffer = new ArrayBuffer(0);
+    const digest = await sha256Hex(buffer);
+    expect(digest).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
+  });
+});
+
+describe('sha256Hex — format et déterminisme', () => {
+  it('retourne toujours un hex minuscule de 64 caractères', async () => {
+    const digest = await sha256HexFromString('kinhale');
+    expect(digest).toMatch(HEX_REGEX);
+    expect(digest).toHaveLength(64);
+  });
+
+  it('produit la même valeur pour deux appels identiques (déterminisme)', async () => {
+    const first = await sha256HexFromString('kinhale-report-v1');
+    const second = await sha256HexFromString('kinhale-report-v1');
+    expect(first).toBe(second);
+  });
+
+  it('produit des digests différents pour des entrées différentes (collision-resistance)', async () => {
+    const a = await sha256HexFromString('a');
+    const b = await sha256HexFromString('b');
+    expect(a).not.toBe(b);
+  });
+
+  it('encode UTF-8 — les caractères multi-octets changent le digest', async () => {
+    const ascii = await sha256HexFromString('e');
+    const accent = await sha256HexFromString('é');
+    expect(ascii).not.toBe(accent);
+  });
+});

--- a/packages/crypto/src/hash/sha256.test.ts
+++ b/packages/crypto/src/hash/sha256.test.ts
@@ -36,6 +36,20 @@ describe('sha256Hex — vecteurs officiels FIPS 180-4', () => {
     const digest = await sha256Hex(buffer);
     expect(digest).toBe('e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855');
   });
+
+  it('hache correctement une sous-view Uint8Array (subarray)', async () => {
+    // Garde-fou : un Uint8Array qui ne couvre PAS la totalité de son
+    // ArrayBuffer sous-jacent doit être haché sur ses bornes effectives
+    // (byteOffset + byteLength), pas sur le buffer entier. Sinon une
+    // simplification de l'implémentation casserait silencieusement le
+    // comportement attendu.
+    const full = new Uint8Array([0x00, 0xff, 0x00]);
+    const view = full.subarray(1, 2); // un seul octet : 0xff
+    expect(view.byteOffset).toBe(1);
+    expect(view.byteLength).toBe(1);
+    const digest = await sha256Hex(view);
+    expect(digest).toBe('a8100ae6aa1940d0b663bb31cd466142ebbdbd5187131b92d93818987832eb89');
+  });
 });
 
 describe('sha256Hex — format et déterminisme', () => {

--- a/packages/crypto/src/hash/sha256.ts
+++ b/packages/crypto/src/hash/sha256.ts
@@ -1,0 +1,78 @@
+/**
+ * SHA-256 via Web Crypto API native (`globalThis.crypto.subtle`).
+ *
+ * **Aucune dépendance externe.** Disponible en Node 20 LTS (globalement
+ * depuis Node 19.0) et dans tous les navigateurs modernes. Aucun polyfill,
+ * aucune ré-implémentation logicielle — si Web Crypto n'est pas disponible,
+ * on lève `CRYPTO_UNAVAILABLE` au premier appel plutôt que de dégrader
+ * silencieusement vers un algorithme plus faible (cf. CLAUDE.md).
+ *
+ * Ce module est le **seul point d'accès** autorisé au SHA-256 dans le
+ * monorepo : `packages/domain`, `apps/api`, etc. doivent importer depuis
+ * `@kinhale/crypto`, jamais depuis `node:crypto` ni `globalThis.crypto`
+ * directement.
+ */
+
+/** Message d'erreur émis lorsque Web Crypto API n'est pas disponible. */
+export const CRYPTO_UNAVAILABLE_MESSAGE =
+  'Web Crypto API (globalThis.crypto.subtle) is not available in this runtime. ' +
+  'Kinhale refuses to fall back to a software implementation; upgrade Node ≥ 20 ' +
+  'or run in a modern browser.';
+
+/**
+ * Retourne l'implémentation SubtleCrypto disponible, ou lève si absente.
+ * Centralisé ici pour que tout le package ait le même contrat runtime.
+ * Le type de retour est inféré à partir de `globalThis.crypto.subtle` pour
+ * rester compatible avec les lib `ES2022` (qui ne déclare pas `SubtleCrypto`
+ * globalement) et les déclarations Web Crypto fournies par `@types/node`.
+ */
+function requireSubtleCrypto() {
+  const subtle = globalThis.crypto?.subtle;
+  if (subtle === undefined) {
+    throw new Error(CRYPTO_UNAVAILABLE_MESSAGE);
+  }
+  return subtle;
+}
+
+/**
+ * Convertit un `ArrayBuffer` en chaîne hex minuscule.
+ * Longueur de sortie = 2 × longueur d'entrée.
+ */
+function bufferToHex(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  let hex = '';
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+/**
+ * Calcule le digest SHA-256 d'un buffer binaire.
+ *
+ * @param data - Buffer d'entrée. `Uint8Array` est recopié en `ArrayBuffer`
+ *   avant appel à `subtle.digest` pour garantir un contrat stable sur
+ *   toutes les plateformes (certains navigateurs refusent un view).
+ * @returns Digest hex-encodé en minuscules, 64 caractères `[0-9a-f]`.
+ * @throws `Error` avec `CRYPTO_UNAVAILABLE_MESSAGE` si Web Crypto absent.
+ */
+export async function sha256Hex(data: Uint8Array | ArrayBuffer): Promise<string> {
+  const subtle = requireSubtleCrypto();
+  const buffer: ArrayBuffer =
+    data instanceof Uint8Array
+      ? data.byteLength === data.buffer.byteLength && data.byteOffset === 0
+        ? (data.buffer as ArrayBuffer)
+        : (data.slice().buffer as ArrayBuffer)
+      : data;
+  const digest = await subtle.digest('SHA-256', buffer);
+  return bufferToHex(digest);
+}
+
+/**
+ * Variante pour texte UTF-8. Équivalent à
+ * `sha256Hex(new TextEncoder().encode(text))`.
+ */
+export async function sha256HexFromString(text: string): Promise<string> {
+  const encoded = new TextEncoder().encode(text);
+  return sha256Hex(encoded);
+}

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,0 +1,1 @@
+export { CRYPTO_UNAVAILABLE_MESSAGE, sha256Hex, sha256HexFromString } from './hash/sha256';

--- a/packages/crypto/tsconfig.json
+++ b/packages/crypto/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@kinhale/tsconfig/library.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/crypto/vitest.config.ts
+++ b/packages/crypto/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/**/index.ts'],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+});

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -38,9 +38,11 @@ src/
 | **RM26**| Regroupement notifications peer : ≥ 3 prises/h + cap 15 notif/jour | §4, RM26     |
 | **RM21**| Limite anti-spam : max 10 invitations actives simultanées par foyer | §4, RM21     |
 | **RM22**| Consentement aidant invité : propres données uniquement, pas l'enfant | §4, RM22   |
+| **RM24**| Intégrité rapport : SHA-256 du contenu + timestamp + générateur (pied PDF) | §4, RM24 |
+| **RM27**| Disclaimer omniprésent aux 4 surfaces (onboarding, CGU, rapport, À propos) | §4, RM27 |
 | **RM28**| Purge invitations : `expired > 30 j`, `consumed > 90 j`, `revoked > 30 j` | §4, RM28 |
 
-Les règles RM8-RM13, RM16, RM19, RM20, RM23, RM24, RM27 arrivent dans les PRs suivantes.
+Les règles RM8-RM13, RM16, RM19, RM20, RM23 arrivent dans les PRs suivantes.
 
 ## Usage
 

--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -67,4 +67,6 @@ export type DomainErrorCode =
   /** RM22 — le consentement référence une autre invitation (incohérence de flux). */
   | 'RM22_CONSENT_INVITATION_MISMATCH'
   /** RM22 — `consentedAtUtc` est strictement postérieur à `nowUtc` (tricherie d'horloge). */
-  | 'RM22_INVALID_CONSENT_TIMESTAMP';
+  | 'RM22_INVALID_CONSENT_TIMESTAMP'
+  /** RM24 — `generator` fourni vide ou whitespace-only lors du calcul du pied d'intégrité. */
+  | 'RM24_INVALID_GENERATOR';

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -79,3 +79,26 @@ export {
   PURGE_REVOKED_AFTER_DAYS,
 } from './rm28-invitation-purge';
 export type { PurgeEligibility, PurgeReason } from './rm28-invitation-purge';
+export {
+  computeReportIntegrityFooter,
+  REPORT_INTEGRITY_FOOTER_VERSION,
+  verifyReportIntegrityFooter,
+} from './rm24-report-integrity';
+export type {
+  ReportBlockKind,
+  ReportContentBlock,
+  ReportIntegrityFooter,
+} from './rm24-report-integrity';
+export {
+  assertDisclaimerCoverage,
+  DISCLAIMER_TEXT_EN,
+  DISCLAIMER_TEXT_FR,
+  getDisclaimerText,
+  REQUIRED_SURFACES,
+} from './rm27-disclaimer-presence';
+export type {
+  DisclaimerCoverageResult,
+  DisclaimerLocale,
+  DisclaimerSurface,
+  DisclaimerSurfaceContent,
+} from './rm27-disclaimer-presence';

--- a/packages/domain/src/rules/rm24-report-integrity.test.ts
+++ b/packages/domain/src/rules/rm24-report-integrity.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from 'vitest';
+import { DomainError } from '../errors';
+import {
+  computeReportIntegrityFooter,
+  type ReportContentBlock,
+  REPORT_INTEGRITY_FOOTER_VERSION,
+  verifyReportIntegrityFooter,
+} from './rm24-report-integrity';
+
+const GENERATED_AT = new Date('2026-04-19T12:00:00Z');
+const GENERATOR = 'kinhale-api/0.1.0';
+
+function sampleBlocks(): readonly ReportContentBlock[] {
+  return [
+    { kind: 'metadata', text: 'Rapport foyer Famille de X — avril 2026' },
+    { kind: 'dose', text: '2026-04-18 08:00 UTC — Fond 1 dose (Parent A)' },
+    { kind: 'dose', text: '2026-04-18 14:30 UTC — Secours 1 dose + toux (Parent B)' },
+    { kind: 'plan', text: 'Plan de fond : 2 doses/j matin et soir' },
+    { kind: 'caregiver', text: 'Parent A (Admin), Parent B (Contributeur)' },
+    { kind: 'disclaimer', text: 'Kinhale ne remplace pas un avis médical.' },
+  ];
+}
+
+describe('RM24 — computeReportIntegrityFooter (chemin nominal)', () => {
+  it('produit un footer avec hash 64 car hex, timestamp ISO et générateur', async () => {
+    const footer = await computeReportIntegrityFooter({
+      content: sampleBlocks(),
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    expect(footer.contentHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(footer.generatedAtUtc).toBe('2026-04-19T12:00:00.000Z');
+    expect(footer.generator).toBe(GENERATOR);
+    expect(footer.version).toBe(REPORT_INTEGRITY_FOOTER_VERSION);
+  });
+
+  it('est déterministe — même contenu + mêmes métadonnées = même hash', async () => {
+    const a = await computeReportIntegrityFooter({
+      content: sampleBlocks(),
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+    const b = await computeReportIntegrityFooter({
+      content: sampleBlocks(),
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    expect(a.contentHash).toBe(b.contentHash);
+  });
+
+  it('contenu vide → hash du string vide canonique (cas dégénéré verrouillé)', async () => {
+    const footer = await computeReportIntegrityFooter({
+      content: [],
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+    // Le hash d'un contenu vide est déterministe et testable.
+    expect(footer.contentHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('RM24 — sensibilité aux modifications (anti-falsification)', () => {
+  it("change d'un seul caractère dans un bloc → hash différent", async () => {
+    const base = await computeReportIntegrityFooter({
+      content: sampleBlocks(),
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    const tampered = [...sampleBlocks()];
+    tampered[1] = { kind: 'dose', text: '2026-04-18 08:01 UTC — Fond 1 dose (Parent A)' };
+
+    const after = await computeReportIntegrityFooter({
+      content: tampered,
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    expect(after.contentHash).not.toBe(base.contentHash);
+  });
+
+  it("change d'ordre des blocs → hash différent (ordre signifiant)", async () => {
+    const base = await computeReportIntegrityFooter({
+      content: sampleBlocks(),
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    const reordered: ReportContentBlock[] = [...sampleBlocks()];
+    // Swap des deux premières doses — ordre différent, contenu équivalent.
+    const idx1 = 1;
+    const idx2 = 2;
+    [reordered[idx1], reordered[idx2]] = [reordered[idx2]!, reordered[idx1]!];
+
+    const after = await computeReportIntegrityFooter({
+      content: reordered,
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    expect(after.contentHash).not.toBe(base.contentHash);
+  });
+
+  it('change de kind sans changer le text → hash différent (le kind est inclus)', async () => {
+    const original: ReportContentBlock[] = [{ kind: 'dose', text: 'Hello' }];
+    const swapped: ReportContentBlock[] = [{ kind: 'plan', text: 'Hello' }];
+
+    const a = await computeReportIntegrityFooter({
+      content: original,
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+    const b = await computeReportIntegrityFooter({
+      content: swapped,
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    expect(a.contentHash).not.toBe(b.contentHash);
+  });
+
+  it('encodage collision-safe : un bloc contenant le séparateur brut ne falsifie pas le hash', async () => {
+    // Attaque classique d'un séparateur non préfixé par longueur :
+    // [A][sep][B]  vs  [A\nsep\nB]  → même concat si séparateur \nsep\n.
+    // Notre encodage préfixe chaque bloc par [kind:length], rendant la
+    // collision impossible.
+    const blocksA: ReportContentBlock[] = [
+      { kind: 'dose', text: 'alpha' },
+      { kind: 'dose', text: 'beta' },
+    ];
+    const blocksB: ReportContentBlock[] = [
+      {
+        kind: 'dose',
+        text: 'alpha\n---\n[dose:4]\nbeta', // tentative de fabriquer la concat
+      },
+    ];
+
+    const a = await computeReportIntegrityFooter({
+      content: blocksA,
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+    const b = await computeReportIntegrityFooter({
+      content: blocksB,
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    expect(a.contentHash).not.toBe(b.contentHash);
+  });
+
+  it('changer generatedAtUtc ou generator ne change PAS contentHash (il ne couvre que le contenu)', async () => {
+    const base = await computeReportIntegrityFooter({
+      content: sampleBlocks(),
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    const diffTime = await computeReportIntegrityFooter({
+      content: sampleBlocks(),
+      generatedAtUtc: new Date('2027-01-01T00:00:00Z'),
+      generator: GENERATOR,
+    });
+    const diffGen = await computeReportIntegrityFooter({
+      content: sampleBlocks(),
+      generatedAtUtc: GENERATED_AT,
+      generator: 'kinhale-api/0.2.0',
+    });
+
+    expect(diffTime.contentHash).toBe(base.contentHash);
+    expect(diffGen.contentHash).toBe(base.contentHash);
+  });
+});
+
+describe('RM24 — validation des paramètres', () => {
+  it('refuse un generator vide (RM24_INVALID_GENERATOR)', async () => {
+    await expect(
+      computeReportIntegrityFooter({
+        content: sampleBlocks(),
+        generatedAtUtc: GENERATED_AT,
+        generator: '',
+      }),
+    ).rejects.toMatchObject({
+      name: 'DomainError',
+      code: 'RM24_INVALID_GENERATOR',
+    });
+  });
+
+  it('refuse un generator whitespace-only (RM24_INVALID_GENERATOR)', async () => {
+    try {
+      await computeReportIntegrityFooter({
+        content: sampleBlocks(),
+        generatedAtUtc: GENERATED_AT,
+        generator: '   \t\n  ',
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM24_INVALID_GENERATOR');
+    }
+  });
+});
+
+describe('RM24 — verifyReportIntegrityFooter', () => {
+  it('retourne true si le footer correspond au contenu', async () => {
+    const blocks = sampleBlocks();
+    const footer = await computeReportIntegrityFooter({
+      content: blocks,
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    const ok = await verifyReportIntegrityFooter({ content: blocks, footer });
+    expect(ok).toBe(true);
+  });
+
+  it('retourne false si contentHash altéré', async () => {
+    const blocks = sampleBlocks();
+    const footer = await computeReportIntegrityFooter({
+      content: blocks,
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    const ok = await verifyReportIntegrityFooter({
+      content: blocks,
+      footer: {
+        ...footer,
+        // Flip du dernier caractère hex : le hash garde le bon format mais
+        // ne correspond plus au contenu.
+        contentHash:
+          footer.contentHash.slice(0, 63) + (footer.contentHash.endsWith('0') ? '1' : '0'),
+      },
+    });
+
+    expect(ok).toBe(false);
+  });
+
+  it('retourne false si ordre de blocs altéré', async () => {
+    const original = sampleBlocks();
+    const footer = await computeReportIntegrityFooter({
+      content: original,
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    const reordered: ReportContentBlock[] = [...original];
+    const idx1 = 1;
+    const idx2 = 3;
+    [reordered[idx1], reordered[idx2]] = [reordered[idx2]!, reordered[idx1]!];
+
+    const ok = await verifyReportIntegrityFooter({ content: reordered, footer });
+    expect(ok).toBe(false);
+  });
+
+  it('retourne false si un bloc a été ajouté', async () => {
+    const original = sampleBlocks();
+    const footer = await computeReportIntegrityFooter({
+      content: original,
+      generatedAtUtc: GENERATED_AT,
+      generator: GENERATOR,
+    });
+
+    const withExtra: ReportContentBlock[] = [...original, { kind: 'dose', text: 'Bloc injecté' }];
+
+    const ok = await verifyReportIntegrityFooter({ content: withExtra, footer });
+    expect(ok).toBe(false);
+  });
+
+  it('ne lève jamais même si le footer est bizarre', async () => {
+    const blocks = sampleBlocks();
+
+    const ok = await verifyReportIntegrityFooter({
+      content: blocks,
+      footer: {
+        contentHash: 'not-a-valid-hash',
+        generatedAtUtc: '2026-04-19T12:00:00.000Z',
+        generator: 'x',
+        version: '1',
+      },
+    });
+
+    expect(ok).toBe(false);
+  });
+});

--- a/packages/domain/src/rules/rm24-report-integrity.test.ts
+++ b/packages/domain/src/rules/rm24-report-integrity.test.ts
@@ -92,7 +92,9 @@ describe('RM24 — sensibilité aux modifications (anti-falsification)', () => {
     // Swap des deux premières doses — ordre différent, contenu équivalent.
     const idx1 = 1;
     const idx2 = 2;
-    [reordered[idx1], reordered[idx2]] = [reordered[idx2]!, reordered[idx1]!];
+    const tmp = reordered[idx1] as ReportContentBlock;
+    reordered[idx1] = reordered[idx2] as ReportContentBlock;
+    reordered[idx2] = tmp;
 
     const after = await computeReportIntegrityFooter({
       content: reordered,
@@ -249,7 +251,9 @@ describe('RM24 — verifyReportIntegrityFooter', () => {
     const reordered: ReportContentBlock[] = [...original];
     const idx1 = 1;
     const idx2 = 3;
-    [reordered[idx1], reordered[idx2]] = [reordered[idx2]!, reordered[idx1]!];
+    const tmp = reordered[idx1] as ReportContentBlock;
+    reordered[idx1] = reordered[idx2] as ReportContentBlock;
+    reordered[idx2] = tmp;
 
     const ok = await verifyReportIntegrityFooter({ content: reordered, footer });
     expect(ok).toBe(false);

--- a/packages/domain/src/rules/rm24-report-integrity.ts
+++ b/packages/domain/src/rules/rm24-report-integrity.ts
@@ -1,0 +1,152 @@
+import { sha256HexFromString } from '@kinhale/crypto';
+import { DomainError } from '../errors';
+
+/**
+ * RM24 — Intégrité rapport (SPECS §4 RM24 + §10).
+ *
+ * Chaque PDF exporté par Kinhale embarque en pied de page trois éléments
+ * permettant de détecter une falsification a posteriori :
+ * 1. un **hash SHA-256** du contenu canonique du rapport ;
+ * 2. un **timestamp ISO-8601 UTC** de génération ;
+ * 3. le **nom + version** du générateur (ex: `kinhale-api/0.1.0`).
+ *
+ * Ce module produit la structure typée `ReportIntegrityFooter` à partir
+ * d'une représentation canonique du rapport (liste ordonnée de blocs).
+ * Aucune I/O : la génération réelle du PDF est faite en dehors, côté
+ * `apps/api` ; RM24 lui fournit seulement les données à imprimer.
+ *
+ * ## Encodage canonique anti-collision
+ *
+ * Le hash est calculé sur une chaîne UTF-8 construite en concaténant,
+ * pour chaque bloc, le motif :
+ *
+ * ```text
+ * [kind:<byteLength>]\n<text>\n
+ * ```
+ *
+ * où `byteLength` est la longueur **en octets UTF-8** du `text`. Chaque
+ * bloc est ainsi **auto-délimité** — un bloc ne peut pas en simuler
+ * deux, quels que soient les caractères de son `text` (même s'il
+ * contient `\n`, `---`, ou un motif `[kind:N]` en clair). La longueur
+ * dénombrée en octets évite l'ambiguïté des surrogate pairs UTF-16.
+ *
+ * Ce choix est plus simple qu'un préfixe de longueur binaire pur
+ * (JSON canonique / TLV) tout en étant démontrablement injectif : deux
+ * listes de blocs différentes produisent des chaînes différentes, donc
+ * (sous hypothèse SHA-256) des hashs différents.
+ *
+ * ## Portée du hash
+ *
+ * Le `contentHash` couvre **uniquement le contenu** (ordre + kind +
+ * text des blocs). Il ne couvre pas `generatedAtUtc` ni `generator` :
+ * deux rapports identiques générés à deux dates distinctes partagent le
+ * même `contentHash`. Cette séparation simplifie l'audit : on peut
+ * regénérer le même rapport plus tard et comparer son hash sans se
+ * soucier du timestamp. Timestamp et générateur sont imprimés dans le
+ * pied de page en clair, signés implicitement par la stack de signature
+ * de l'API (hors périmètre RM24).
+ *
+ * ## Règle monorepo
+ *
+ * Le hash transite par `@kinhale/crypto` (SubtleCrypto) — AUCUN import
+ * direct de `node:crypto` ni `globalThis.crypto` ici. Conformément à
+ * CLAUDE.md §Principes : « Primitives crypto : uniquement via
+ * `packages/crypto` ».
+ */
+
+/** Version du format de pied d'intégrité. Incrémentée si l'encodage change. */
+export const REPORT_INTEGRITY_FOOTER_VERSION = '1';
+
+/** Catégorie d'un bloc de contenu du rapport. Ordre d'apparition = sémantique. */
+export type ReportBlockKind = 'dose' | 'plan' | 'caregiver' | 'metadata' | 'disclaimer';
+
+/**
+ * Un bloc atomique du rapport. Le `text` est la représentation textuelle
+ * canonique du bloc, pas son rendu visuel (les styles PDF ne sont pas
+ * hachés — on signe le fait, pas sa mise en forme).
+ */
+export interface ReportContentBlock {
+  readonly kind: ReportBlockKind;
+  readonly text: string;
+}
+
+/**
+ * Pied d'intégrité imprimé en bas de chaque PDF exporté. Structure stable,
+ * versionnée via {@link REPORT_INTEGRITY_FOOTER_VERSION}.
+ */
+export interface ReportIntegrityFooter {
+  /** SHA-256 du contenu canonique (64 caractères hex minuscules). */
+  readonly contentHash: string;
+  /** Timestamp UTC ISO-8601 de génération du rapport (incl. millisecondes). */
+  readonly generatedAtUtc: string;
+  /** Identifiant du générateur (ex: `kinhale-api/0.1.0`). */
+  readonly generator: string;
+  /** Version du format de pied. Cf. {@link REPORT_INTEGRITY_FOOTER_VERSION}. */
+  readonly version: typeof REPORT_INTEGRITY_FOOTER_VERSION;
+}
+
+/**
+ * Encodage canonique d'une liste de blocs. Chaque bloc est préfixé par
+ * `[kind:byteLength]\n` (où byteLength = longueur UTF-8 du text) puis
+ * suivi du `text` et d'un `\n` final. Injectif : deux listes différentes
+ * produisent deux chaînes différentes (voir discussion dans le JSDoc du
+ * module).
+ */
+function canonicalize(content: ReadonlyArray<ReportContentBlock>): string {
+  const encoder = new TextEncoder();
+  let out = '';
+  for (const block of content) {
+    const byteLength = encoder.encode(block.text).byteLength;
+    out += `[${block.kind}:${String(byteLength)}]\n${block.text}\n`;
+  }
+  return out;
+}
+
+/**
+ * RM24 — calcule le pied d'intégrité d'un rapport exporté.
+ *
+ * @throws {DomainError} `RM24_INVALID_GENERATOR` si `generator` est vide ou
+ *   composé uniquement de whitespace.
+ */
+export async function computeReportIntegrityFooter(options: {
+  readonly content: ReadonlyArray<ReportContentBlock>;
+  readonly generatedAtUtc: Date;
+  readonly generator: string;
+}): Promise<ReportIntegrityFooter> {
+  if (options.generator.trim().length === 0) {
+    throw new DomainError(
+      'RM24_INVALID_GENERATOR',
+      'generator must be a non-empty, non-whitespace string (ex: "kinhale-api/0.1.0").',
+    );
+  }
+
+  const canonical = canonicalize(options.content);
+  const contentHash = await sha256HexFromString(canonical);
+
+  return {
+    contentHash,
+    generatedAtUtc: options.generatedAtUtc.toISOString(),
+    generator: options.generator,
+    version: REPORT_INTEGRITY_FOOTER_VERSION,
+  };
+}
+
+/**
+ * RM24 — vérifie qu'un pied d'intégrité correspond bien à un contenu.
+ *
+ * Ne lève jamais : retourne `false` pour toute divergence (hash qui ne
+ * matche pas, format hex invalide, bloc ajouté/retiré, ordre altéré).
+ * Utilisé côté re-lecture d'un rapport archivé ou côté CI snapshot.
+ */
+export async function verifyReportIntegrityFooter(options: {
+  readonly content: ReadonlyArray<ReportContentBlock>;
+  readonly footer: ReportIntegrityFooter;
+}): Promise<boolean> {
+  try {
+    const canonical = canonicalize(options.content);
+    const expected = await sha256HexFromString(canonical);
+    return expected === options.footer.contentHash;
+  } catch {
+    return false;
+  }
+}

--- a/packages/domain/src/rules/rm24-report-integrity.ts
+++ b/packages/domain/src/rules/rm24-report-integrity.ts
@@ -46,6 +46,27 @@ import { DomainError } from '../errors';
  * pied de page en clair, signés implicitement par la stack de signature
  * de l'API (hors périmètre RM24).
  *
+ * ## Modèle de menace
+ *
+ * RM24 protège contre la **falsification non détectée** : un tiers qui
+ * modifie le contenu du PDF (ex: changer une dose) sans recalculer le
+ * hash est immédiatement détectable en re-hashant le contenu. Le hash
+ * n'est **pas signé cryptographiquement** : un attaquant qui maîtrise
+ * le pipeline de génération peut produire un rapport arbitraire avec
+ * un hash cohérent. Une signature Ed25519 par clé de foyer viendra en
+ * v1.1+ (hors périmètre v1.0).
+ *
+ * ## Normalisation Unicode
+ *
+ * La chaîne canonique est hachée **telle quelle en UTF-8**, sans
+ * normalisation NFC/NFD préalable. Conséquence : `"é"` composé (U+00E9)
+ * et `"é"` décomposé (U+0065 + U+0301) produisent deux hashs distincts
+ * même s'ils s'affichent identiquement. Choix délibéré : injectivité
+ * stricte + simplicité, pas de sur-normalisation qui pourrait cacher
+ * une modification. Les producteurs de rapports (Kinhale API, futurs
+ * clients) doivent émettre en NFC par défaut via
+ * `String.prototype.normalize('NFC')` avant d'appeler cette règle.
+ *
  * ## Règle monorepo
  *
  * Le hash transite par `@kinhale/crypto` (SubtleCrypto) — AUCUN import
@@ -97,7 +118,7 @@ function canonicalize(content: ReadonlyArray<ReportContentBlock>): string {
   let out = '';
   for (const block of content) {
     const byteLength = encoder.encode(block.text).byteLength;
-    out += `[${block.kind}:${String(byteLength)}]\n${block.text}\n`;
+    out += `[${block.kind}:${byteLength}]\n${block.text}\n`;
   }
   return out;
 }

--- a/packages/domain/src/rules/rm27-disclaimer-presence.test.ts
+++ b/packages/domain/src/rules/rm27-disclaimer-presence.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertDisclaimerCoverage,
+  DISCLAIMER_TEXT_EN,
+  DISCLAIMER_TEXT_FR,
+  type DisclaimerSurface,
+  type DisclaimerSurfaceContent,
+  getDisclaimerText,
+  REQUIRED_SURFACES,
+} from './rm27-disclaimer-presence';
+
+function contentFr(surface: DisclaimerSurface, extra = ''): DisclaimerSurfaceContent {
+  return {
+    surface,
+    locale: 'fr',
+    text: extra ? `${extra}\n\n${DISCLAIMER_TEXT_FR}` : DISCLAIMER_TEXT_FR,
+  };
+}
+
+function contentEn(surface: DisclaimerSurface, extra = ''): DisclaimerSurfaceContent {
+  return {
+    surface,
+    locale: 'en',
+    text: extra ? `${extra}\n\n${DISCLAIMER_TEXT_EN}` : DISCLAIMER_TEXT_EN,
+  };
+}
+
+describe('RM27 — constantes', () => {
+  it('expose le disclaimer FR strictement conforme aux SPECS §4 RM27', () => {
+    expect(DISCLAIMER_TEXT_FR).toBe(
+      'Kinhale est un outil de suivi et de coordination. Il ne remplace pas un avis médical.',
+    );
+  });
+
+  it('expose la traduction EN', () => {
+    expect(DISCLAIMER_TEXT_EN).toBe(
+      'Kinhale is a tracking and coordination tool. It does not replace medical advice.',
+    );
+  });
+
+  it("liste les 4 surfaces requises dans l'ordre SPECS (onboarding, cgu, report_footer, about)", () => {
+    expect(REQUIRED_SURFACES).toEqual(['onboarding', 'cgu', 'report_footer', 'about']);
+  });
+});
+
+describe('RM27 — getDisclaimerText', () => {
+  it('retourne le texte FR pour locale fr', () => {
+    expect(getDisclaimerText('fr')).toBe(DISCLAIMER_TEXT_FR);
+  });
+
+  it('retourne le texte EN pour locale en', () => {
+    expect(getDisclaimerText('en')).toBe(DISCLAIMER_TEXT_EN);
+  });
+});
+
+describe('RM27 — assertDisclaimerCoverage (chemin nominal)', () => {
+  it('accepte les 4 surfaces présentes en FR avec le bon texte', () => {
+    const result = assertDisclaimerCoverage({
+      contents: [
+        contentFr('onboarding'),
+        contentFr('cgu'),
+        contentFr('report_footer'),
+        contentFr('about'),
+      ],
+    });
+
+    expect(result.compliant).toBe(true);
+    expect(result.missingSurfaces).toEqual([]);
+    expect(result.incorrectSurfaces).toEqual([]);
+  });
+
+  it('accepte les 4 surfaces présentes en EN avec le bon texte', () => {
+    const result = assertDisclaimerCoverage({
+      contents: [
+        contentEn('onboarding'),
+        contentEn('cgu'),
+        contentEn('report_footer'),
+        contentEn('about'),
+      ],
+    });
+
+    expect(result.compliant).toBe(true);
+  });
+
+  it('accepte un doublon FR + EN pour une même surface si les deux textes sont valides', () => {
+    const result = assertDisclaimerCoverage({
+      contents: [
+        contentFr('onboarding'),
+        contentEn('onboarding'),
+        contentFr('cgu'),
+        contentFr('report_footer'),
+        contentFr('about'),
+      ],
+    });
+
+    expect(result.compliant).toBe(true);
+    expect(result.incorrectSurfaces).toEqual([]);
+  });
+
+  it('accepte un disclaimer noyé dans un texte plus large (inclusion, pas match strict)', () => {
+    // Un écran d'onboarding peut contenir un titre, un bouton, puis le
+    // disclaimer en pied. L'inclusion (String#includes) est le critère retenu.
+    const result = assertDisclaimerCoverage({
+      contents: [
+        contentFr('onboarding', 'Bienvenue sur Kinhale'),
+        contentFr('cgu', 'Article 1 — Objet'),
+        contentFr('report_footer'),
+        contentFr('about'),
+      ],
+    });
+
+    expect(result.compliant).toBe(true);
+  });
+
+  it('ignore une surface supplémentaire non requise (ex: "email_footer")', () => {
+    const extra: DisclaimerSurfaceContent = {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      surface: 'email_footer' as any,
+      locale: 'fr',
+      text: DISCLAIMER_TEXT_FR,
+    };
+    const result = assertDisclaimerCoverage({
+      contents: [
+        contentFr('onboarding'),
+        contentFr('cgu'),
+        contentFr('report_footer'),
+        contentFr('about'),
+        extra,
+      ],
+    });
+
+    expect(result.compliant).toBe(true);
+  });
+});
+
+describe('RM27 — assertDisclaimerCoverage (cas de non-conformité)', () => {
+  it('signale la surface manquante (ex: pas de cgu)', () => {
+    const result = assertDisclaimerCoverage({
+      contents: [contentFr('onboarding'), contentFr('report_footer'), contentFr('about')],
+    });
+
+    expect(result.compliant).toBe(false);
+    expect(result.missingSurfaces).toEqual(['cgu']);
+    expect(result.incorrectSurfaces).toEqual([]);
+  });
+
+  it('signale plusieurs surfaces manquantes', () => {
+    const result = assertDisclaimerCoverage({
+      contents: [contentFr('onboarding')],
+    });
+
+    expect(result.compliant).toBe(false);
+    expect(result.missingSurfaces).toEqual(['cgu', 'report_footer', 'about']);
+  });
+
+  it('signale une surface présente avec texte altéré (report_footer)', () => {
+    const altered: DisclaimerSurfaceContent = {
+      surface: 'report_footer',
+      locale: 'fr',
+      text: 'Kinhale est un outil de suivi. Il ne remplace pas un avis médical.', // phrase tronquée
+    };
+    const result = assertDisclaimerCoverage({
+      contents: [contentFr('onboarding'), contentFr('cgu'), altered, contentFr('about')],
+    });
+
+    expect(result.compliant).toBe(false);
+    expect(result.incorrectSurfaces).toEqual(['report_footer']);
+    expect(result.missingSurfaces).toEqual([]);
+  });
+
+  it('signale une surface fr dont le texte est la version EN (locale mismatch)', () => {
+    const mismatch: DisclaimerSurfaceContent = {
+      surface: 'about',
+      locale: 'fr',
+      text: DISCLAIMER_TEXT_EN,
+    };
+    const result = assertDisclaimerCoverage({
+      contents: [contentFr('onboarding'), contentFr('cgu'), contentFr('report_footer'), mismatch],
+    });
+
+    expect(result.compliant).toBe(false);
+    expect(result.incorrectSurfaces).toEqual(['about']);
+  });
+
+  it('si la surface est à la fois présente-mais-altérée et répétée-correctement, la couverture est OK', () => {
+    // Une surface peut apparaître plusieurs fois (ex: rendu FR et EN). Au
+    // moins une occurrence doit être correcte pour la locale annoncée.
+    const altered: DisclaimerSurfaceContent = {
+      surface: 'about',
+      locale: 'fr',
+      text: 'Kinhale est super.',
+    };
+    const result = assertDisclaimerCoverage({
+      contents: [
+        contentFr('onboarding'),
+        contentFr('cgu'),
+        contentFr('report_footer'),
+        altered,
+        contentEn('about'), // version EN correcte : couvre la surface
+      ],
+    });
+
+    expect(result.compliant).toBe(true);
+    expect(result.missingSurfaces).toEqual([]);
+    // La variante altérée FR n'est pas signalée car la surface est couverte
+    // par une autre variante correcte. On rapporte la surface uniquement
+    // quand AUCUNE variante n'est valide.
+    expect(result.incorrectSurfaces).toEqual([]);
+  });
+
+  it("cumule missing et incorrect quand c'est le cas", () => {
+    const altered: DisclaimerSurfaceContent = {
+      surface: 'onboarding',
+      locale: 'fr',
+      text: 'Texte hors spec',
+    };
+    const result = assertDisclaimerCoverage({
+      contents: [altered, contentFr('cgu'), contentFr('report_footer')], // about manquant
+    });
+
+    expect(result.compliant).toBe(false);
+    expect(result.missingSurfaces).toEqual(['about']);
+    expect(result.incorrectSurfaces).toEqual(['onboarding']);
+  });
+});
+
+describe('RM27 — résilience aux variations de whitespace (inclusion avec normalisation)', () => {
+  it('accepte un disclaimer précédé/suivi de newlines (trim implicite via inclusion)', () => {
+    const padded: DisclaimerSurfaceContent = {
+      surface: 'report_footer',
+      locale: 'fr',
+      text: `\n\n   ${DISCLAIMER_TEXT_FR}   \n`,
+    };
+    const result = assertDisclaimerCoverage({
+      contents: [contentFr('onboarding'), contentFr('cgu'), padded, contentFr('about')],
+    });
+
+    expect(result.compliant).toBe(true);
+  });
+
+  it('REFUSE un texte qui simplement contient "avis médical" sans la phrase complète', () => {
+    // Garde-fou : l'inclusion est stricte sur la PHRASE COMPLÈTE canonique,
+    // pas un fuzzy match. Un rapport avec "consultez un avis médical"
+    // seul n'atteste pas le disclaimer non-DM.
+    const partial: DisclaimerSurfaceContent = {
+      surface: 'cgu',
+      locale: 'fr',
+      text: 'Consultez votre avis médical en cas de doute.',
+    };
+    const result = assertDisclaimerCoverage({
+      contents: [contentFr('onboarding'), partial, contentFr('report_footer'), contentFr('about')],
+    });
+
+    expect(result.compliant).toBe(false);
+    expect(result.incorrectSurfaces).toEqual(['cgu']);
+  });
+});

--- a/packages/domain/src/rules/rm27-disclaimer-presence.test.ts
+++ b/packages/domain/src/rules/rm27-disclaimer-presence.test.ts
@@ -114,8 +114,7 @@ describe('RM27 — assertDisclaimerCoverage (chemin nominal)', () => {
 
   it('ignore une surface supplémentaire non requise (ex: "email_footer")', () => {
     const extra: DisclaimerSurfaceContent = {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      surface: 'email_footer' as any,
+      surface: 'email_footer' as unknown as DisclaimerSurface,
       locale: 'fr',
       text: DISCLAIMER_TEXT_FR,
     };

--- a/packages/domain/src/rules/rm27-disclaimer-presence.ts
+++ b/packages/domain/src/rules/rm27-disclaimer-presence.ts
@@ -1,0 +1,126 @@
+/**
+ * RM27 — Disclaimer omniprésent (SPECS §4 RM27 + §10 Transparence).
+ *
+ * La mention « *Kinhale est un outil de suivi et de coordination. Il ne
+ * remplace pas un avis médical.* » doit apparaître à **4 emplacements** :
+ * (a) onboarding, (b) CGU, (c) pied de chaque rapport exporté, (d)
+ * paramètres « À propos ».
+ *
+ * Ce module fournit une **validation côté domaine** — pure, sans I/O. Il
+ * est invoqué par les tests d'intégration (ex: un parcours E2E qui vérifie
+ * la présence du disclaimer dans les rendus) et peut être exécuté en CI
+ * sur un snapshot des chaînes i18n + les PDF générés.
+ *
+ * Choix documenté :
+ * - Le critère de validation est **l'inclusion** de la phrase canonique
+ *   dans le texte fourni (`text.includes(DISCLAIMER_TEXT_XX)`), et non un
+ *   match strict d'égalité. Justification : un écran d'onboarding
+ *   contient aussi un titre, des CTA, un récap produit ; seul le
+ *   disclaimer canonique doit y être présent, intact.
+ * - L'inclusion se fait sur la chaîne **brute** du contenu fourni. Toute
+ *   coupe de caractères (tronquage, traduction partielle, reformulation)
+ *   est détectée — c'est le point dur de RM27 : la phrase NON-DM est
+ *   légalement chargée et ne doit pas être paraphrasée.
+ * - Les variations de whitespace autour de la phrase (newlines, espaces)
+ *   ne sont pas un problème puisque l'inclusion tolère tout préfixe /
+ *   suffixe. En revanche une variation **à l'intérieur** de la phrase
+ *   (ex: double espace) est refusée. Documenté.
+ * - Une surface est **couverte** dès qu'au moins une variante fournie
+ *   (FR ou EN, multiples rendus autorisés) matche la phrase pour sa
+ *   locale. La liste `incorrectSurfaces` ne remonte que les surfaces
+ *   pour lesquelles AUCUNE variante n'est valide — évite le bruit quand
+ *   l'app offre plusieurs rendus (ex: FR + EN du même écran).
+ * - Aucun code d'erreur RM27 n'est exposé : la fonction retourne un
+ *   résultat structuré (`compliant`, `missingSurfaces`, `incorrectSurfaces`),
+ *   jamais de lève. C'est une règle de **validation**, pas d'assertion.
+ */
+
+/** Phrase canonique FR — voir SPECS §4 RM27 ligne 351. */
+export const DISCLAIMER_TEXT_FR =
+  'Kinhale est un outil de suivi et de coordination. Il ne remplace pas un avis médical.';
+
+/** Traduction EN officielle — miroir strict du FR. */
+export const DISCLAIMER_TEXT_EN =
+  'Kinhale is a tracking and coordination tool. It does not replace medical advice.';
+
+/**
+ * Les 4 surfaces imposées par RM27, dans l'ordre SPECS §4 RM27 :
+ * onboarding → CGU → pied rapport exporté → À propos.
+ */
+export type DisclaimerSurface = 'onboarding' | 'cgu' | 'report_footer' | 'about';
+
+/** Liste figée des surfaces requises, dans l'ordre spécifié par les SPECS. */
+export const REQUIRED_SURFACES: ReadonlyArray<DisclaimerSurface> = [
+  'onboarding',
+  'cgu',
+  'report_footer',
+  'about',
+];
+
+/** Locales supportées par Kinhale en v1.0 (CLAUDE.md §Principes). */
+export type DisclaimerLocale = 'fr' | 'en';
+
+/**
+ * Contenu d'une surface UI / document à vérifier. Le `text` est la chaîne
+ * brute rendue à l'utilisateur pour la locale indiquée.
+ */
+export interface DisclaimerSurfaceContent {
+  readonly surface: DisclaimerSurface;
+  readonly locale: DisclaimerLocale;
+  /** Texte brut rendu à l'utilisateur (peut contenir d'autres éléments). */
+  readonly text: string;
+}
+
+/** Résultat de la vérification de couverture. */
+export interface DisclaimerCoverageResult {
+  /** `true` ssi chaque surface de {@link REQUIRED_SURFACES} est couverte. */
+  readonly compliant: boolean;
+  /** Surfaces totalement absentes des contenus fournis. Ordre : SPECS. */
+  readonly missingSurfaces: ReadonlyArray<DisclaimerSurface>;
+  /**
+   * Surfaces fournies mais dont **aucune variante** (toutes locales
+   * confondues) ne contient la phrase canonique pour sa locale.
+   */
+  readonly incorrectSurfaces: ReadonlyArray<DisclaimerSurface>;
+}
+
+/** Retourne la phrase canonique pour une locale donnée. */
+export function getDisclaimerText(locale: DisclaimerLocale): string {
+  return locale === 'fr' ? DISCLAIMER_TEXT_FR : DISCLAIMER_TEXT_EN;
+}
+
+/**
+ * RM27 — vérifie que le disclaimer non-DM est présent aux 4 emplacements
+ * requis pour au moins une locale.
+ */
+export function assertDisclaimerCoverage(options: {
+  readonly contents: ReadonlyArray<DisclaimerSurfaceContent>;
+}): DisclaimerCoverageResult {
+  const missingSurfaces: DisclaimerSurface[] = [];
+  const incorrectSurfaces: DisclaimerSurface[] = [];
+
+  for (const required of REQUIRED_SURFACES) {
+    const variants = options.contents.filter((c) => c.surface === required);
+
+    if (variants.length === 0) {
+      missingSurfaces.push(required);
+      continue;
+    }
+
+    const hasValid = variants.some((variant) =>
+      variant.text.includes(getDisclaimerText(variant.locale)),
+    );
+
+    if (!hasValid) {
+      incorrectSurfaces.push(required);
+    }
+  }
+
+  const compliant = missingSurfaces.length === 0 && incorrectSurfaces.length === 0;
+
+  return {
+    compliant,
+    missingSurfaces,
+    incorrectSurfaces,
+  };
+}

--- a/packages/eslint-config/index.js
+++ b/packages/eslint-config/index.js
@@ -60,6 +60,39 @@ export default tseslint.config(
               name: 'crypto-js',
               message: 'crypto-js est interdit. Utilise @kinhale/crypto (libsodium).',
             },
+            {
+              name: 'node:crypto',
+              message:
+                'node:crypto est Node-only et casse la portabilité web/mobile. Utilise @kinhale/crypto.',
+            },
+            {
+              name: 'crypto',
+              message:
+                'node:crypto est Node-only et casse la portabilité web/mobile. Utilise @kinhale/crypto.',
+            },
+            {
+              name: 'js-sha256',
+              message:
+                'Implémentation JS interdite. Utilise @kinhale/crypto (Web Crypto API native).',
+            },
+            {
+              name: 'sha.js',
+              message:
+                'Implémentation JS interdite. Utilise @kinhale/crypto (Web Crypto API native).',
+            },
+            {
+              name: 'hash.js',
+              message:
+                'Implémentation JS interdite. Utilise @kinhale/crypto (Web Crypto API native).',
+            },
+            {
+              name: 'crypto-browserify',
+              message: 'Polyfill interdit. Utilise @kinhale/crypto (Web Crypto API native).',
+            },
+            {
+              name: 'tweetnacl',
+              message: 'Import direct interdit. Utilise @kinhale/crypto.',
+            },
           ],
         },
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,32 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  packages/crypto:
+    devDependencies:
+      '@kinhale/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@kinhale/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.17
+      eslint:
+        specifier: ^9.18.0
+        version: 9.39.4
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.2
+        version: 3.2.4(@types/node@22.19.17)
+
   packages/domain:
+    dependencies:
+      '@kinhale/crypto':
+        specifier: workspace:*
+        version: link:../crypto
     devDependencies:
       '@kinhale/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
## Résumé

Huitième lot de travaux dans le monorepo Kinhale. Chantier **compliance & intégrité** :

1. **Scaffold nouveau package `@kinhale/crypto`** — SHA-256 via Web Crypto API native, zéro dépendance externe. Fondation pour tous les futurs chantiers crypto (libsodium, MLS, Argon2id, Ed25519).
2. **RM24** — Intégrité rapport : hash SHA-256 du contenu PDF exporté + timestamp + générateur en pied de page.
3. **RM27** — Disclaimer omniprésent : validation que la mention non-DM apparaît aux 4 surfaces requises (onboarding, CGU, rapport, À propos) en FR et EN.
4. **Durcissement ESLint `no-restricted-imports`** : 7 librairies crypto tierces ajoutées à la liste des imports interdits.

**43 nouveaux tests** (10 crypto + 33 domain). Total monorepo : 283 → **317 tests** tous verts.

## Workflow pré-PR appliqué

Conforme à `CLAUDE.md §Méthodologie` — **double revue** passée AVANT ouverture de PR (zone sensible crypto) :

- **kz-review** → APPROUVÉ AVEC MODIFICATIONS MINEURES, 0 MAJEUR
- **kz-securite** → APPROUVÉ AVEC MODIFICATIONS MINEURES, 0 GRAVE, 0 MAJEUR

Corrections intégrées dans le commit `399d89c` :
- `no-restricted-imports` durci (7 libs crypto tierces ajoutées)
- Modèle de menace RM24 documenté en JSDoc (hash nu ≠ signé, v1.1+ pour Ed25519)
- Décision « pas de normalisation Unicode » documentée + consigne NFC côté producteurs
- Test garde-fou sur `sha256Hex` pour sous-view `Uint8Array.subarray()`
- `as any` remplacé par `as unknown as` dans test RM27

## Nouveau package `@kinhale/crypto`

```ts
// packages/crypto/src/index.ts
export { sha256Hex, sha256HexFromString, CRYPTO_UNAVAILABLE_MESSAGE } from './hash/sha256';
```

- **Implémentation** : `globalThis.crypto.subtle.digest('SHA-256', ...)` — Web Crypto API native, zéro polyfill
- **Fail-fast** : si `subtle` n'est pas disponible (ex: RN Hermes pre-0.74 sans polyfill), lève avec `CRYPTO_UNAVAILABLE_MESSAGE` — pas de dégradation silencieuse
- **Zéro dépendance externe** : uniquement Web Crypto + `TextEncoder` natifs
- **Vecteurs FIPS 180-4 officiels testés** : chaîne vide, `"abc"`, fox pangram, `0xff` isolé
- **AGPL v3** (cohérent avec le reste du monorepo)

## API RM24

```ts
export const REPORT_INTEGRITY_FOOTER_VERSION = '1';

export interface ReportContentBlock {
  readonly kind: 'dose' | 'plan' | 'caregiver' | 'metadata' | 'disclaimer';
  readonly text: string;
}

export interface ReportIntegrityFooter {
  readonly contentHash: string;      // SHA-256 hex 64 car
  readonly generatedAtUtc: string;   // ISO-8601 UTC
  readonly generator: string;        // ex "kinhale-api/0.1.0"
  readonly version: '1';
}

export async function computeReportIntegrityFooter({content, generatedAtUtc, generator}): Promise<ReportIntegrityFooter>;
export async function verifyReportIntegrityFooter({content, footer}): Promise<boolean>;
```

**Encodage canonique collision-safe** : chaque bloc préfixé par `[kind:<byteLength UTF-8>]\n<text>\n`. Injectif : un bloc contenant le séparateur brut en clair ne peut pas se faire passer pour deux blocs. Test dédié verrouille cette propriété.

## API RM27

```ts
export const DISCLAIMER_TEXT_FR = 'Kinhale est un outil de suivi et de coordination. Il ne remplace pas un avis médical.';
export const DISCLAIMER_TEXT_EN = 'Kinhale is a tracking and coordination tool. It does not replace medical advice.';

export type DisclaimerSurface = 'onboarding' | 'cgu' | 'report_footer' | 'about';
export const REQUIRED_SURFACES: ReadonlyArray<DisclaimerSurface> = [...];

export function assertDisclaimerCoverage({contents}): DisclaimerCoverageResult;
```

Validation par `String.includes()` (inclusion) : un écran peut avoir d'autres textes (titre, actions) autour du disclaimer canonique.

## Code d'erreur ajouté

- `RM24_INVALID_GENERATOR` — `generator` vide ou whitespace-only

## Choix sémantiques documentés

- **Modèle de menace RM24** : hash nu non signé. Protège contre falsification NON détectée (modification sans recalcul). Signature Ed25519 par clé de foyer en v1.1+.
- **Encodage canonique** : `[kind:byteLength]\n<text>\n`, longueur en octets UTF-8 (pas de surprise surrogate pair).
- **`contentHash` ne couvre PAS** `generatedAtUtc` ni `generator` — permet de regénérer le même rapport plus tard avec un hash identique.
- **Pas de normalisation Unicode** : `"é"` (U+00E9) et `"é"` (U+0065 + U+0301) produisent des hashs distincts. Les producteurs doivent émettre en NFC.
- **RM27 inclusion** : `String.includes()` permet aux écrans d'avoir du texte autour du disclaimer.
- **RM27 FR+EN distincts** : une surface peut fournir plusieurs variantes (mobile/web, FR/EN), la vérification passe si AU MOINS UNE match pour chaque surface requise.

## Privacy — contexts d'erreur

Aucune donnée santé ni personnelle dans les `DomainError.context`. Seul `RM24_INVALID_GENERATOR` lève — context contient uniquement `generator: string` (non-donnée-santé).

## Vérifications

- [x] `pnpm --filter @kinhale/crypto typecheck` : vert
- [x] `pnpm --filter @kinhale/crypto lint` : vert
- [x] `pnpm --filter @kinhale/crypto test` : 10/10
- [x] `pnpm --filter @kinhale/domain typecheck` : vert
- [x] `pnpm --filter @kinhale/domain lint` : vert
- [x] `pnpm --filter @kinhale/domain test` : 307/307
- [x] `pnpm format:check` : vert
- [x] `pnpm typecheck` (turbo) : vert
- [x] `pnpm lint` (turbo) : vert
- [x] **kz-review** passé pré-PR : 0 MAJEUR
- [x] **kz-securite** passé pré-PR : 0 GRAVE, 0 MAJEUR
- [x] Règle CLAUDE.md « crypto uniquement via `@kinhale/crypto` » respectée
- [x] `no-restricted-imports` durci (7 libs tierces bloquées)
- [x] Zéro dépendance externe ajoutée
- [x] Ligne rouge dispositif médical préservée (RM27 EST le garde-fou, RM24 = intégrité pure)
- [x] AGPL v3 cohérent sur nouveau package

## Points de vigilance pour la revue humaine

1. **Validation linguistique du `DISCLAIMER_TEXT_EN`** — traduction raisonnable mais juridiquement chargée. Idéalement validée par un juriste avant release v1.0.
2. **ADR à créer** : « Encodage canonique de hash de rapport » — le format `[kind:byteLength]\n<text>\n` devient un contrat inter-plateformes dès qu'`apps/api`, `apps/mobile` et `apps/web` devront regénérer / vérifier le même hash. La JSDoc actuelle est suffisante, mais formaliser en ADR est préférable.
3. **React Native / Hermes** : le package crypto suppose Web Crypto API global. À valider avec le test d'intégration mobile dès que `apps/mobile` existera. `CRYPTO_UNAVAILABLE_MESSAGE` lève proprement sinon.
4. **Signatures Ed25519 RM24 v1.1+** : le hash nu est un choix v1.0 volontaire. Si un modèle de menace plus fort émerge en revue conformité, prioriser KIN-XXX pour la signature par clé de foyer.

## Taille de PR

1 217 insertions (scaffold + 2 règles + 43 tests + durcissement eslint). Justifiée : scaffold d'un package crypto entier ne peut pas être découpé, et la famille compliance+intégrité forme un tout cohérent.

## Avancement v1.0 domaine

**18 règles livrées / 28** après merge (64%) : RM1-7, RM14, RM15, RM17, RM18, RM21, RM22, RM24, RM25, RM26, RM27, RM28.

**10 restantes** : RM8, RM9, RM10, RM11, RM12, RM13, RM16, RM19, RM20, RM23.

## Ce qui arrive ensuite

- **Lot D** (règles usage & état) à découper en sous-lots : export PDF (RM8+RM16), lifecycle pompe (RM19+RM20), rôles & sessions (RM10+RM11+RM12), géoloc (RM23), etc.
- **Scaffold `apps/api`** dès que les règles critiques sont livrées, pour commencer l'intégration

## Test plan

- [ ] Cloner + `pnpm install` + `pnpm test` → 317/317 vert
- [ ] `pnpm format:check` → vert
- [ ] Valider le modèle de menace RM24 (hash nu v1.0 vs signature Ed25519 v1.1+)
- [ ] Valider la traduction EN du disclaimer (juriste)
- [ ] Statuer sur la création d'un ADR pour l'encodage canonique RM24

---

Refs : KIN-012

🤖 Generated with [Claude Code](https://claude.com/claude-code)