### PR TITLE
feat(KIN-013): RM8 rapport médecin + RM16 payload push safe

### DIFF
--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -69,4 +69,10 @@ export type DomainErrorCode =
   /** RM22 — `consentedAtUtc` est strictement postérieur à `nowUtc` (tricherie d'horloge). */
   | 'RM22_INVALID_CONSENT_TIMESTAMP'
   /** RM24 — `generator` fourni vide ou whitespace-only lors du calcul du pied d'intégrité. */
-  | 'RM24_INVALID_GENERATOR';
+  | 'RM24_INVALID_GENERATOR'
+  /** RM8 — période invalide (ex: `fromUtc` strictement postérieur à `toUtc`). */
+  | 'RM8_INVALID_PERIOD'
+  /** RM8 — enfant invalide (prénom vide ou année de naissance aberrante). */
+  | 'RM8_INVALID_CHILD'
+  /** RM16 — payload push contient du contenu interdit (mot-clé santé / PII / titre non générique). */
+  | 'RM16_FORBIDDEN_CONTENT';

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -89,6 +89,29 @@ export type {
   ReportContentBlock,
   ReportIntegrityFooter,
 } from './rm24-report-integrity';
+export { buildMedicalReport } from './rm8-medical-report';
+export type {
+  ConfirmedDoseSummary,
+  MedicalReport,
+  MedicalReportPeriod,
+  VoidedDoseSummary,
+  WeeklyRescueFrequency,
+} from './rm8-medical-report';
+export {
+  buildSafePushPayload,
+  ensurePushPayloadSafe,
+  FORBIDDEN_PUSH_KEYWORDS_EN,
+  FORBIDDEN_PUSH_KEYWORDS_FR,
+  PUSH_BODY_GENERIC,
+  PUSH_BODY_MAX_LENGTH,
+  PUSH_TITLE_GENERIC,
+  validatePushPayload,
+} from './rm16-push-payload';
+export type {
+  PushPayloadViolation,
+  PushPayloadViolationKind,
+  SafePushPayload,
+} from './rm16-push-payload';
 export {
   assertDisclaimerCoverage,
   DISCLAIMER_TEXT_EN,

--- a/packages/domain/src/rules/rm16-push-payload.test.ts
+++ b/packages/domain/src/rules/rm16-push-payload.test.ts
@@ -1,0 +1,353 @@
+import { describe, expect, it } from 'vitest';
+import { DomainError } from '../errors';
+import {
+  buildSafePushPayload,
+  ensurePushPayloadSafe,
+  FORBIDDEN_PUSH_KEYWORDS_EN,
+  FORBIDDEN_PUSH_KEYWORDS_FR,
+  PUSH_BODY_GENERIC,
+  PUSH_BODY_MAX_LENGTH,
+  PUSH_TITLE_GENERIC,
+  type SafePushPayload,
+  validatePushPayload,
+} from './rm16-push-payload';
+
+const HOUSEHOLD_ID = '11111111-1111-4111-8111-111111111111';
+const NOTIFICATION_ID = '22222222-2222-4222-8222-222222222222';
+
+describe('RM16 — buildSafePushPayload', () => {
+  it('retourne un payload avec title/body génériques par défaut', () => {
+    const payload = buildSafePushPayload({
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    });
+
+    expect(payload.title).toBe(PUSH_TITLE_GENERIC);
+    expect(payload.body).toBe(PUSH_BODY_GENERIC);
+    expect(payload.householdId).toBe(HOUSEHOLD_ID);
+    expect(payload.notificationId).toBe(NOTIFICATION_ID);
+  });
+
+  it('accepte un override body pour locale (ex: EN)', () => {
+    const payload = buildSafePushPayload({
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+      bodyOverride: 'New activity',
+    });
+
+    expect(payload.body).toBe('New activity');
+  });
+
+  it("accepte un titleOverride tant qu'il matche le titre générique localisé", () => {
+    const payload = buildSafePushPayload({
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+      titleOverride: 'Kinhale',
+    });
+
+    expect(payload.title).toBe('Kinhale');
+  });
+
+  it('rejette un householdId non-UUIDv4', () => {
+    expect(() =>
+      buildSafePushPayload({
+        householdId: 'not-a-uuid',
+        notificationId: NOTIFICATION_ID,
+      }),
+    ).toThrow(DomainError);
+  });
+
+  it('rejette un notificationId non-UUIDv4', () => {
+    expect(() =>
+      buildSafePushPayload({
+        householdId: HOUSEHOLD_ID,
+        notificationId: 'xxx',
+      }),
+    ).toThrow(DomainError);
+  });
+
+  it('garantit par construction que le payload est safe (aucune violation)', () => {
+    const payload = buildSafePushPayload({
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    });
+
+    expect(validatePushPayload(payload)).toEqual([]);
+  });
+});
+
+describe('RM16 — validatePushPayload (chemin nominal)', () => {
+  it('payload safe construit → 0 violation', () => {
+    const payload = buildSafePushPayload({
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    });
+
+    expect(validatePushPayload(payload)).toEqual([]);
+  });
+
+  it('ne mute pas le payload', () => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body: PUSH_BODY_GENERIC,
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+    const snapshot = JSON.stringify(payload);
+
+    validatePushPayload(payload, ['Mia']);
+
+    expect(JSON.stringify(payload)).toBe(snapshot);
+  });
+});
+
+describe('RM16 — validatePushPayload (détection mots-clés FR)', () => {
+  it.each([
+    'Dose à prendre',
+    'Secours activé',
+    'Nouvelle pompe',
+    'Inhalateur rechargé',
+    'Toux détectée',
+    'Essoufflement signalé',
+    'Sifflement enregistré',
+    'Symptôme observé',
+    'Crise probable',
+    'Respiration difficile',
+    'Allergène présent',
+    'Prescription à jour',
+    'Posologie révisée',
+    'Administré par Maman',
+  ])('flag "%s" comme forbidden_keyword', (body) => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body,
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    const violations = validatePushPayload(payload);
+    expect(violations.some((v) => v.field === 'body' && v.kind === 'forbidden_keyword')).toBe(true);
+  });
+
+  it('détection case-insensitive', () => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body: 'DOSE prise',
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    const violations = validatePushPayload(payload);
+    expect(violations.some((v) => v.kind === 'forbidden_keyword')).toBe(true);
+  });
+});
+
+describe('RM16 — validatePushPayload (détection mots-clés EN)', () => {
+  it.each([
+    'Dose due',
+    'Rescue used',
+    'Pump refilled',
+    'Inhaler available',
+    'Symptom reported',
+    'Attack suspected',
+    'Cough observed',
+    'Wheezing recorded',
+    'Shortness of breath',
+    'Allergen alert',
+    'Prescription updated',
+    'Administered by Dad',
+    'Breathing difficulty',
+  ])('flag "%s" comme forbidden_keyword', (body) => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body,
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    const violations = validatePushPayload(payload);
+    expect(violations.some((v) => v.field === 'body' && v.kind === 'forbidden_keyword')).toBe(true);
+  });
+});
+
+describe('RM16 — validatePushPayload (PII dynamique)', () => {
+  it('flag un body contenant le prénom enfant passé en knownForbiddenStrings', () => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body: 'Activité enregistrée pour Mia',
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    const violations = validatePushPayload(payload, ['Mia']);
+    expect(violations.some((v) => v.field === 'body' && v.kind === 'suspected_pii')).toBe(true);
+  });
+
+  it('détection PII case-insensitive', () => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body: 'mia a pris sa dose',
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    const violations = validatePushPayload(payload, ['Mia']);
+    expect(violations.some((v) => v.kind === 'suspected_pii')).toBe(true);
+  });
+
+  it('ignore une knownForbiddenString vide ou whitespace', () => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body: PUSH_BODY_GENERIC,
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    expect(validatePushPayload(payload, ['', '   '])).toEqual([]);
+  });
+});
+
+describe('RM16 — validatePushPayload (titre non générique)', () => {
+  it('flag un title différent de Kinhale', () => {
+    const payload: SafePushPayload = {
+      title: 'Alerte médicale',
+      body: PUSH_BODY_GENERIC,
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    const violations = validatePushPayload(payload);
+    expect(violations.some((v) => v.field === 'title' && v.kind === 'title_not_generic')).toBe(
+      true,
+    );
+  });
+
+  it('accepte title "Kinhale" (générique officiel)', () => {
+    const payload: SafePushPayload = {
+      title: 'Kinhale',
+      body: PUSH_BODY_GENERIC,
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    expect(validatePushPayload(payload)).toEqual([]);
+  });
+});
+
+describe('RM16 — validatePushPayload (longueur excessive)', () => {
+  it('flag un body dépassant PUSH_BODY_MAX_LENGTH', () => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body: 'a'.repeat(PUSH_BODY_MAX_LENGTH + 1),
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    const violations = validatePushPayload(payload);
+    expect(
+      violations.some((v) => v.field === 'body' && v.kind === 'non_ascii_length_exceeded'),
+    ).toBe(true);
+  });
+
+  it('accepte un body pile à PUSH_BODY_MAX_LENGTH', () => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body: 'a'.repeat(PUSH_BODY_MAX_LENGTH),
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    const violations = validatePushPayload(payload);
+    expect(violations.some((v) => v.kind === 'non_ascii_length_exceeded')).toBe(false);
+  });
+});
+
+describe('RM16 — validatePushPayload (UUIDv4 IDs)', () => {
+  it('flag un householdId non-UUIDv4 (toujours via violation, pas throw)', () => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body: PUSH_BODY_GENERIC,
+      householdId: 'bad',
+      notificationId: NOTIFICATION_ID,
+    };
+
+    const violations = validatePushPayload(payload);
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  it('flag un notificationId non-UUIDv4', () => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body: PUSH_BODY_GENERIC,
+      householdId: HOUSEHOLD_ID,
+      notificationId: 'bad',
+    };
+
+    const violations = validatePushPayload(payload);
+    expect(violations.length).toBeGreaterThan(0);
+  });
+});
+
+describe('RM16 — ensurePushPayloadSafe', () => {
+  it('ne lève rien pour un payload safe', () => {
+    const payload = buildSafePushPayload({
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    });
+
+    expect(() => ensurePushPayloadSafe(payload)).not.toThrow();
+  });
+
+  it('lève RM16_FORBIDDEN_CONTENT si violation détectée', () => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body: 'Dose prise',
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    try {
+      ensurePushPayloadSafe(payload);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM16_FORBIDDEN_CONTENT');
+    }
+  });
+
+  it("expose les violations via le context de l'erreur", () => {
+    const payload: SafePushPayload = {
+      title: PUSH_TITLE_GENERIC,
+      body: 'Dose prise par Mia',
+      householdId: HOUSEHOLD_ID,
+      notificationId: NOTIFICATION_ID,
+    };
+
+    try {
+      ensurePushPayloadSafe(payload, ['Mia']);
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      const domainErr = err as DomainError;
+      expect(domainErr.context).toBeDefined();
+      expect(domainErr.context?.['violations']).toBeDefined();
+    }
+  });
+});
+
+describe('RM16 — listes FORBIDDEN_KEYWORDS exposées et non vides', () => {
+  it('FORBIDDEN_PUSH_KEYWORDS_FR contient les racines attendues', () => {
+    expect(FORBIDDEN_PUSH_KEYWORDS_FR.length).toBeGreaterThan(5);
+    // Échantillon obligatoire — détecte toute régression de liste.
+    expect(FORBIDDEN_PUSH_KEYWORDS_FR).toContain('dose');
+    expect(FORBIDDEN_PUSH_KEYWORDS_FR).toContain('pompe');
+    expect(FORBIDDEN_PUSH_KEYWORDS_FR).toContain('secours');
+  });
+
+  it('FORBIDDEN_PUSH_KEYWORDS_EN contient les racines attendues', () => {
+    expect(FORBIDDEN_PUSH_KEYWORDS_EN.length).toBeGreaterThan(5);
+    expect(FORBIDDEN_PUSH_KEYWORDS_EN).toContain('dose');
+    expect(FORBIDDEN_PUSH_KEYWORDS_EN).toContain('pump');
+    expect(FORBIDDEN_PUSH_KEYWORDS_EN).toContain('rescue');
+  });
+});

--- a/packages/domain/src/rules/rm16-push-payload.test.ts
+++ b/packages/domain/src/rules/rm16-push-payload.test.ts
@@ -28,26 +28,6 @@ describe('RM16 — buildSafePushPayload', () => {
     expect(payload.notificationId).toBe(NOTIFICATION_ID);
   });
 
-  it('accepte un override body pour locale (ex: EN)', () => {
-    const payload = buildSafePushPayload({
-      householdId: HOUSEHOLD_ID,
-      notificationId: NOTIFICATION_ID,
-      bodyOverride: 'New activity',
-    });
-
-    expect(payload.body).toBe('New activity');
-  });
-
-  it("accepte un titleOverride tant qu'il matche le titre générique localisé", () => {
-    const payload = buildSafePushPayload({
-      householdId: HOUSEHOLD_ID,
-      notificationId: NOTIFICATION_ID,
-      titleOverride: 'Kinhale',
-    });
-
-    expect(payload.title).toBe('Kinhale');
-  });
-
   it('rejette un householdId non-UUIDv4', () => {
     expect(() =>
       buildSafePushPayload({
@@ -244,9 +224,9 @@ describe('RM16 — validatePushPayload (longueur excessive)', () => {
     };
 
     const violations = validatePushPayload(payload);
-    expect(
-      violations.some((v) => v.field === 'body' && v.kind === 'non_ascii_length_exceeded'),
-    ).toBe(true);
+    expect(violations.some((v) => v.field === 'body' && v.kind === 'body_length_exceeded')).toBe(
+      true,
+    );
   });
 
   it('accepte un body pile à PUSH_BODY_MAX_LENGTH', () => {
@@ -258,7 +238,7 @@ describe('RM16 — validatePushPayload (longueur excessive)', () => {
     };
 
     const violations = validatePushPayload(payload);
-    expect(violations.some((v) => v.kind === 'non_ascii_length_exceeded')).toBe(false);
+    expect(violations.some((v) => v.kind === 'body_length_exceeded')).toBe(false);
   });
 });
 
@@ -331,6 +311,40 @@ describe('RM16 — ensurePushPayloadSafe', () => {
       const domainErr = err as DomainError;
       expect(domainErr.context).toBeDefined();
       expect(domainErr.context?.['violations']).toBeDefined();
+    }
+  });
+
+  it("NE FUIT PAS le body, keyword, PII ni les IDs dans le context ou le message d'erreur", () => {
+    // Ironie à éviter : une règle anti-fuite push qui fuiterait elle-même
+    // dans les logs structurés. Le detail des violations et le message
+    // d'erreur doivent être non-révélateurs.
+    const childName = 'Mia';
+    const pumpLabel = 'Pompe bleue';
+    const unsafePayload: SafePushPayload = {
+      title: 'Alerte médicale',
+      body: `${childName} a pris sa dose avec la ${pumpLabel}`,
+      householdId: 'not-a-uuid',
+      notificationId: 'not-a-uuid-either',
+    };
+
+    try {
+      ensurePushPayloadSafe(unsafePayload, [childName, pumpLabel]);
+      expect.fail('should have thrown RM16_FORBIDDEN_CONTENT');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      const payload = JSON.stringify({
+        message: (err as DomainError).message,
+        context: (err as DomainError).context,
+      });
+      // Aucune valeur offensante ne doit figurer dans une sérialisation
+      // du message + context : pas le prénom, pas le label de pompe, pas
+      // le mot-clé, pas le body complet, pas l'ID non-UUID.
+      expect(payload).not.toContain(childName);
+      expect(payload).not.toContain(pumpLabel);
+      expect(payload).not.toContain('dose');
+      expect(payload).not.toContain('Alerte médicale');
+      expect(payload).not.toContain('not-a-uuid');
+      expect(payload).not.toContain('a pris sa');
     }
   });
 });

--- a/packages/domain/src/rules/rm16-push-payload.ts
+++ b/packages/domain/src/rules/rm16-push-payload.ts
@@ -1,0 +1,295 @@
+import { DomainError } from '../errors';
+
+/**
+ * RM16 — Jamais de donnée santé dans les push (SPECS §4 RM16 + CA18).
+ *
+ * Kinhale respecte une promesse zero-knowledge : le payload transmis aux
+ * services OS (APNs / FCM) **ne doit contenir aucune donnée santé en clair**.
+ * Il n'embarque qu'un identifiant opaque (`notificationId`) qui déclenche,
+ * à l'ouverture, un fetch authentifié côté client pour récupérer le
+ * contenu chiffré réel.
+ *
+ * Ce module fournit deux responsabilités :
+ *
+ * 1. **Constructeur sûr par construction** : {@link buildSafePushPayload}
+ *    ne prend en entrée que des identifiants opaques et un texte générique
+ *    (title = "Kinhale", body = "Nouvelle activité"). Impossible d'y
+ *    injecter une donnée santé sans passer par un `Override` dont la valeur
+ *    est ensuite validée.
+ *
+ * 2. **Validateur défensif** : {@link validatePushPayload} et
+ *    {@link ensurePushPayloadSafe} parcourent un payload déjà formé pour y
+ *    détecter des violations (mots-clés médicaux, PII connue, titre non
+ *    générique, longueur suspecte, IDs non-UUID). C'est la porte de sortie
+ *    qu'un test CI CA18 peut activer sur n'importe quel chemin qui produit
+ *    un payload, pour détecter une régression.
+ *
+ * ## Sémantique de détection
+ *
+ * La détection est **grossière mais utile** : elle vise les erreurs
+ * manifestes (quelqu'un qui injecte `dose` ou `secours` par étourderie),
+ * pas à prouver l'absence de fuite — la preuve est structurelle (zéro
+ * donnée santé transite jamais par la fonction de construction).
+ *
+ * - **Matching par inclusion** (substring insensible à la casse) plutôt
+ *   que par word boundaries : les `\b` de JavaScript sont ASCII-only et
+ *   ne gèrent pas `é`, `à`, apostrophes courbes, ponctuation Unicode.
+ *   L'inclusion est plus large (faux positifs possibles, ex: `dose`
+ *   comme partie d'un nom de famille), mais en pratique les corpus de
+ *   push ne sont pas des œuvres littéraires — les faux positifs sont
+ *   acceptables quand la règle vise à bloquer un mot-clé santé.
+ *
+ * - **Racines plutôt que mots** : on détecte `administr` (couvre
+ *   "administré", "administrée", "administer", "administered",
+ *   "administration") plutôt que de maintenir N variantes morphologiques.
+ *
+ * - **Pas de normalisation NFC/NFD** : la chaîne est prise telle quelle.
+ *   La liste `FORBIDDEN_PUSH_KEYWORDS_*` est écrite en NFC — si un payload
+ *   arrive en NFD (rare en JS qui sérialise en NFC par défaut) la détection
+ *   peut rater. Documenté pour le reviewer.
+ *
+ * ## Ligne rouge dispositif médical
+ *
+ * Le titre doit rester **strictement générique** (`Kinhale`). Toute
+ * variante (ex: `Alerte médicale`, `Kinhale - Crise`) est flaggée
+ * `title_not_generic`. Raison : un titre de notification apparaît sur
+ * l'écran verrouillé de l'appareil et devient lisible par tout tiers
+ * — même un "Kinhale - Nouvelle prise" fuiterait que l'utilisateur
+ * utilise une app d'asthme, ce qui reste une donnée santé.
+ */
+
+/** Titre générique imposé pour tout payload push v1.0. */
+export const PUSH_TITLE_GENERIC = 'Kinhale';
+
+/** Corps générique par défaut — peut être remplacé par une variante i18n. */
+export const PUSH_BODY_GENERIC = 'Nouvelle activité';
+
+/**
+ * Longueur maximale du `body` (défense en profondeur contre un payload qui
+ * embarquerait beaucoup de données structurées). Les textes génériques FR/EN
+ * font < 30 caractères ; 200 laisse une marge pour les locales verbeuses.
+ */
+export const PUSH_BODY_MAX_LENGTH = 200;
+
+/**
+ * Regex UUID v4. Miroir de {@link UUID_V4_REGEX} défini dans RM15 — dupliqué
+ * ici plutôt qu'importé pour éviter un couplage inutile entre règles.
+ */
+const UUID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Mots-clés / racines interdits en FR dans le corps d'une notification push.
+ * Ordonnés par thématique (santé respiratoire puis pharmacologie). Liste
+ * non exhaustive — son but est de flagger les erreurs manifestes. Toute
+ * extension doit être revue par `kz-conformite` (ligne rouge DM).
+ */
+export const FORBIDDEN_PUSH_KEYWORDS_FR: ReadonlyArray<string> = [
+  // Pharmacologie / dispositif
+  'dose',
+  'pompe',
+  'inhalateur',
+  'secours',
+  'prescription',
+  'posologie',
+  'administr', // administré, administrée, administration
+  // Symptômes / crise
+  'symptôme',
+  'symptome', // tolérance variante sans accent
+  'crise',
+  'respiration',
+  'toux',
+  'sifflement',
+  'essoufflement',
+  'allergène',
+  'allergene',
+];
+
+/**
+ * Mots-clés / racines interdits en EN. Même principe que la liste FR.
+ */
+export const FORBIDDEN_PUSH_KEYWORDS_EN: ReadonlyArray<string> = [
+  // Pharmacologie / dispositif
+  'dose',
+  'pump',
+  'inhaler',
+  'rescue',
+  'prescription',
+  'administer', // administered, administration
+  // Symptômes / crise
+  'symptom',
+  'attack',
+  'breathing',
+  'cough',
+  'wheezing',
+  'shortness',
+  'allergen',
+];
+
+/** Kinds de violations détectables par {@link validatePushPayload}. */
+export type PushPayloadViolationKind =
+  | 'forbidden_keyword'
+  | 'suspected_pii'
+  | 'title_not_generic'
+  | 'non_ascii_length_exceeded'
+  | 'invalid_household_id'
+  | 'invalid_notification_id';
+
+export interface PushPayloadViolation {
+  readonly field: 'title' | 'body' | 'householdId' | 'notificationId';
+  readonly kind: PushPayloadViolationKind;
+  readonly detail: string;
+}
+
+/**
+ * Payload push minimal transmis aux services OS (APNs / FCM). Aucune
+ * donnée santé : uniquement un titre générique, un corps générique, et
+ * deux identifiants opaques permettant au client de récupérer le
+ * contenu chiffré réel via un appel authentifié à l'ouverture.
+ */
+export interface SafePushPayload {
+  readonly title: string;
+  readonly body: string;
+  readonly householdId: string;
+  readonly notificationId: string;
+}
+
+/**
+ * Construit un payload push sûr pour un événement donné. Ne prend en
+ * entrée que des identifiants opaques + un contexte générique — il est
+ * impossible d'y injecter une donnée santé par construction. Valide les
+ * IDs en UUID v4 et lève `RM16_FORBIDDEN_CONTENT` si les overrides
+ * fournis contiennent déjà une violation (défense en profondeur contre
+ * un appelant qui passerait un `bodyOverride` avec une donnée santé).
+ *
+ * @throws {DomainError} `RM16_FORBIDDEN_CONTENT` si `householdId` /
+ *   `notificationId` ne sont pas des UUID v4, ou si les overrides
+ *   produisent un payload non safe.
+ */
+export function buildSafePushPayload(options: {
+  readonly householdId: string;
+  readonly notificationId: string;
+  readonly titleOverride?: string;
+  readonly bodyOverride?: string;
+}): SafePushPayload {
+  const payload: SafePushPayload = {
+    title: options.titleOverride ?? PUSH_TITLE_GENERIC,
+    body: options.bodyOverride ?? PUSH_BODY_GENERIC,
+    householdId: options.householdId,
+    notificationId: options.notificationId,
+  };
+
+  ensurePushPayloadSafe(payload);
+  return payload;
+}
+
+/**
+ * Valide qu'un payload push ne contient aucune donnée santé ni mot-clé
+ * médical suspect (prénom enfant, nom pompe, lexique secours, dose, etc.).
+ * Retourne les violations trouvées sans lever.
+ *
+ * @param payload payload à inspecter (non muté).
+ * @param knownForbiddenStrings chaînes dynamiques supplémentaires à
+ *   détecter (typiquement : prénom enfant, nom de pompe en clair). Les
+ *   entrées vides ou whitespace-only sont ignorées silencieusement.
+ */
+export function validatePushPayload(
+  payload: SafePushPayload,
+  knownForbiddenStrings?: ReadonlyArray<string>,
+): ReadonlyArray<PushPayloadViolation> {
+  const violations: PushPayloadViolation[] = [];
+
+  // --- Title : doit être strictement générique ---
+  if (payload.title !== PUSH_TITLE_GENERIC) {
+    violations.push({
+      field: 'title',
+      kind: 'title_not_generic',
+      detail: `title must be exactly "${PUSH_TITLE_GENERIC}", got "${payload.title}"`,
+    });
+  }
+
+  // --- Body : longueur ---
+  if (payload.body.length > PUSH_BODY_MAX_LENGTH) {
+    violations.push({
+      field: 'body',
+      kind: 'non_ascii_length_exceeded',
+      detail: `body length ${payload.body.length} exceeds max ${PUSH_BODY_MAX_LENGTH}`,
+    });
+  }
+
+  // --- Body : mots-clés interdits (FR + EN) ---
+  const lowerBody = payload.body.toLowerCase();
+  const allKeywords = [...FORBIDDEN_PUSH_KEYWORDS_FR, ...FORBIDDEN_PUSH_KEYWORDS_EN];
+  const seenKeywords = new Set<string>();
+  for (const keyword of allKeywords) {
+    const lowerKeyword = keyword.toLowerCase();
+    if (seenKeywords.has(lowerKeyword)) {
+      continue;
+    }
+    if (lowerBody.includes(lowerKeyword)) {
+      seenKeywords.add(lowerKeyword);
+      violations.push({
+        field: 'body',
+        kind: 'forbidden_keyword',
+        detail: `body contains forbidden keyword "${keyword}"`,
+      });
+    }
+  }
+
+  // --- Body : PII dynamique (ex: prénom enfant, nom de pompe) ---
+  if (knownForbiddenStrings) {
+    for (const raw of knownForbiddenStrings) {
+      const normalized = raw.trim();
+      if (normalized.length === 0) {
+        continue;
+      }
+      if (lowerBody.includes(normalized.toLowerCase())) {
+        violations.push({
+          field: 'body',
+          kind: 'suspected_pii',
+          detail: `body contains suspected PII "${normalized}"`,
+        });
+      }
+    }
+  }
+
+  // --- IDs : format UUID v4 ---
+  if (!UUID_V4_REGEX.test(payload.householdId)) {
+    violations.push({
+      field: 'householdId',
+      kind: 'invalid_household_id',
+      detail: `householdId is not a UUID v4: "${payload.householdId}"`,
+    });
+  }
+  if (!UUID_V4_REGEX.test(payload.notificationId)) {
+    violations.push({
+      field: 'notificationId',
+      kind: 'invalid_notification_id',
+      detail: `notificationId is not a UUID v4: "${payload.notificationId}"`,
+    });
+  }
+
+  return violations;
+}
+
+/**
+ * Variante assertive de {@link validatePushPayload}. Lève
+ * `RM16_FORBIDDEN_CONTENT` si des violations sont détectées. Le `context`
+ * de l'erreur contient le tableau des violations pour inspection.
+ *
+ * @throws {DomainError} `RM16_FORBIDDEN_CONTENT`
+ */
+export function ensurePushPayloadSafe(
+  payload: SafePushPayload,
+  knownForbiddenStrings?: ReadonlyArray<string>,
+): void {
+  const violations = validatePushPayload(payload, knownForbiddenStrings);
+  if (violations.length > 0) {
+    throw new DomainError(
+      'RM16_FORBIDDEN_CONTENT',
+      `push payload contains ${violations.length} violation(s): ${violations
+        .map((v) => `${v.field}/${v.kind}`)
+        .join(', ')}`,
+      { violations },
+    );
+  }
+}

--- a/packages/domain/src/rules/rm16-push-payload.ts
+++ b/packages/domain/src/rules/rm16-push-payload.ts
@@ -92,16 +92,30 @@ export const FORBIDDEN_PUSH_KEYWORDS_FR: ReadonlyArray<string> = [
   'prescription',
   'posologie',
   'administr', // administré, administrée, administration
-  // Symptômes / crise
+  'ventoline',
+  'salbutamol',
+  'salbu',
+  'médicament',
+  'medicament',
+  'antibio',
+  // Symptômes / crise / contexte médical
+  'asthme',
   'symptôme',
-  'symptome', // tolérance variante sans accent
+  'symptome',
   'crise',
+  'oppression',
   'respiration',
   'toux',
   'sifflement',
   'essoufflement',
   'allergène',
   'allergene',
+  // Contexte soignant
+  'médecin',
+  'medecin',
+  'hôpital',
+  'hopital',
+  'urgences',
 ];
 
 /**
@@ -114,15 +128,27 @@ export const FORBIDDEN_PUSH_KEYWORDS_EN: ReadonlyArray<string> = [
   'inhaler',
   'rescue',
   'prescription',
-  'administer', // administered, administration
-  // Symptômes / crise
+  'administer',
+  'ventolin',
+  'albuterol',
+  'salbutamol',
+  'medication',
+  'medicine',
+  // Symptômes / crise / contexte médical
+  'asthma',
   'symptom',
   'attack',
+  'tightness',
   'breathing',
   'cough',
   'wheezing',
   'shortness',
   'allergen',
+  // Contexte soignant
+  'doctor',
+  'physician',
+  'hospital',
+  'emergency',
 ];
 
 /** Kinds de violations détectables par {@link validatePushPayload}. */
@@ -130,10 +156,18 @@ export type PushPayloadViolationKind =
   | 'forbidden_keyword'
   | 'suspected_pii'
   | 'title_not_generic'
-  | 'non_ascii_length_exceeded'
+  | 'body_length_exceeded'
   | 'invalid_household_id'
   | 'invalid_notification_id';
 
+/**
+ * Violation détectée sur un payload push. Le champ `detail` est
+ * **délibérément non révélateur** : il ne contient jamais la valeur
+ * offensante (keyword, PII, title/body) pour éviter qu'un logger qui
+ * sérialiserait ce contexte en JSON structuré fuite la donnée même que
+ * RM16 protège. Le `kind` + `field` suffisent au dev pour reproduire
+ * l'erreur localement avec des fixtures synthétiques.
+ */
 export interface PushPayloadViolation {
   readonly field: 'title' | 'body' | 'householdId' | 'notificationId';
   readonly kind: PushPayloadViolationKind;
@@ -155,25 +189,24 @@ export interface SafePushPayload {
 
 /**
  * Construit un payload push sûr pour un événement donné. Ne prend en
- * entrée que des identifiants opaques + un contexte générique — il est
- * impossible d'y injecter une donnée santé par construction. Valide les
- * IDs en UUID v4 et lève `RM16_FORBIDDEN_CONTENT` si les overrides
- * fournis contiennent déjà une violation (défense en profondeur contre
- * un appelant qui passerait un `bodyOverride` avec une donnée santé).
+ * entrée que des identifiants opaques — il est impossible d'y injecter
+ * une donnée santé par construction. Le title et le body sont toujours
+ * les constantes génériques `PUSH_TITLE_GENERIC` / `PUSH_BODY_GENERIC`
+ * (pas d'override en v1.0 : un override strict serait un no-op, un
+ * override libre ouvrirait une porte à l'injection). Si une localisation
+ * du body est nécessaire en v1.1+, ajouter une API dédiée validée en
+ * conformité.
  *
- * @throws {DomainError} `RM16_FORBIDDEN_CONTENT` si `householdId` /
- *   `notificationId` ne sont pas des UUID v4, ou si les overrides
- *   produisent un payload non safe.
+ * @throws {DomainError} `RM16_FORBIDDEN_CONTENT` si `householdId` ou
+ *   `notificationId` ne sont pas des UUID v4.
  */
 export function buildSafePushPayload(options: {
   readonly householdId: string;
   readonly notificationId: string;
-  readonly titleOverride?: string;
-  readonly bodyOverride?: string;
 }): SafePushPayload {
   const payload: SafePushPayload = {
-    title: options.titleOverride ?? PUSH_TITLE_GENERIC,
-    body: options.bodyOverride ?? PUSH_BODY_GENERIC,
+    title: PUSH_TITLE_GENERIC,
+    body: PUSH_BODY_GENERIC,
     householdId: options.householdId,
     notificationId: options.notificationId,
   };
@@ -199,25 +232,28 @@ export function validatePushPayload(
   const violations: PushPayloadViolation[] = [];
 
   // --- Title : doit être strictement générique ---
+  // Les `detail` ci-dessous ne contiennent JAMAIS la valeur offensante
+  // (title, body, keyword, PII, ID) pour éviter qu'un logger structuré
+  // ne fuite, via context d'erreur, la donnée même que RM16 protège.
   if (payload.title !== PUSH_TITLE_GENERIC) {
     violations.push({
       field: 'title',
       kind: 'title_not_generic',
-      detail: `title must be exactly "${PUSH_TITLE_GENERIC}", got "${payload.title}"`,
+      detail: 'title differs from the generic title',
     });
   }
 
-  // --- Body : longueur ---
+  // --- Body : longueur (garde-fou anti-payload structuré, pas limite APNs) ---
   if (payload.body.length > PUSH_BODY_MAX_LENGTH) {
     violations.push({
       field: 'body',
-      kind: 'non_ascii_length_exceeded',
-      detail: `body length ${payload.body.length} exceeds max ${PUSH_BODY_MAX_LENGTH}`,
+      kind: 'body_length_exceeded',
+      detail: `body exceeds max length ${PUSH_BODY_MAX_LENGTH}`,
     });
   }
 
   // --- Body : mots-clés interdits (FR + EN) ---
-  const lowerBody = payload.body.toLowerCase();
+  const lowerBody = payload.body.normalize('NFC').toLowerCase();
   const allKeywords = [...FORBIDDEN_PUSH_KEYWORDS_FR, ...FORBIDDEN_PUSH_KEYWORDS_EN];
   const seenKeywords = new Set<string>();
   for (const keyword of allKeywords) {
@@ -230,7 +266,7 @@ export function validatePushPayload(
       violations.push({
         field: 'body',
         kind: 'forbidden_keyword',
-        detail: `body contains forbidden keyword "${keyword}"`,
+        detail: 'body contains a forbidden medical keyword',
       });
     }
   }
@@ -242,11 +278,11 @@ export function validatePushPayload(
       if (normalized.length === 0) {
         continue;
       }
-      if (lowerBody.includes(normalized.toLowerCase())) {
+      if (lowerBody.includes(normalized.normalize('NFC').toLowerCase())) {
         violations.push({
           field: 'body',
           kind: 'suspected_pii',
-          detail: `body contains suspected PII "${normalized}"`,
+          detail: 'body contains a known sensitive string',
         });
       }
     }
@@ -257,14 +293,14 @@ export function validatePushPayload(
     violations.push({
       field: 'householdId',
       kind: 'invalid_household_id',
-      detail: `householdId is not a UUID v4: "${payload.householdId}"`,
+      detail: 'householdId is not a UUID v4',
     });
   }
   if (!UUID_V4_REGEX.test(payload.notificationId)) {
     violations.push({
       field: 'notificationId',
       kind: 'invalid_notification_id',
-      detail: `notificationId is not a UUID v4: "${payload.notificationId}"`,
+      detail: 'notificationId is not a UUID v4',
     });
   }
 
@@ -284,11 +320,12 @@ export function ensurePushPayloadSafe(
 ): void {
   const violations = validatePushPayload(payload, knownForbiddenStrings);
   if (violations.length > 0) {
+    // Le message et le context ne contiennent QUE des kinds/fields
+    // génériques — jamais la valeur offensante. Un reviewer peut
+    // reproduire l'erreur localement avec des fixtures synthétiques.
     throw new DomainError(
       'RM16_FORBIDDEN_CONTENT',
-      `push payload contains ${violations.length} violation(s): ${violations
-        .map((v) => `${v.field}/${v.kind}`)
-        .join(', ')}`,
+      `push payload has ${violations.length} safety violation(s)`,
       { violations },
     );
   }

--- a/packages/domain/src/rules/rm8-medical-report.test.ts
+++ b/packages/domain/src/rules/rm8-medical-report.test.ts
@@ -1,0 +1,679 @@
+import { describe, expect, it } from 'vitest';
+import type { Dose } from '../entities/dose';
+import { DomainError } from '../errors';
+import { buildMedicalReport, type MedicalReport } from './rm8-medical-report';
+
+const HOUSEHOLD_ID = 'h-1';
+const CHILD_ID = 'c-1';
+const PUMP_MAINTENANCE = 'pump-fond';
+const PUMP_RESCUE = 'pump-secours';
+const CAREGIVER = 'cg-1';
+
+function makeDose(override: Partial<Dose> = {}): Dose {
+  const base: Dose = {
+    id: 'd-1',
+    householdId: HOUSEHOLD_ID,
+    childId: CHILD_ID,
+    pumpId: PUMP_MAINTENANCE,
+    caregiverId: CAREGIVER,
+    type: 'maintenance',
+    status: 'confirmed',
+    source: 'manual',
+    dosesAdministered: 1,
+    administeredAtUtc: new Date('2026-04-10T08:00:00Z'),
+    recordedAtUtc: new Date('2026-04-10T08:00:01Z'),
+    symptoms: [],
+    circumstances: [],
+    freeFormTag: null,
+    voidedReason: null,
+  };
+  return { ...base, ...override };
+}
+
+function defaultPeriod(): { fromUtc: Date; toUtc: Date } {
+  return {
+    fromUtc: new Date('2026-04-01T00:00:00Z'),
+    toUtc: new Date('2026-04-30T23:59:59.999Z'),
+  };
+}
+
+describe('RM8 — buildMedicalReport (chemin nominal)', () => {
+  it('rapport vide → structure avec tableaux vides', () => {
+    const report = buildMedicalReport({
+      doses: [],
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.confirmedDoses).toEqual([]);
+    expect(report.voidedDoses).toEqual([]);
+    expect(report.rescueFrequencyByWeek).toEqual([]);
+    expect(report.symptomsEncountered).toEqual([]);
+    expect(report.circumstancesEncountered).toEqual([]);
+    expect(report.childFirstName).toBe('Mia');
+    expect(report.childYearOfBirth).toBe(2020);
+    expect(report.period.fromUtc).toEqual(new Date('2026-04-01T00:00:00Z'));
+    expect(report.period.toUtc).toEqual(new Date('2026-04-30T23:59:59.999Z'));
+  });
+
+  it('inclut les 3 prises confirmed de la période', () => {
+    const doses = [
+      makeDose({
+        id: 'd1',
+        administeredAtUtc: new Date('2026-04-10T08:00:00Z'),
+        dosesAdministered: 1,
+      }),
+      makeDose({
+        id: 'd2',
+        administeredAtUtc: new Date('2026-04-12T20:00:00Z'),
+        dosesAdministered: 2,
+      }),
+      makeDose({
+        id: 'd3',
+        administeredAtUtc: new Date('2026-04-15T09:00:00Z'),
+        dosesAdministered: 1,
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.confirmedDoses.map((d) => d.doseId)).toEqual(['d1', 'd2', 'd3']);
+  });
+
+  it('exclut les prises hors période (avant from, après to)', () => {
+    const doses = [
+      makeDose({ id: 'before', administeredAtUtc: new Date('2026-03-31T23:59:58Z') }),
+      makeDose({ id: 'inRange', administeredAtUtc: new Date('2026-04-10T08:00:00Z') }),
+      makeDose({ id: 'after', administeredAtUtc: new Date('2026-05-01T00:00:01Z') }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.confirmedDoses.map((d) => d.doseId)).toEqual(['inRange']);
+  });
+
+  it('bornes inclusives : fromUtc et toUtc pile sont dans la période', () => {
+    const period = defaultPeriod();
+    const doses = [
+      makeDose({ id: 'onFrom', administeredAtUtc: period.fromUtc }),
+      makeDose({ id: 'onTo', administeredAtUtc: period.toUtc }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period,
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.confirmedDoses.map((d) => d.doseId).sort()).toEqual(['onFrom', 'onTo']);
+  });
+
+  it('exclut les prises pending_review (pas confirmed)', () => {
+    const doses = [
+      makeDose({ id: 'confirmed-1' }),
+      makeDose({ id: 'pending-1', status: 'pending_review' }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.confirmedDoses.map((d) => d.doseId)).toEqual(['confirmed-1']);
+  });
+
+  it('prise voidée : exclue de confirmedDoses, incluse dans voidedDoses avec reason', () => {
+    const doses = [
+      makeDose({ id: 'ok' }),
+      makeDose({
+        id: 'voided-1',
+        status: 'voided',
+        voidedReason: 'erreur de saisie',
+        administeredAtUtc: new Date('2026-04-14T08:00:00Z'),
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.confirmedDoses.map((d) => d.doseId)).toEqual(['ok']);
+    expect(report.voidedDoses).toHaveLength(1);
+    const voided = report.voidedDoses[0];
+    if (voided === undefined) throw new Error('unreachable');
+    expect(voided.doseId).toBe('voided-1');
+    expect(voided.voidedReason).toBe('erreur de saisie');
+    expect(voided.originalAdministeredAtUtc).toEqual(new Date('2026-04-14T08:00:00Z'));
+  });
+
+  it('prise voidée sans reason → voidedReason=null conservé', () => {
+    const doses = [
+      makeDose({
+        id: 'voided-noreason',
+        status: 'voided',
+        voidedReason: null,
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.voidedDoses).toHaveLength(1);
+    const voided = report.voidedDoses[0];
+    if (voided === undefined) throw new Error('unreachable');
+    expect(voided.voidedReason).toBeNull();
+  });
+
+  it('voidedDoses hors période sont exclues aussi', () => {
+    const doses = [
+      makeDose({
+        id: 'voided-outside',
+        status: 'voided',
+        administeredAtUtc: new Date('2026-03-01T08:00:00Z'),
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.voidedDoses).toEqual([]);
+  });
+});
+
+describe('RM8 — ordre chronologique croissant', () => {
+  it('confirmedDoses triés par administeredAtUtc croissant même si input désordonné', () => {
+    const doses = [
+      makeDose({ id: 'mid', administeredAtUtc: new Date('2026-04-15T08:00:00Z') }),
+      makeDose({ id: 'early', administeredAtUtc: new Date('2026-04-05T08:00:00Z') }),
+      makeDose({ id: 'late', administeredAtUtc: new Date('2026-04-25T08:00:00Z') }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.confirmedDoses.map((d) => d.doseId)).toEqual(['early', 'mid', 'late']);
+  });
+
+  it('voidedDoses triés chronologiquement aussi', () => {
+    const doses = [
+      makeDose({
+        id: 'v-late',
+        status: 'voided',
+        administeredAtUtc: new Date('2026-04-25T08:00:00Z'),
+      }),
+      makeDose({
+        id: 'v-early',
+        status: 'voided',
+        administeredAtUtc: new Date('2026-04-05T08:00:00Z'),
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.voidedDoses.map((v) => v.doseId)).toEqual(['v-early', 'v-late']);
+  });
+});
+
+describe('RM8 — agrégation hebdomadaire secours (semaine ISO, lundi UTC)', () => {
+  it("regroupe 3 rescues d'une même semaine en un seul bucket", () => {
+    // 2026-04-06 lundi → 2026-04-12 dimanche (semaine ISO 15).
+    const doses = [
+      makeDose({
+        id: 'r1',
+        type: 'rescue',
+        pumpId: PUMP_RESCUE,
+        symptoms: ['cough'],
+        administeredAtUtc: new Date('2026-04-06T10:00:00Z'),
+      }),
+      makeDose({
+        id: 'r2',
+        type: 'rescue',
+        pumpId: PUMP_RESCUE,
+        symptoms: ['cough'],
+        administeredAtUtc: new Date('2026-04-08T15:00:00Z'),
+      }),
+      makeDose({
+        id: 'r3',
+        type: 'rescue',
+        pumpId: PUMP_RESCUE,
+        symptoms: ['cough'],
+        administeredAtUtc: new Date('2026-04-12T23:00:00Z'),
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.rescueFrequencyByWeek).toHaveLength(1);
+    const week = report.rescueFrequencyByWeek[0];
+    if (week === undefined) throw new Error('unreachable');
+    expect(week.weekStartUtc).toEqual(new Date('2026-04-06T00:00:00.000Z'));
+    expect(week.rescueCount).toBe(3);
+  });
+
+  it('lundi pile → début de semaine (00:00 UTC)', () => {
+    // 2026-04-06 est un lundi.
+    const doses = [
+      makeDose({
+        id: 'monday-00',
+        type: 'rescue',
+        pumpId: PUMP_RESCUE,
+        symptoms: ['cough'],
+        administeredAtUtc: new Date('2026-04-06T00:00:00Z'),
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    const week = report.rescueFrequencyByWeek[0];
+    if (week === undefined) throw new Error('unreachable');
+    expect(week.weekStartUtc).toEqual(new Date('2026-04-06T00:00:00.000Z'));
+  });
+
+  it('dimanche 23:59 → fin de cette semaine, pas la suivante', () => {
+    // 2026-04-12 est un dimanche → semaine du lundi 2026-04-06.
+    const doses = [
+      makeDose({
+        id: 'sunday-end',
+        type: 'rescue',
+        pumpId: PUMP_RESCUE,
+        symptoms: ['cough'],
+        administeredAtUtc: new Date('2026-04-12T23:59:59Z'),
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    const week = report.rescueFrequencyByWeek[0];
+    if (week === undefined) throw new Error('unreachable');
+    expect(week.weekStartUtc).toEqual(new Date('2026-04-06T00:00:00.000Z'));
+  });
+
+  it('2 semaines distinctes → 2 buckets triés chronologiquement', () => {
+    const doses = [
+      makeDose({
+        id: 'r-w2',
+        type: 'rescue',
+        pumpId: PUMP_RESCUE,
+        symptoms: ['cough'],
+        administeredAtUtc: new Date('2026-04-20T10:00:00Z'), // semaine 16 (lundi 2026-04-20)
+      }),
+      makeDose({
+        id: 'r-w1',
+        type: 'rescue',
+        pumpId: PUMP_RESCUE,
+        symptoms: ['cough'],
+        administeredAtUtc: new Date('2026-04-07T10:00:00Z'), // semaine 15 (lundi 2026-04-06)
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.rescueFrequencyByWeek).toHaveLength(2);
+    expect(report.rescueFrequencyByWeek[0]?.weekStartUtc).toEqual(
+      new Date('2026-04-06T00:00:00.000Z'),
+    );
+    expect(report.rescueFrequencyByWeek[1]?.weekStartUtc).toEqual(
+      new Date('2026-04-20T00:00:00.000Z'),
+    );
+  });
+
+  it("n'inclut pas les prises maintenance dans la fréquence secours", () => {
+    const doses = [
+      makeDose({
+        id: 'maint',
+        type: 'maintenance',
+        administeredAtUtc: new Date('2026-04-07T10:00:00Z'),
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.rescueFrequencyByWeek).toEqual([]);
+  });
+
+  it("n'inclut pas les rescues voidées/pending dans la fréquence", () => {
+    const doses = [
+      makeDose({
+        id: 'r-confirmed',
+        type: 'rescue',
+        pumpId: PUMP_RESCUE,
+        symptoms: ['cough'],
+        administeredAtUtc: new Date('2026-04-07T10:00:00Z'),
+      }),
+      makeDose({
+        id: 'r-voided',
+        type: 'rescue',
+        pumpId: PUMP_RESCUE,
+        status: 'voided',
+        administeredAtUtc: new Date('2026-04-07T11:00:00Z'),
+      }),
+      makeDose({
+        id: 'r-pending',
+        type: 'rescue',
+        pumpId: PUMP_RESCUE,
+        status: 'pending_review',
+        administeredAtUtc: new Date('2026-04-07T12:00:00Z'),
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.rescueFrequencyByWeek).toHaveLength(1);
+    expect(report.rescueFrequencyByWeek[0]?.rescueCount).toBe(1);
+  });
+});
+
+describe('RM8 — symptômes / circonstances dé-dupliqués', () => {
+  it('symptômes uniques, même ordre que première occurrence', () => {
+    const doses = [
+      makeDose({
+        id: 'r1',
+        type: 'rescue',
+        symptoms: ['cough', 'wheezing'],
+        administeredAtUtc: new Date('2026-04-05T08:00:00Z'),
+      }),
+      makeDose({
+        id: 'r2',
+        type: 'rescue',
+        symptoms: ['cough', 'shortness_of_breath'],
+        administeredAtUtc: new Date('2026-04-10T08:00:00Z'),
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.symptomsEncountered).toEqual(['cough', 'wheezing', 'shortness_of_breath']);
+  });
+
+  it('circonstances uniques, même ordre que première occurrence', () => {
+    const doses = [
+      makeDose({
+        id: 'r1',
+        type: 'rescue',
+        symptoms: ['cough'],
+        circumstances: ['exercise', 'cold_air'],
+        administeredAtUtc: new Date('2026-04-05T08:00:00Z'),
+      }),
+      makeDose({
+        id: 'r2',
+        type: 'rescue',
+        symptoms: ['cough'],
+        circumstances: ['exercise', 'allergen'],
+        administeredAtUtc: new Date('2026-04-10T08:00:00Z'),
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.circumstancesEncountered).toEqual(['exercise', 'cold_air', 'allergen']);
+  });
+
+  it('ignore les symptômes/circonstances des prises exclues (voidées / hors période)', () => {
+    const doses = [
+      makeDose({
+        id: 'r-voided',
+        type: 'rescue',
+        status: 'voided',
+        symptoms: ['cough'],
+        circumstances: ['exercise'],
+        administeredAtUtc: new Date('2026-04-05T08:00:00Z'),
+      }),
+      makeDose({
+        id: 'r-out',
+        type: 'rescue',
+        symptoms: ['wheezing'],
+        circumstances: ['night'],
+        administeredAtUtc: new Date('2026-05-15T08:00:00Z'), // hors période
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(report.symptomsEncountered).toEqual([]);
+    expect(report.circumstancesEncountered).toEqual([]);
+  });
+});
+
+describe('RM8 — ConfirmedDoseSummary : champs copiés intégralement', () => {
+  it('copie type, dosesAdministered, pumpId, symptoms, circumstances, freeFormTag', () => {
+    const doses = [
+      makeDose({
+        id: 'r-detailed',
+        type: 'rescue',
+        pumpId: PUMP_RESCUE,
+        dosesAdministered: 2,
+        symptoms: ['cough', 'wheezing'],
+        circumstances: ['cold_air'],
+        freeFormTag: 'après sport',
+        administeredAtUtc: new Date('2026-04-10T08:00:00Z'),
+      }),
+    ];
+
+    const report = buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    const summary = report.confirmedDoses[0];
+    if (summary === undefined) throw new Error('unreachable');
+    expect(summary.type).toBe('rescue');
+    expect(summary.pumpId).toBe(PUMP_RESCUE);
+    expect(summary.dosesAdministered).toBe(2);
+    expect(summary.symptoms).toEqual(['cough', 'wheezing']);
+    expect(summary.circumstances).toEqual(['cold_air']);
+    expect(summary.freeFormTag).toBe('après sport');
+    expect(summary.administeredAtUtc).toEqual(new Date('2026-04-10T08:00:00Z'));
+  });
+});
+
+describe('RM8 — validation enfant', () => {
+  it('lève RM8_INVALID_CHILD si prénom vide', () => {
+    try {
+      buildMedicalReport({
+        doses: [],
+        period: defaultPeriod(),
+        childFirstName: '',
+        childYearOfBirth: 2020,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM8_INVALID_CHILD');
+    }
+  });
+
+  it('lève RM8_INVALID_CHILD si prénom whitespace-only', () => {
+    expect(() =>
+      buildMedicalReport({
+        doses: [],
+        period: defaultPeriod(),
+        childFirstName: '   ',
+        childYearOfBirth: 2020,
+      }),
+    ).toThrow(DomainError);
+  });
+
+  it('lève RM8_INVALID_CHILD si année < 1900', () => {
+    expect(() =>
+      buildMedicalReport({
+        doses: [],
+        period: defaultPeriod(),
+        childFirstName: 'Mia',
+        childYearOfBirth: 1899,
+      }),
+    ).toThrow(DomainError);
+  });
+
+  it('lève RM8_INVALID_CHILD si année > année de la période (to)', () => {
+    expect(() =>
+      buildMedicalReport({
+        doses: [],
+        period: defaultPeriod(),
+        childFirstName: 'Mia',
+        childYearOfBirth: 2099, // la période est en 2026
+      }),
+    ).toThrow(DomainError);
+  });
+
+  it('accepte une année pile à la borne supérieure (année de period.toUtc)', () => {
+    expect(() =>
+      buildMedicalReport({
+        doses: [],
+        period: defaultPeriod(),
+        childFirstName: 'Mia',
+        childYearOfBirth: 2026,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('RM8 — validation période', () => {
+  it('lève RM8_INVALID_PERIOD si fromUtc > toUtc', () => {
+    try {
+      buildMedicalReport({
+        doses: [],
+        period: {
+          fromUtc: new Date('2026-05-01T00:00:00Z'),
+          toUtc: new Date('2026-04-01T00:00:00Z'),
+        },
+        childFirstName: 'Mia',
+        childYearOfBirth: 2020,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM8_INVALID_PERIOD');
+    }
+  });
+
+  it('accepte fromUtc = toUtc (rapport instantané, valide)', () => {
+    expect(() =>
+      buildMedicalReport({
+        doses: [],
+        period: {
+          fromUtc: new Date('2026-04-15T12:00:00Z'),
+          toUtc: new Date('2026-04-15T12:00:00Z'),
+        },
+        childFirstName: 'Mia',
+        childYearOfBirth: 2020,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('RM8 — pureté (inputs non mutés)', () => {
+  it('inputs doses non mutés', () => {
+    const doses = [makeDose({ id: 'd1' })];
+    const snapshot = JSON.stringify(doses);
+
+    buildMedicalReport({
+      doses,
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    expect(JSON.stringify(doses)).toBe(snapshot);
+  });
+});
+
+describe('RM8 — ligne rouge dispositif médical (type interdit)', () => {
+  it('aucun champ recommendation / interpretation / controlScore / diagnosis dans le type', () => {
+    const report: MedicalReport = buildMedicalReport({
+      doses: [],
+      period: defaultPeriod(),
+      childFirstName: 'Mia',
+      childYearOfBirth: 2020,
+    });
+
+    // Cast en Record pour détecter un champ imprévu côté runtime.
+    const asRecord = report as unknown as Record<string, unknown>;
+    expect(asRecord['recommendation']).toBeUndefined();
+    expect(asRecord['interpretation']).toBeUndefined();
+    expect(asRecord['controlScore']).toBeUndefined();
+    expect(asRecord['diagnosis']).toBeUndefined();
+    expect(asRecord['alert']).toBeUndefined();
+    expect(asRecord['advice']).toBeUndefined();
+  });
+});

--- a/packages/domain/src/rules/rm8-medical-report.ts
+++ b/packages/domain/src/rules/rm8-medical-report.ts
@@ -1,0 +1,291 @@
+import type { Circumstance, Dose, Symptom } from '../entities/dose';
+import { DomainError } from '../errors';
+
+/**
+ * RM8 — Rapport médecin structuré (SPECS §4 RM8 + §W9 export rapport).
+ *
+ * Ce module produit la **structure canonique** d'un rapport médecin à
+ * partir d'un jeu de prises. Aucune I/O ; le rendu PDF est exécuté côté
+ * `apps/api` qui consomme cette structure. RM24 en calcule ensuite le pied
+ * d'intégrité (hash SHA-256).
+ *
+ * ## Contenu imposé (SPECS §4 RM8 ligne 332)
+ *
+ * > « Le rapport médecin inclut toutes les prises `confirmed` (voidées
+ * > signalées séparément) sur la plage demandée + un graphique de
+ * > fréquence secours/semaine + la liste des symptômes et circonstances. »
+ *
+ * - `confirmedDoses` : toutes les prises confirmées de la période, triées
+ *   chronologiquement croissant par `administeredAtUtc` (RM14 autorité
+ *   serveur).
+ * - `voidedDoses` : prises voidées signalées séparément (dans leur propre
+ *   section), avec `voidedReason` pour que le praticien juge du contexte.
+ * - `rescueFrequencyByWeek` : agrégation hebdomadaire (semaine ISO,
+ *   lundi-dimanche UTC) du **nombre** de prises rescue confirmées —
+ *   PAS le `dosesAdministered`, on compte les événements (chaque
+ *   déclenchement de pompe est une crise potentielle).
+ * - `symptomsEncountered` : union des symptômes apparus au moins une fois
+ *   dans les prises confirmées de la période, dé-dupliqués, ordre de
+ *   première occurrence chronologique.
+ * - `circumstancesEncountered` : idem pour les circonstances.
+ *
+ * ## Contenu interdit (ligne rouge dispositif médical)
+ *
+ * Ce module **ne produit pas**, et la structure de sortie **ne permet
+ * pas de porter** :
+ *
+ * - AUCUNE recommandation de dose (pas de champ `recommendation`)
+ * - AUCUNE interprétation de contrôle (pas de champ `interpretation`,
+ *   `controlScore`, `asthmaControlTest`)
+ * - AUCUN diagnostic (pas de champ `diagnosis`)
+ * - AUCUN message d'alerte type « appelez votre médecin » (pas de champ
+ *   `alert` / `advice`)
+ *
+ * Un test explicite (`ligne rouge dispositif médical`) verrouille
+ * l'absence de ces champs au runtime. Toute extension doit repasser par
+ * `kz-conformite`.
+ *
+ * ## Frontières de période
+ *
+ * La période est **inclusive aux deux bornes** :
+ * `period.fromUtc <= administeredAtUtc <= period.toUtc`. Choix délibéré —
+ * SPECS §RM8 dit « plage demandée » sans préciser ; l'inclusivité est
+ * plus intuitive pour un praticien qui demande « du 1er au 30 avril » et
+ * s'attend à voir ces deux jours complets inclus. L'appelant qui veut une
+ * semaine civile passera `to = dimanche 23:59:59.999`.
+ *
+ * ## Définition de semaine
+ *
+ * Les semaines sont **ISO 8601** : lundi 00:00:00.000 UTC → dimanche
+ * 23:59:59.999 UTC. Le `weekStartUtc` est toujours un lundi à minuit UTC.
+ * Pas d'adaptation au fuseau du praticien — un rapport généré à Montréal
+ * (UTC-4) pour un enfant à Paris (UTC+2) verrait sinon deux semaines
+ * différentes selon le locuteur. UTC est la seule heure stable.
+ *
+ * ## Protection des données enfant
+ *
+ * Le rapport porte uniquement `childFirstName` + `childYearOfBirth`
+ * (pas de date complète, pas de nom de famille, pas d'ID). Ce sont les
+ * seules données nécessaires pour qu'un praticien identifie son patient
+ * sans exposer plus. L'année de naissance suffit à l'anamnèse
+ * (« enfant de 5-6 ans ») — la date exacte n'apporte rien de clinique
+ * et serait une donnée nominative superflue.
+ */
+
+/** Période demandée pour le rapport, bornes **inclusives** aux deux extrémités. */
+export interface MedicalReportPeriod {
+  readonly fromUtc: Date;
+  readonly toUtc: Date;
+}
+
+/** Agrégat hebdomadaire du nombre de prises rescue. */
+export interface WeeklyRescueFrequency {
+  /** Lundi 00:00:00.000 UTC de la semaine ISO. */
+  readonly weekStartUtc: Date;
+  /** Nombre de prises rescue confirmées dans la semaine. */
+  readonly rescueCount: number;
+}
+
+/**
+ * Résumé d'une prise confirmée tel qu'imprimé dans le rapport. Contient
+ * uniquement des champs factuels — ni recommandation, ni interprétation.
+ */
+export interface ConfirmedDoseSummary {
+  readonly doseId: string;
+  readonly type: 'maintenance' | 'rescue';
+  readonly administeredAtUtc: Date;
+  readonly dosesAdministered: number;
+  readonly pumpId: string;
+  readonly symptoms: ReadonlyArray<Symptom>;
+  readonly circumstances: ReadonlyArray<Circumstance>;
+  readonly freeFormTag: string | null;
+}
+
+/** Résumé d'une prise voidée signalée séparément dans le rapport. */
+export interface VoidedDoseSummary {
+  readonly doseId: string;
+  readonly voidedReason: string | null;
+  readonly originalAdministeredAtUtc: Date;
+}
+
+/** Rapport médecin canonique. Structure volontairement restreinte (pas de DM). */
+export interface MedicalReport {
+  readonly period: MedicalReportPeriod;
+  readonly childFirstName: string;
+  readonly childYearOfBirth: number;
+  readonly confirmedDoses: ReadonlyArray<ConfirmedDoseSummary>;
+  readonly voidedDoses: ReadonlyArray<VoidedDoseSummary>;
+  readonly rescueFrequencyByWeek: ReadonlyArray<WeeklyRescueFrequency>;
+  readonly symptomsEncountered: ReadonlyArray<Symptom>;
+  readonly circumstancesEncountered: ReadonlyArray<Circumstance>;
+}
+
+/** Borne inférieure plausible pour une année de naissance (grands-parents inclus). */
+const MIN_BIRTH_YEAR = 1900;
+
+/**
+ * RM8 — construit la structure du rapport médecin pour une période donnée.
+ *
+ * Fonction **pure** : aucune lecture d'horloge, aucun I/O, aucune mutation
+ * des inputs. Déterministe pour un même `doses` + `period`.
+ *
+ * @throws {DomainError} `RM8_INVALID_PERIOD` si `fromUtc > toUtc`.
+ * @throws {DomainError} `RM8_INVALID_CHILD` si `childFirstName` est vide
+ *   ou whitespace-only, ou si `childYearOfBirth` est hors [1900, année de
+ *   `period.toUtc`].
+ */
+export function buildMedicalReport(options: {
+  readonly doses: readonly Dose[];
+  readonly period: MedicalReportPeriod;
+  readonly childFirstName: string;
+  readonly childYearOfBirth: number;
+}): MedicalReport {
+  const { doses, period, childFirstName, childYearOfBirth } = options;
+
+  // --- Validation période ---
+  if (period.fromUtc.getTime() > period.toUtc.getTime()) {
+    throw new DomainError(
+      'RM8_INVALID_PERIOD',
+      `period.fromUtc (${period.fromUtc.toISOString()}) must be <= period.toUtc (${period.toUtc.toISOString()}).`,
+    );
+  }
+
+  // --- Validation enfant ---
+  if (childFirstName.trim().length === 0) {
+    throw new DomainError('RM8_INVALID_CHILD', 'childFirstName must be a non-empty string.');
+  }
+  const periodEndYear = period.toUtc.getUTCFullYear();
+  if (
+    !Number.isInteger(childYearOfBirth) ||
+    childYearOfBirth < MIN_BIRTH_YEAR ||
+    childYearOfBirth > periodEndYear
+  ) {
+    throw new DomainError(
+      'RM8_INVALID_CHILD',
+      `childYearOfBirth must be an integer in [${MIN_BIRTH_YEAR}, ${periodEndYear}], got ${childYearOfBirth}.`,
+    );
+  }
+
+  // --- Filtrage période + statut ---
+  const fromMs = period.fromUtc.getTime();
+  const toMs = period.toUtc.getTime();
+  const inPeriod = (d: Dose): boolean => {
+    const t = d.administeredAtUtc.getTime();
+    return t >= fromMs && t <= toMs;
+  };
+
+  const dosesInPeriod = doses.filter(inPeriod);
+
+  const confirmedInPeriod = dosesInPeriod
+    .filter((d) => d.status === 'confirmed')
+    .slice()
+    .sort((a, b) => a.administeredAtUtc.getTime() - b.administeredAtUtc.getTime());
+
+  const voidedInPeriod = dosesInPeriod
+    .filter((d) => d.status === 'voided')
+    .slice()
+    .sort((a, b) => a.administeredAtUtc.getTime() - b.administeredAtUtc.getTime());
+
+  // --- Confirmed summaries ---
+  const confirmedDoses: ConfirmedDoseSummary[] = confirmedInPeriod.map((d) => ({
+    doseId: d.id,
+    type: d.type,
+    administeredAtUtc: d.administeredAtUtc,
+    dosesAdministered: d.dosesAdministered,
+    pumpId: d.pumpId,
+    symptoms: d.symptoms,
+    circumstances: d.circumstances,
+    freeFormTag: d.freeFormTag,
+  }));
+
+  // --- Voided summaries ---
+  const voidedDoses: VoidedDoseSummary[] = voidedInPeriod.map((d) => ({
+    doseId: d.id,
+    voidedReason: d.voidedReason,
+    originalAdministeredAtUtc: d.administeredAtUtc,
+  }));
+
+  // --- Rescue frequency by week (ISO, lundi UTC) ---
+  const rescueFrequencyByWeek = aggregateRescuePerWeek(confirmedInPeriod);
+
+  // --- Symptoms / circumstances uniques en ordre de première occurrence ---
+  const symptomsEncountered = uniqueInOrder<Symptom>(
+    confirmedInPeriod.flatMap((d) => [...d.symptoms]),
+  );
+  const circumstancesEncountered = uniqueInOrder<Circumstance>(
+    confirmedInPeriod.flatMap((d) => [...d.circumstances]),
+  );
+
+  return {
+    period: { fromUtc: period.fromUtc, toUtc: period.toUtc },
+    childFirstName,
+    childYearOfBirth,
+    confirmedDoses,
+    voidedDoses,
+    rescueFrequencyByWeek,
+    symptomsEncountered,
+    circumstancesEncountered,
+  };
+}
+
+/**
+ * Dé-duplique en préservant l'ordre de première occurrence. Pure.
+ */
+function uniqueInOrder<T>(items: readonly T[]): T[] {
+  const seen = new Set<T>();
+  const out: T[] = [];
+  for (const item of items) {
+    if (!seen.has(item)) {
+      seen.add(item);
+      out.push(item);
+    }
+  }
+  return out;
+}
+
+/**
+ * Retourne le début de la semaine ISO (lundi 00:00:00.000 UTC) qui
+ * contient la date fournie. Pour une date un lundi à 00:00 UTC, retourne
+ * exactement cette date. Pour un dimanche à 23:59:59 UTC, retourne le
+ * lundi précédent à 00:00 UTC.
+ *
+ * Implémentation : `getUTCDay()` renvoie 0 pour dimanche, 1 pour lundi,
+ * etc. On calcule l'offset vers le lundi précédent (0 si lundi, 6 si
+ * dimanche, etc.) puis on recule la date de cet offset à minuit UTC.
+ */
+function startOfWeekUtc(date: Date): Date {
+  const day = date.getUTCDay();
+  const daysSinceMonday = (day + 6) % 7; // lundi=0, ..., dimanche=6
+  const d = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate() - daysSinceMonday),
+  );
+  return d;
+}
+
+/**
+ * Compte le nombre de prises rescue par semaine ISO. Retourne une liste
+ * triée chronologiquement croissante par `weekStartUtc`. Seules les prises
+ * de type `rescue` contribuent ; les maintenance sont ignorées.
+ */
+function aggregateRescuePerWeek(
+  confirmedDoses: readonly Dose[],
+): ReadonlyArray<WeeklyRescueFrequency> {
+  const buckets = new Map<number, { weekStartUtc: Date; rescueCount: number }>();
+  for (const dose of confirmedDoses) {
+    if (dose.type !== 'rescue') {
+      continue;
+    }
+    const weekStart = startOfWeekUtc(dose.administeredAtUtc);
+    const key = weekStart.getTime();
+    const existing = buckets.get(key);
+    if (existing) {
+      buckets.set(key, {
+        weekStartUtc: existing.weekStartUtc,
+        rescueCount: existing.rescueCount + 1,
+      });
+    } else {
+      buckets.set(key, { weekStartUtc: weekStart, rescueCount: 1 });
+    }
+  }
+  return [...buckets.values()].sort((a, b) => a.weekStartUtc.getTime() - b.weekStartUtc.getTime());
+}

--- a/packages/domain/src/rules/rm8-medical-report.ts
+++ b/packages/domain/src/rules/rm8-medical-report.ts
@@ -154,15 +154,22 @@ export function buildMedicalReport(options: {
   if (childFirstName.trim().length === 0) {
     throw new DomainError('RM8_INVALID_CHILD', 'childFirstName must be a non-empty string.');
   }
-  const periodEndYear = period.toUtc.getUTCFullYear();
+  // Borne haute : année de fin de période + 1 an de tolérance, pour
+  // couvrir les cas limites (enfant prématuré né juste après la fin
+  // d'une période rétrospective, cf. revue kz-securite MIN-3). La borne
+  // basse (1900) reste l'anti-valeur aberrante. La valeur invalide
+  // elle-même reste hors du message d'erreur — pseudonymisation cohérente
+  // avec la règle CLAUDE.md « aucune donnée nominative dans les logs ».
+  const maxBirthYear = period.toUtc.getUTCFullYear() + 1;
   if (
     !Number.isInteger(childYearOfBirth) ||
     childYearOfBirth < MIN_BIRTH_YEAR ||
-    childYearOfBirth > periodEndYear
+    childYearOfBirth > maxBirthYear
   ) {
     throw new DomainError(
       'RM8_INVALID_CHILD',
-      `childYearOfBirth must be an integer in [${MIN_BIRTH_YEAR}, ${periodEndYear}], got ${childYearOfBirth}.`,
+      'childYearOfBirth must be an integer within the allowed range.',
+      { minYear: MIN_BIRTH_YEAR, maxYear: maxBirthYear },
     );
   }
 


### PR DESCRIPTION
## Résumé

Neuvième lot de travaux dans le monorepo Kinhale. Lot **D1 — compliance & ligne rouge DM** :

- **RM8** — Rapport médecin structuré, sans recommandation ni interprétation
- **RM16** — Validation que les payloads push APNs/FCM ne contiennent AUCUNE donnée santé (défense structurelle CA18)

**77 nouveaux tests** (29 RM8 + 48 RM16). Total domain : 307 → **385 tests** tous verts.

## Workflow pré-PR appliqué — double revue

Conforme à `CLAUDE.md §Méthodologie` :

- **kz-review** (qualité/design) → APPROUVÉ AVEC MINEURS, 0 MAJEUR
- **kz-securite** (RM16 touche la sortie push externe) → APPROUVÉ AVEC MINEURS, 0 GRAVE, 0 MAJEUR

Corrections intégrées dans le commit `9b7f6d9` :

### Sécurité (kz-securite)
- **MIN-1 critique** : les `DomainError.context.violations[].detail` stockaient **le contenu offensant en clair** (keyword médical, prénom enfant, body complet, title altéré, UUID invalide). Un logger structuré aurait fuité la donnée même que RM16 protège. **Correctif : tous les `detail` sont désormais non-révélateurs**. Test dédié `NE FUIT PAS le body, keyword, PII ni les IDs` verrouille cette garantie par sérialisation JSON + `not.toContain`.
- **MIN-2** : enrichissement `FORBIDDEN_PUSH_KEYWORDS_*` avec les mots métier Kinhale prioritaires (FR: asthme, ventoline, salbutamol, oppression, médicament, médecin, hôpital, urgences, antibio ; EN: asthma, ventolin, albuterol, tightness, medication, doctor, hospital, emergency).
- **MIN-3** : borne haute `childYearOfBirth` RM8 assouplie (fin de période + 1 an de tolérance) pour couvrir le cas enfant prématuré né juste après la période d'un rapport rétrospectif.
- **Bonus** : normalisation NFC sur le body + knownForbiddenStrings avant détection (ferme la porte d'évasion par NFD).

### Qualité (kz-review)
- **M1** : renommage `non_ascii_length_exceeded` → `body_length_exceeded` (nom trompeur — check de longueur, pas d'octets ASCII).
- **M2** : suppression de `titleOverride` et `bodyOverride` (dead API — seul override valide = constante → no-op).
- **M3** : message RM8_INVALID_CHILD ne contient plus l'année de naissance invalide (donnée nominative) ; déplacée vers `context: { minYear, maxYear }`.

## API RM8

```ts
export interface MedicalReport {
  readonly period: { fromUtc: Date; toUtc: Date };
  readonly childFirstName: string;
  readonly childYearOfBirth: number;
  readonly confirmedDoses: ReadonlyArray<ConfirmedDoseSummary>;
  readonly voidedDoses: ReadonlyArray<VoidedDoseSummary>;
  readonly rescueFrequencyByWeek: ReadonlyArray<WeeklyRescueFrequency>;
  readonly symptomsEncountered: ReadonlyArray<string>;
  readonly circumstancesEncountered: ReadonlyArray<string>;
}

export function buildMedicalReport({doses, period, childFirstName, childYearOfBirth}): MedicalReport;
```

**Ligne rouge DM verrouillée structurellement** :
- Le type `MedicalReport` n'a **aucun** champ `recommendation`, `interpretation`, `controlScore`, `diagnosis`, `alert`, `advice`
- Test runtime `as Record<string, unknown>` vérifie l'absence effective au runtime — toute régression qui ajouterait un champ DM casserait le test

**Minimisation données enfant** : uniquement `firstName` + `yearOfBirth` (pas de nom de famille, pas de date complète, pas d'ID).

## API RM16

```ts
export const PUSH_TITLE_GENERIC = 'Kinhale';
export const PUSH_BODY_GENERIC = 'Nouvelle activité';
export const FORBIDDEN_PUSH_KEYWORDS_FR: ReadonlyArray<string>;  // 30 mots
export const FORBIDDEN_PUSH_KEYWORDS_EN: ReadonlyArray<string>;  // 25 mots

export function buildSafePushPayload({householdId, notificationId}): SafePushPayload;
export function validatePushPayload(payload, knownForbiddenStrings?): ReadonlyArray<PushPayloadViolation>;
export function ensurePushPayloadSafe(payload, knownForbiddenStrings?): void;
```

**Design safe-by-construction + validation défensive** :
- `buildSafePushPayload` applique `ensurePushPayloadSafe` en interne — tout payload retourné est garanti safe
- Pas d'override en v1.0 : une API de localisation dédiée viendra si nécessaire
- `validatePushPayload` détecte : mots-clés médicaux FR/EN, PII dynamique (prénom enfant, nom pompe), title non-générique, longueur excessive, UUID non-v4
- **Privacy par design** : aucun `detail` ne contient la valeur offensante — verrouille le scenario ironique d'une règle anti-fuite qui fuite via ses propres logs

## Codes d'erreur ajoutés

- `RM8_INVALID_PERIOD` — `fromUtc > toUtc`
- `RM8_INVALID_CHILD` — firstName vide ou yearOfBirth hors range (context `{minYear, maxYear}`, jamais la valeur invalide)
- `RM16_FORBIDDEN_CONTENT` — violations dans le payload push (context : tableau violations avec detail non-révélateur)

## Choix sémantiques verrouillés

- **RM8 frontières période** : `from <= administered <= to` (inclusive aux deux bornes)
- **RM8 semaine ISO** : lundi-dimanche UTC. Pas d'adaptation fuseau local (cohérent RM14 autorité serveur). Un parent en Nouvelle-Calédonie voit un léger décalage par rapport à sa semaine civile — choix UX assumé.
- **RM8 tri chronologique** : par `administeredAtUtc` (cohérent RM14)
- **RM8 dé-duplication** : symptômes/circonstances dédupliqués en ordre de première occurrence, stable pour RM24 hash
- **RM8 `childYearOfBirth` max** : `period.toUtc.getUTCFullYear() + 1` (tolérance prématuré)
- **RM16 détection** : substring case-insensitive + normalisation NFC — limitations documentées
- **RM16 title strict** : exactement `Kinhale` (sinon fuit que l'app est de santé)
- **RM16 body max** : 200 chars, garde-fou anti-payload structuré (pas limite APNs)

## Vérifications

- [x] `pnpm --filter @kinhale/domain typecheck` : vert
- [x] `pnpm --filter @kinhale/domain lint` : vert
- [x] `pnpm --filter @kinhale/domain test` : **385/385** en < 100 ms
- [x] `pnpm format:check` : vert
- [x] `pnpm lint:root` : vert (checklist apprise suite au fail CI KIN-012)
- [x] **kz-review** passé pré-PR : 0 MAJEUR
- [x] **kz-securite** passé pré-PR : 0 GRAVE, 0 MAJEUR
- [x] Ligne rouge DM verrouillée structurellement (type MedicalReport sans champs interprétatifs + test runtime)
- [x] Aucune donnée santé dans le context ou le message des DomainError
- [x] Aucune chaîne UI hardcodée (constantes canoniques documentées comme source)
- [x] Pas de `Date.now()`, `Math.random()`, `console.*`

## Points de vigilance pour la revue humaine

1. **Privacy par design RM16** : la garantie « le context d'erreur ne fuite rien » est testée mais à vérifier côté `apps/api` : aucun logger ne doit sérialiser tout l'objet DomainError sans scrubbing. La règle CLAUDE.md logger pseudonymisé applique.
2. **Test bout-en-bout CA18** : RM16 est la brique domaine, mais un test d'intégration côté `apps/api` interceptant le vrai payload envoyé à APNs/FCM est recommandé (REC-1 de kz-securite).
3. **Branded type `SafePushPayload`** : suggestion kz-securite REC-3 pour une future PR — empêcher structurellement de créer un `SafePushPayload` sans passer par `buildSafePushPayload`.
4. **ADR « Push opacity »** : formaliser dans un ADR les limites de RM16 (protège contre l'étourderie dev, pas contre un attaquant avec privilège code).
5. **`DISCLAIMER_TEXT_EN`** (hors scope de cette PR) — rappel de la revue KIN-012 : traduction à valider par un juriste avant release.

## Taille de PR

1 648 insertions (dont ~586 de prod + ~1 062 de tests, ratio ~1.8x). Au-dessus des 400 lignes CLAUDE.md mais justifiée : **2 règles d'une même famille compliance, dont une avec 48 tests (RM16 = défense en profondeur CA18)**. Découper aurait multiplié les cycles de revue sans gain.

## Avancement v1.0 domaine

**20/28 règles après merge (71%)** : RM1-8, RM14, RM15, RM16, RM17, RM18, RM21, RM22, RM24, RM25, RM26, RM27, RM28.

**8 restantes** : RM9, RM10, RM11, RM12, RM13, RM19, RM20, RM23.

## Ce qui arrive ensuite

- **Lot D4 — Foyer & enfant** : RM9 (1 enfant/foyer v1.0) + RM13 (1 profil enfant actif) — petit lot rapide
- **Lot D2 — Lifecycle pompe** : RM19 + RM20 (offline 30j)
- **Lot D3 — Rôles & sessions** : RM10, RM11, RM12
- **Lot E — Géolocalisation** : RM23 (opt-in)

## Test plan

- [ ] Cloner + `pnpm install` + `pnpm test` → 385/385 vert
- [ ] `pnpm lint:root` + `pnpm format:check` → verts
- [ ] Valider le design safe-by-construction de RM16 (zero override en v1.0)
- [ ] Valider la décision UTC pour l'agrégation hebdomadaire RM8
- [ ] Statuer sur la création d'un ADR « Push opacity »

---

Refs : KIN-013

🤖 Generated with [Claude Code](https://claude.com/claude-code)