### PR TITLE
feat(KIN-014): RM9 consentement CGU/PC + RM13 un enfant par foyer

### DIFF
--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -80,7 +80,12 @@ export type DomainErrorCode =
   | 'RM9_INVALID_VERSION_FORMAT'
   /** RM9 — `acceptedAtUtc` strictement postérieur à `nowUtc` au-delà de la tolérance NTP. */
   | 'RM9_INVALID_ACCEPTANCE_TIMESTAMP'
-  /** RM9 — version acceptée strictement supérieure à la version publiée (suspicieux). */
+  /**
+   * RM9 — incohérence de flux entre acceptance et version courante :
+   * mismatch de `kind` (TOS vs PP), major accepté supérieur à major
+   * courant (suspicieux), ou major accepté inférieur (ré-acceptation
+   * requise avant de ré-écrire une acceptance du même major).
+   */
   | 'RM9_VERSION_MISMATCH'
   /** RM13 — tentative d'ajouter un enfant à un foyer qui a déjà atteint la limite v1.0 (1). */
   | 'RM13_CHILD_LIMIT_REACHED';

--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -75,4 +75,12 @@ export type DomainErrorCode =
   /** RM8 — enfant invalide (prénom vide ou année de naissance aberrante). */
   | 'RM8_INVALID_CHILD'
   /** RM16 — payload push contient du contenu interdit (mot-clé santé / PII / titre non générique). */
-  | 'RM16_FORBIDDEN_CONTENT';
+  | 'RM16_FORBIDDEN_CONTENT'
+  /** RM9 — version semver invalide (format `MAJOR.MINOR.PATCH` requis, sans préfixe). */
+  | 'RM9_INVALID_VERSION_FORMAT'
+  /** RM9 — `acceptedAtUtc` strictement postérieur à `nowUtc` au-delà de la tolérance NTP. */
+  | 'RM9_INVALID_ACCEPTANCE_TIMESTAMP'
+  /** RM9 — version acceptée strictement supérieure à la version publiée (suspicieux). */
+  | 'RM9_VERSION_MISMATCH'
+  /** RM13 — tentative d'ajouter un enfant à un foyer qui a déjà atteint la limite v1.0 (1). */
+  | 'RM13_CHILD_LIMIT_REACHED';

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -1,5 +1,23 @@
 export { ensureAtLeastOneAdmin } from './rm1-admin-guarantee';
 export {
+  ensureAcceptanceValid,
+  evaluateConsentStatus,
+  isAcceptanceValid,
+  parseMajorVersion,
+} from './rm9-consent-acceptance';
+export type {
+  ConsentStatus,
+  DocumentAcceptance,
+  DocumentKind,
+  DocumentVersion,
+} from './rm9-consent-acceptance';
+export {
+  canAddChild,
+  CHILDREN_PER_HOUSEHOLD_LIMIT_V1,
+  countChildrenInHousehold,
+  ensureCanAddChild,
+} from './rm13-single-child-per-household';
+export {
   BACKFILL_HORIZON_MINUTES,
   classifyDoseTiming,
   ensureDoseTimingAcceptable,

--- a/packages/domain/src/rules/rm13-single-child-per-household.test.ts
+++ b/packages/domain/src/rules/rm13-single-child-per-household.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import type { Child } from '../entities/child';
+import { DomainError } from '../errors';
+import {
+  canAddChild,
+  CHILDREN_PER_HOUSEHOLD_LIMIT_V1,
+  countChildrenInHousehold,
+  ensureCanAddChild,
+} from './rm13-single-child-per-household';
+
+function makeChild(overrides: Partial<Child> & { id: string; householdId: string }): Child {
+  return {
+    firstName: 'Alix',
+    birthYear: 2020,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+describe('RM13 — CHILDREN_PER_HOUSEHOLD_LIMIT_V1', () => {
+  it('vaut 1 en v1.0 (spec ligne 337)', () => {
+    expect(CHILDREN_PER_HOUSEHOLD_LIMIT_V1).toBe(1);
+  });
+});
+
+describe('RM13 — countChildrenInHousehold', () => {
+  it('retourne 0 pour un foyer vide', () => {
+    expect(countChildrenInHousehold([], 'h1')).toBe(0);
+  });
+
+  it('retourne 1 quand un enfant appartient au foyer demandé', () => {
+    const children = [makeChild({ id: 'c1', householdId: 'h1' })];
+    expect(countChildrenInHousehold(children, 'h1')).toBe(1);
+  });
+
+  it("ne compte pas les enfants d'autres foyers", () => {
+    const children = [
+      makeChild({ id: 'c1', householdId: 'h1' }),
+      makeChild({ id: 'c2', householdId: 'h2' }),
+      makeChild({ id: 'c3', householdId: 'h3' }),
+    ];
+    expect(countChildrenInHousehold(children, 'h1')).toBe(1);
+    expect(countChildrenInHousehold(children, 'h2')).toBe(1);
+    expect(countChildrenInHousehold(children, 'h-unknown')).toBe(0);
+  });
+
+  it('compte plusieurs enfants du même foyer (état incohérent détectable)', () => {
+    const children = [
+      makeChild({ id: 'c1', householdId: 'h1' }),
+      makeChild({ id: 'c2', householdId: 'h1' }),
+    ];
+    expect(countChildrenInHousehold(children, 'h1')).toBe(2);
+  });
+
+  it('est une fonction pure (ne mute pas les entrées)', () => {
+    const children: Child[] = [
+      makeChild({ id: 'c1', householdId: 'h1' }),
+      makeChild({ id: 'c2', householdId: 'h2' }),
+    ];
+    const snapshot = JSON.stringify(children);
+    countChildrenInHousehold(children, 'h1');
+    expect(JSON.stringify(children)).toBe(snapshot);
+  });
+});
+
+describe('RM13 — canAddChild', () => {
+  it('autorise un premier enfant dans un foyer vide', () => {
+    expect(canAddChild({ existingChildren: [], householdId: 'h1' })).toBe(true);
+  });
+
+  it('refuse un deuxième enfant quand le foyer en possède déjà un', () => {
+    const existingChildren = [makeChild({ id: 'c1', householdId: 'h1' })];
+    expect(canAddChild({ existingChildren, householdId: 'h1' })).toBe(false);
+  });
+
+  it('ignore les enfants appartenant à un autre foyer', () => {
+    const existingChildren = [
+      makeChild({ id: 'c1', householdId: 'h2' }),
+      makeChild({ id: 'c2', householdId: 'h3' }),
+    ];
+    expect(canAddChild({ existingChildren, householdId: 'h1' })).toBe(true);
+  });
+
+  it("autorise l'ajout dans un foyer vide même si un enfant existe dans un autre foyer", () => {
+    const existingChildren = [makeChild({ id: 'c1', householdId: 'h2' })];
+    expect(canAddChild({ existingChildren, householdId: 'h1' })).toBe(true);
+  });
+
+  it('refuse si foyer cible contient 1 + autre foyer contient aussi un enfant (isolation)', () => {
+    const existingChildren = [
+      makeChild({ id: 'c1', householdId: 'h1' }),
+      makeChild({ id: 'c2', householdId: 'h2' }),
+    ];
+    expect(canAddChild({ existingChildren, householdId: 'h1' })).toBe(false);
+  });
+
+  it('refuse en cas d’état incohérent (plusieurs enfants dans le même foyer)', () => {
+    const existingChildren = [
+      makeChild({ id: 'c1', householdId: 'h1' }),
+      makeChild({ id: 'c2', householdId: 'h1' }),
+    ];
+    expect(canAddChild({ existingChildren, householdId: 'h1' })).toBe(false);
+  });
+});
+
+describe('RM13 — ensureCanAddChild', () => {
+  it('ne lève pas pour un foyer vide', () => {
+    expect(() => ensureCanAddChild({ existingChildren: [], householdId: 'h1' })).not.toThrow();
+  });
+
+  it('lève RM13_CHILD_LIMIT_REACHED quand un enfant existe déjà', () => {
+    const existingChildren = [makeChild({ id: 'c1', householdId: 'h1' })];
+    try {
+      ensureCanAddChild({ existingChildren, householdId: 'h1' });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM13_CHILD_LIMIT_REACHED');
+      expect((err as DomainError).context).toEqual({
+        householdId: 'h1',
+        currentCount: 1,
+        limit: CHILDREN_PER_HOUSEHOLD_LIMIT_V1,
+      });
+    }
+  });
+
+  it("ne fuite ni prénom ni id enfant dans le context de l'erreur", () => {
+    const existingChildren = [makeChild({ id: 'c-secret', householdId: 'h1', firstName: 'Alice' })];
+    try {
+      ensureCanAddChild({ existingChildren, householdId: 'h1' });
+      expect.fail('should have thrown');
+    } catch (err) {
+      const ctx = (err as DomainError).context ?? {};
+      expect(JSON.stringify(ctx)).not.toContain('c-secret');
+      expect(JSON.stringify(ctx)).not.toContain('Alice');
+    }
+  });
+
+  it('lève aussi en état incohérent (currentCount >= limit)', () => {
+    const existingChildren = [
+      makeChild({ id: 'c1', householdId: 'h1' }),
+      makeChild({ id: 'c2', householdId: 'h1' }),
+    ];
+    try {
+      ensureCanAddChild({ existingChildren, householdId: 'h1' });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM13_CHILD_LIMIT_REACHED');
+      expect((err as DomainError).context).toMatchObject({
+        householdId: 'h1',
+        currentCount: 2,
+        limit: CHILDREN_PER_HOUSEHOLD_LIMIT_V1,
+      });
+    }
+  });
+
+  it('est pur : ne mute pas la liste reçue', () => {
+    const existingChildren: Child[] = [makeChild({ id: 'c1', householdId: 'h1' })];
+    const snapshot = JSON.stringify(existingChildren);
+    try {
+      ensureCanAddChild({ existingChildren, householdId: 'h1' });
+    } catch {
+      // attendu
+    }
+    expect(JSON.stringify(existingChildren)).toBe(snapshot);
+  });
+});

--- a/packages/domain/src/rules/rm13-single-child-per-household.ts
+++ b/packages/domain/src/rules/rm13-single-child-per-household.ts
@@ -1,0 +1,78 @@
+import type { Child } from '../entities/child';
+import { DomainError } from '../errors';
+
+/**
+ * Nombre maximal d'enfants autorisés par foyer en v1.0 (SPECS §4 RM13,
+ * ligne 337). La valeur est une constante domaine : toute tentative d'ajout
+ * d'un second enfant est refusée tant que v1.0 est en vigueur. En v1.1
+ * (voir spec ligne 904), la contrainte 1:1 deviendra 1:N et cette règle
+ * sera désactivée en amont (le domaine sera mis à jour à ce moment-là, pas
+ * piloté par feature flag).
+ */
+export const CHILDREN_PER_HOUSEHOLD_LIMIT_V1 = 1;
+
+/**
+ * RM13 — Compte les enfants d'un foyer donné dans une liste potentiellement
+ * multi-foyer. Fonction **pure** : ne mute pas le tableau.
+ *
+ * Le filtrage par `householdId` est strict : un enfant dont le
+ * `householdId` diffère de l'argument n'est jamais comptabilisé. Cela rend
+ * l'appel sûr quel que soit le bruit d'amont (liste paginée, fuite
+ * multi-foyer, doublon).
+ */
+export function countChildrenInHousehold(children: readonly Child[], householdId: string): number {
+  let count = 0;
+  for (const child of children) {
+    if (child.householdId === householdId) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/** Options partagées par {@link canAddChild} et {@link ensureCanAddChild}. */
+interface AddChildOptions {
+  readonly existingChildren: readonly Child[];
+  readonly householdId: string;
+}
+
+/**
+ * RM13 — prédicat : peut-on ajouter un enfant au foyer ? Retourne un
+ * boolean, jamais de lève. Utile pour piloter l'UI (masquer le CTA
+ * « Ajouter un enfant » en v1.0 dès qu'un enfant existe, afficher le
+ * teasing v1.1 — voir spec ligne 598 / E9).
+ */
+export function canAddChild(options: AddChildOptions): boolean {
+  const { existingChildren, householdId } = options;
+  return countChildrenInHousehold(existingChildren, householdId) < CHILDREN_PER_HOUSEHOLD_LIMIT_V1;
+}
+
+/**
+ * RM13 — assertion : refuse la création si le foyer atteint déjà la limite
+ * v1.0. Lève `RM13_CHILD_LIMIT_REACHED` sinon.
+ *
+ * Le `context` d'erreur ne contient **jamais** ni prénom ni identifiant
+ * d'enfant — uniquement `householdId`, `currentCount`, `limit`. Mapper
+ * côté API : HTTP 409 `feature_not_yet_available`, body i18n pointant vers
+ * le roadmap v1.1 (SPECS §4 RM13, ligne 337).
+ *
+ * @throws {DomainError} `RM13_CHILD_LIMIT_REACHED` si le foyer héberge
+ *   déjà `CHILDREN_PER_HOUSEHOLD_LIMIT_V1` enfants ou plus (état
+ *   incohérent inclus — on bloque la création dans les deux cas).
+ */
+export function ensureCanAddChild(options: AddChildOptions): void {
+  const { existingChildren, householdId } = options;
+  const currentCount = countChildrenInHousehold(existingChildren, householdId);
+
+  if (currentCount >= CHILDREN_PER_HOUSEHOLD_LIMIT_V1) {
+    throw new DomainError(
+      'RM13_CHILD_LIMIT_REACHED',
+      `Household ${householdId} has already reached the v1.0 child limit (${CHILDREN_PER_HOUSEHOLD_LIMIT_V1}).`,
+      {
+        householdId,
+        currentCount,
+        limit: CHILDREN_PER_HOUSEHOLD_LIMIT_V1,
+      },
+    );
+  }
+}

--- a/packages/domain/src/rules/rm9-consent-acceptance.test.ts
+++ b/packages/domain/src/rules/rm9-consent-acceptance.test.ts
@@ -3,6 +3,7 @@ import { DomainError } from '../errors';
 import {
   type ConsentStatus,
   type DocumentAcceptance,
+  DOCUMENT_KINDS_CANONICAL_ORDER,
   type DocumentVersion,
   ensureAcceptanceValid,
   evaluateConsentStatus,
@@ -45,6 +46,15 @@ function makePpAcceptance(acceptedVersion: string): DocumentAcceptance {
     userId: 'user-1',
   };
 }
+
+describe('RM9 — DOCUMENT_KINDS_CANONICAL_ORDER invariant', () => {
+  it('expose exactement TOS puis PP, dans cet ordre', () => {
+    // Invariant d'ordre stable : les tableaux `missing` et `outdated` de
+    // ConsentStatus reposent sur ce tri. Toute modification silencieuse
+    // casserait les assertions UI consommatrices.
+    expect(DOCUMENT_KINDS_CANONICAL_ORDER).toEqual(['terms_of_service', 'privacy_policy']);
+  });
+});
 
 describe('RM9 — parseMajorVersion', () => {
   it('extrait le major de `1.2.3`', () => {
@@ -221,6 +231,17 @@ describe('RM9 — evaluateConsentStatus (priorité never_accepted sur major_bump
     expect(status).toEqual<ConsentStatus>({
       kind: 'never_accepted',
       missing: ['privacy_policy'],
+    });
+  });
+
+  it('cas symétrique : PP major bumpé + TOS jamais acceptée → never_accepted', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('1.0.0'), makePpVersion('2.0.0')],
+      acceptances: [makePpAcceptance('1.0.0')],
+    });
+    expect(status).toEqual<ConsentStatus>({
+      kind: 'never_accepted',
+      missing: ['terms_of_service'],
     });
   });
 });

--- a/packages/domain/src/rules/rm9-consent-acceptance.test.ts
+++ b/packages/domain/src/rules/rm9-consent-acceptance.test.ts
@@ -1,0 +1,454 @@
+import { describe, expect, it } from 'vitest';
+import { DomainError } from '../errors';
+import {
+  type ConsentStatus,
+  type DocumentAcceptance,
+  type DocumentVersion,
+  ensureAcceptanceValid,
+  evaluateConsentStatus,
+  isAcceptanceValid,
+  parseMajorVersion,
+} from './rm9-consent-acceptance';
+
+const NOW = new Date('2026-04-19T12:00:00Z');
+
+function makeTosVersion(version: string): DocumentVersion {
+  return {
+    kind: 'terms_of_service',
+    version,
+    publishedAtUtc: new Date('2026-01-01T00:00:00Z'),
+  };
+}
+
+function makePpVersion(version: string): DocumentVersion {
+  return {
+    kind: 'privacy_policy',
+    version,
+    publishedAtUtc: new Date('2026-01-01T00:00:00Z'),
+  };
+}
+
+function makeTosAcceptance(acceptedVersion: string): DocumentAcceptance {
+  return {
+    kind: 'terms_of_service',
+    acceptedVersion,
+    acceptedAtUtc: new Date('2026-03-01T12:00:00Z'),
+    userId: 'user-1',
+  };
+}
+
+function makePpAcceptance(acceptedVersion: string): DocumentAcceptance {
+  return {
+    kind: 'privacy_policy',
+    acceptedVersion,
+    acceptedAtUtc: new Date('2026-03-01T12:00:00Z'),
+    userId: 'user-1',
+  };
+}
+
+describe('RM9 — parseMajorVersion', () => {
+  it('extrait le major de `1.2.3`', () => {
+    expect(parseMajorVersion('1.2.3')).toBe(1);
+  });
+
+  it('extrait le major de `2.0.0`', () => {
+    expect(parseMajorVersion('2.0.0')).toBe(2);
+  });
+
+  it('extrait le major de `10.5.7` (plusieurs chiffres)', () => {
+    expect(parseMajorVersion('10.5.7')).toBe(10);
+  });
+
+  it('extrait le major de `0.0.1`', () => {
+    expect(parseMajorVersion('0.0.1')).toBe(0);
+  });
+
+  it('lève RM9_INVALID_VERSION_FORMAT si format invalide (2.0)', () => {
+    try {
+      parseMajorVersion('2.0');
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM9_INVALID_VERSION_FORMAT');
+    }
+  });
+
+  it('lève RM9_INVALID_VERSION_FORMAT si préfixe v (v1.2.3)', () => {
+    expect(() => parseMajorVersion('v1.2.3')).toThrow(DomainError);
+  });
+
+  it('lève RM9_INVALID_VERSION_FORMAT pour chaîne vide', () => {
+    expect(() => parseMajorVersion('')).toThrow(DomainError);
+  });
+
+  it('lève RM9_INVALID_VERSION_FORMAT pour non-numérique (1.a.0)', () => {
+    expect(() => parseMajorVersion('1.a.0')).toThrow(DomainError);
+  });
+
+  it('lève RM9_INVALID_VERSION_FORMAT pour composant négatif (-1.0.0)', () => {
+    expect(() => parseMajorVersion('-1.0.0')).toThrow(DomainError);
+  });
+
+  it('lève RM9_INVALID_VERSION_FORMAT si segments additionnels (1.2.3.4)', () => {
+    expect(() => parseMajorVersion('1.2.3.4')).toThrow(DomainError);
+  });
+});
+
+describe('RM9 — evaluateConsentStatus (never_accepted)', () => {
+  it('signale les deux documents manquants si aucune acceptation', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('1.0.0'), makePpVersion('1.0.0')],
+      acceptances: [],
+    });
+    expect(status.kind).toBe('never_accepted');
+    expect(status).toEqual<ConsentStatus>({
+      kind: 'never_accepted',
+      missing: ['terms_of_service', 'privacy_policy'],
+    });
+  });
+
+  it('signale uniquement PP manquante si seul TOS est accepté', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('1.0.0'), makePpVersion('1.0.0')],
+      acceptances: [makeTosAcceptance('1.0.0')],
+    });
+    expect(status).toEqual<ConsentStatus>({
+      kind: 'never_accepted',
+      missing: ['privacy_policy'],
+    });
+  });
+
+  it('signale uniquement TOS manquante si seule PP est acceptée', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('1.0.0'), makePpVersion('1.0.0')],
+      acceptances: [makePpAcceptance('1.0.0')],
+    });
+    expect(status).toEqual<ConsentStatus>({
+      kind: 'never_accepted',
+      missing: ['terms_of_service'],
+    });
+  });
+});
+
+describe('RM9 — evaluateConsentStatus (all_accepted_current)', () => {
+  it('accepte les deux à la version courante exacte', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('1.2.0'), makePpVersion('1.1.0')],
+      acceptances: [makeTosAcceptance('1.2.0'), makePpAcceptance('1.1.0')],
+    });
+    expect(status.kind).toBe('all_accepted_current');
+  });
+
+  it('accepte quand un minor bump est intervenu (1.2.0 accepté, 1.3.0 publié)', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('1.3.0'), makePpVersion('1.1.0')],
+      acceptances: [makeTosAcceptance('1.2.0'), makePpAcceptance('1.1.0')],
+    });
+    expect(status.kind).toBe('all_accepted_current');
+  });
+
+  it('accepte quand un patch bump est intervenu (1.2.0 accepté, 1.2.1 publié)', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('1.2.1'), makePpVersion('1.1.0')],
+      acceptances: [makeTosAcceptance('1.2.0'), makePpAcceptance('1.1.0')],
+    });
+    expect(status.kind).toBe('all_accepted_current');
+  });
+
+  it('accepte même si versions majors identiques mais minor antérieur', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('1.9.9'), makePpVersion('1.0.0')],
+      acceptances: [makeTosAcceptance('1.0.0'), makePpAcceptance('1.0.0')],
+    });
+    expect(status.kind).toBe('all_accepted_current');
+  });
+});
+
+describe('RM9 — evaluateConsentStatus (major_bump_requires_reacceptance)', () => {
+  it('bloque si TOS major bumpé (1.2.0 → 2.0.0), PP inchangé', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('2.0.0'), makePpVersion('1.0.0')],
+      acceptances: [makeTosAcceptance('1.2.0'), makePpAcceptance('1.0.0')],
+    });
+    expect(status).toEqual<ConsentStatus>({
+      kind: 'major_bump_requires_reacceptance',
+      outdated: ['terms_of_service'],
+    });
+  });
+
+  it('bloque si PP major bumpé, TOS inchangé', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('1.2.0'), makePpVersion('2.0.0')],
+      acceptances: [makeTosAcceptance('1.2.0'), makePpAcceptance('1.0.0')],
+    });
+    expect(status).toEqual<ConsentStatus>({
+      kind: 'major_bump_requires_reacceptance',
+      outdated: ['privacy_policy'],
+    });
+  });
+
+  it('bloque les deux si les deux majors ont bumpé', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('2.0.0'), makePpVersion('2.0.0')],
+      acceptances: [makeTosAcceptance('1.2.0'), makePpAcceptance('1.0.0')],
+    });
+    expect(status).toEqual<ConsentStatus>({
+      kind: 'major_bump_requires_reacceptance',
+      outdated: ['terms_of_service', 'privacy_policy'],
+    });
+  });
+
+  it('bloque saut de plusieurs majors (1.x → 3.x)', () => {
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('3.0.0'), makePpVersion('1.0.0')],
+      acceptances: [makeTosAcceptance('1.2.0'), makePpAcceptance('1.0.0')],
+    });
+    expect(status).toEqual<ConsentStatus>({
+      kind: 'major_bump_requires_reacceptance',
+      outdated: ['terms_of_service'],
+    });
+  });
+});
+
+describe('RM9 — evaluateConsentStatus (priorité never_accepted sur major_bump)', () => {
+  it('signale never_accepted si un document n’a jamais été accepté (priorité absolue)', () => {
+    // TOS major bumpé ET PP jamais acceptée → `never_accepted` l'emporte
+    // (un blocage est suffisant, mais on remonte l'état le plus grave).
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('2.0.0'), makePpVersion('1.0.0')],
+      acceptances: [makeTosAcceptance('1.2.0')],
+    });
+    expect(status).toEqual<ConsentStatus>({
+      kind: 'never_accepted',
+      missing: ['privacy_policy'],
+    });
+  });
+});
+
+describe('RM9 — evaluateConsentStatus (ignore acceptations obsolètes et autres users)', () => {
+  it("ignore les acceptations d'un autre kind que demandé", () => {
+    // Seulement TOS dans currentVersions, acceptances contient PP → PP ignorée
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('1.0.0')],
+      acceptances: [makeTosAcceptance('1.0.0'), makePpAcceptance('1.0.0')],
+    });
+    expect(status.kind).toBe('all_accepted_current');
+  });
+
+  it('ne conserve que la dernière acceptation par kind (la plus récente)', () => {
+    // Deux acceptations TOS : 1.0.0 (vieille) + 2.0.0 (récente). La règle
+    // prend la plus récente par `acceptedAtUtc`.
+    const status = evaluateConsentStatus({
+      currentVersions: [makeTosVersion('2.0.0')],
+      acceptances: [
+        {
+          kind: 'terms_of_service',
+          acceptedVersion: '1.0.0',
+          acceptedAtUtc: new Date('2025-01-01T00:00:00Z'),
+          userId: 'user-1',
+        },
+        {
+          kind: 'terms_of_service',
+          acceptedVersion: '2.0.0',
+          acceptedAtUtc: new Date('2026-03-01T00:00:00Z'),
+          userId: 'user-1',
+        },
+      ],
+    });
+    expect(status.kind).toBe('all_accepted_current');
+  });
+});
+
+describe('RM9 — evaluateConsentStatus (pureté)', () => {
+  it('ne mute ni currentVersions ni acceptances', () => {
+    const currentVersions = [makeTosVersion('1.2.0'), makePpVersion('1.1.0')];
+    const acceptances = [makeTosAcceptance('1.2.0'), makePpAcceptance('1.1.0')];
+    const versionsSnap = JSON.stringify(currentVersions);
+    const acceptancesSnap = JSON.stringify(acceptances);
+
+    evaluateConsentStatus({ currentVersions, acceptances });
+
+    expect(JSON.stringify(currentVersions)).toBe(versionsSnap);
+    expect(JSON.stringify(acceptances)).toBe(acceptancesSnap);
+  });
+});
+
+describe('RM9 — ensureAcceptanceValid (chemin nominal)', () => {
+  it('accepte une acceptation à la version courante exacte', () => {
+    const currentVersion = makeTosVersion('1.2.0');
+    const acceptance = makeTosAcceptance('1.2.0');
+
+    expect(() => ensureAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW })).not.toThrow();
+  });
+});
+
+describe('RM9 — ensureAcceptanceValid (cas de refus)', () => {
+  it('refuse si version acceptée dans un format invalide', () => {
+    const currentVersion = makeTosVersion('1.2.0');
+    const acceptance: DocumentAcceptance = {
+      kind: 'terms_of_service',
+      acceptedVersion: 'v1.2.0',
+      acceptedAtUtc: new Date('2026-03-01T00:00:00Z'),
+      userId: 'user-1',
+    };
+
+    try {
+      ensureAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM9_INVALID_VERSION_FORMAT');
+    }
+  });
+
+  it('refuse si acceptedAtUtc > nowUtc + tolérance NTP (RM9_INVALID_ACCEPTANCE_TIMESTAMP)', () => {
+    const currentVersion = makeTosVersion('1.2.0');
+    // Tolérance 1 s (CLOCK_SKEW_TOLERANCE_MS partagé avec RM14/RM22).
+    const acceptance: DocumentAcceptance = {
+      kind: 'terms_of_service',
+      acceptedVersion: '1.2.0',
+      acceptedAtUtc: new Date('2026-04-19T12:00:02Z'),
+      userId: 'user-1',
+    };
+
+    try {
+      ensureAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM9_INVALID_ACCEPTANCE_TIMESTAMP');
+    }
+  });
+
+  it('accepte acceptedAtUtc légèrement futur (< 1 s, bruit NTP)', () => {
+    const currentVersion = makeTosVersion('1.2.0');
+    const acceptance: DocumentAcceptance = {
+      kind: 'terms_of_service',
+      acceptedVersion: '1.2.0',
+      acceptedAtUtc: new Date('2026-04-19T12:00:00.500Z'),
+      userId: 'user-1',
+    };
+
+    expect(() => ensureAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW })).not.toThrow();
+  });
+
+  it('accepte acceptedAtUtc pile à la borne de tolérance (nowUtc + 1000 ms)', () => {
+    const currentVersion = makeTosVersion('1.2.0');
+    const acceptance: DocumentAcceptance = {
+      kind: 'terms_of_service',
+      acceptedVersion: '1.2.0',
+      acceptedAtUtc: new Date('2026-04-19T12:00:01.000Z'),
+      userId: 'user-1',
+    };
+
+    expect(() => ensureAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW })).not.toThrow();
+  });
+
+  it('refuse si kind acceptance ≠ kind currentVersion (incohérence de flux)', () => {
+    const currentVersion = makeTosVersion('1.2.0');
+    const acceptance: DocumentAcceptance = {
+      kind: 'privacy_policy',
+      acceptedVersion: '1.2.0',
+      acceptedAtUtc: new Date('2026-03-01T00:00:00Z'),
+      userId: 'user-1',
+    };
+
+    try {
+      ensureAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM9_VERSION_MISMATCH');
+    }
+  });
+
+  it('refuse si major accepté > major courant (tricherie/regression)', () => {
+    const currentVersion = makeTosVersion('1.2.0');
+    const acceptance = makeTosAcceptance('2.0.0');
+
+    try {
+      ensureAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM9_VERSION_MISMATCH');
+    }
+  });
+
+  it('accepte si major accepté < major courant (rétrocompatibilité minor)', () => {
+    // accepted=1.2.0, current=1.5.3 → même major, ok (minor/patch bumps)
+    const currentVersion = makeTosVersion('1.5.3');
+    const acceptance = makeTosAcceptance('1.2.0');
+
+    expect(() => ensureAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW })).not.toThrow();
+  });
+
+  it('refuse si major accepté < major courant (major bump détecté)', () => {
+    // accepted=1.2.0, current=2.0.0 → major bump → requiert ré-acceptation
+    const currentVersion = makeTosVersion('2.0.0');
+    const acceptance = makeTosAcceptance('1.2.0');
+
+    try {
+      ensureAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM9_VERSION_MISMATCH');
+    }
+  });
+});
+
+describe('RM9 — ensureAcceptanceValid (context erreur confidentiel)', () => {
+  it("ne fuit pas userId dans le context d'erreur", () => {
+    const currentVersion = makeTosVersion('2.0.0');
+    const acceptance: DocumentAcceptance = {
+      kind: 'terms_of_service',
+      acceptedVersion: '1.2.0',
+      acceptedAtUtc: new Date('2026-03-01T00:00:00Z'),
+      userId: 'super-secret-user',
+    };
+
+    try {
+      ensureAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW });
+      expect.fail('should have thrown');
+    } catch (err) {
+      const ctx = (err as DomainError).context ?? {};
+      expect(JSON.stringify(ctx)).not.toContain('super-secret-user');
+      expect(ctx).not.toHaveProperty('userId');
+    }
+  });
+});
+
+describe('RM9 — ensureAcceptanceValid (pureté)', () => {
+  it('ne mute ni acceptance ni currentVersion', () => {
+    const currentVersion = makeTosVersion('1.2.0');
+    const acceptance = makeTosAcceptance('1.2.0');
+    const versionSnap = JSON.stringify(currentVersion);
+    const acceptanceSnap = JSON.stringify(acceptance);
+
+    ensureAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW });
+
+    expect(JSON.stringify(currentVersion)).toBe(versionSnap);
+    expect(JSON.stringify(acceptance)).toBe(acceptanceSnap);
+  });
+});
+
+describe('RM9 — isAcceptanceValid', () => {
+  it('retourne true quand l’acceptation est valide', () => {
+    const currentVersion = makeTosVersion('1.2.0');
+    const acceptance = makeTosAcceptance('1.2.0');
+    expect(isAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW })).toBe(true);
+  });
+
+  it('retourne false quand major bump', () => {
+    const currentVersion = makeTosVersion('2.0.0');
+    const acceptance = makeTosAcceptance('1.2.0');
+    expect(isAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW })).toBe(false);
+  });
+
+  it('retourne false pour un format de version invalide (jamais de lève)', () => {
+    const currentVersion = makeTosVersion('1.2.0');
+    const acceptance: DocumentAcceptance = {
+      kind: 'terms_of_service',
+      acceptedVersion: 'not.a.semver',
+      acceptedAtUtc: new Date('2026-03-01T00:00:00Z'),
+      userId: 'user-1',
+    };
+    expect(isAcceptanceValid({ acceptance, currentVersion, nowUtc: NOW })).toBe(false);
+  });
+});

--- a/packages/domain/src/rules/rm9-consent-acceptance.ts
+++ b/packages/domain/src/rules/rm9-consent-acceptance.ts
@@ -10,7 +10,13 @@ import { CLOCK_SKEW_TOLERANCE_MS } from './rm14-recorded-timestamp';
  */
 export type DocumentKind = 'terms_of_service' | 'privacy_policy';
 
-const DOCUMENT_KINDS_CANONICAL_ORDER: ReadonlyArray<DocumentKind> = [
+/**
+ * Ordre canonique d'apparition des kinds de documents dans les tableaux
+ * `missing` / `outdated`. Exposé pour que les tests et les consommateurs
+ * puissent verrouiller l'invariant d'ordre stable (sinon un ajout futur
+ * pourrait briser les assertions `toEqual` côté UI sans test en filet).
+ */
+export const DOCUMENT_KINDS_CANONICAL_ORDER: ReadonlyArray<DocumentKind> = [
   'terms_of_service',
   'privacy_policy',
 ];
@@ -95,7 +101,8 @@ interface ParsedSemver {
   readonly patch: number;
 }
 
-const SEMVER_STRICT_REGEX = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+const SEMVER_STRICT_REGEX =
+  /^(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)\.(?<patch>0|[1-9][0-9]*)$/;
 
 function parseSemverOrThrow(version: string): ParsedSemver {
   if (typeof version !== 'string' || version.length === 0) {
@@ -105,7 +112,7 @@ function parseSemverOrThrow(version: string): ParsedSemver {
   }
 
   const match = SEMVER_STRICT_REGEX.exec(version);
-  if (match === null) {
+  if (match === null || match.groups === undefined) {
     throw new DomainError(
       'RM9_INVALID_VERSION_FORMAT',
       `Version "${version}" is not in strict MAJOR.MINOR.PATCH format.`,
@@ -113,12 +120,13 @@ function parseSemverOrThrow(version: string): ParsedSemver {
     );
   }
 
-  // Les trois groupes sont garantis par le regex ; on convertit sans risque.
-  const [, majorStr, minorStr, patchStr] = match;
+  // Les groupes nommés sont garantis non-undefined par la regex (tous
+  // obligatoires) ; on coalesce en '' par sécurité type stricte.
+  const { major = '', minor = '', patch = '' } = match.groups;
   return {
-    major: Number.parseInt(majorStr as string, 10),
-    minor: Number.parseInt(minorStr as string, 10),
-    patch: Number.parseInt(patchStr as string, 10),
+    major: Number.parseInt(major, 10),
+    minor: Number.parseInt(minor, 10),
+    patch: Number.parseInt(patch, 10),
   };
 }
 

--- a/packages/domain/src/rules/rm9-consent-acceptance.ts
+++ b/packages/domain/src/rules/rm9-consent-acceptance.ts
@@ -1,0 +1,306 @@
+import { DomainError } from '../errors';
+import { CLOCK_SKEW_TOLERANCE_MS } from './rm14-recorded-timestamp';
+
+/**
+ * Documents de consentement obligatoires à la création de compte puis à
+ * chaque bump majeur (SPECS §4 RM9, ligne 333).
+ *
+ * Les valeurs sont stables côté API — ne pas renommer sans migration
+ * explicite.
+ */
+export type DocumentKind = 'terms_of_service' | 'privacy_policy';
+
+const DOCUMENT_KINDS_CANONICAL_ORDER: ReadonlyArray<DocumentKind> = [
+  'terms_of_service',
+  'privacy_policy',
+];
+
+/**
+ * Version publiée d'un document de consentement. Le `version` suit le format
+ * semver strict `MAJOR.MINOR.PATCH` (trois segments numériques entiers non
+ * négatifs, sans préfixe `v`, sans pre-release). Un bump majeur bloque
+ * l'usage jusqu'à ré-acceptation ; `MINOR` et `PATCH` sont considérés
+ * comme rétro-compatibles vis-à-vis du consentement.
+ */
+export interface DocumentVersion {
+  readonly kind: DocumentKind;
+  /** Format strict `MAJOR.MINOR.PATCH`. */
+  readonly version: string;
+  readonly publishedAtUtc: Date;
+}
+
+/**
+ * Acceptation horodatée d'un document par un utilisateur. Jamais
+ * pré-cochée côté UI (contrainte UX, RM9 ligne 333). Le domaine ne peut
+ * pas prouver l'explicitness de l'interaction UI (pas de télémétrie d'event
+ * `click`), mais exige la cohérence minimale :
+ * - `acceptedAtUtc` pas dans le futur au-delà de la tolérance NTP,
+ * - `kind` cohérent avec le document auquel il est confronté,
+ * - `acceptedVersion` au format semver valide.
+ *
+ * Le contrat vers la couche application est documenté : l'API qui
+ * enregistre une acceptation DOIT s'assurer que l'utilisateur a explicitement
+ * coché la case (pas de valeur par défaut `true` côté formulaire).
+ */
+export interface DocumentAcceptance {
+  readonly kind: DocumentKind;
+  /** Version acceptée (semver strict). */
+  readonly acceptedVersion: string;
+  readonly acceptedAtUtc: Date;
+  readonly userId: string;
+}
+
+/**
+ * Résultat de l'évaluation globale du consentement d'un utilisateur.
+ *
+ * Sémantique de priorité (ordre décroissant) :
+ * 1. `never_accepted` — au moins un document n'a jamais été accepté. C'est
+ *    le cas de la création de compte et de l'ajout d'un nouveau type de
+ *    document en cours de vie produit.
+ * 2. `major_bump_requires_reacceptance` — tous les documents ont été
+ *    acceptés un jour, mais un ou plusieurs ont subi un bump majeur depuis.
+ * 3. `all_accepted_current` — utilisateur à jour (bumps minor/patch inclus).
+ *
+ * Si les deux états 1 et 2 coexistent (doc A jamais accepté, doc B
+ * obsolète), on remonte `never_accepted` avec uniquement le doc A dans
+ * `missing`. La couche application décide de l'UI unifiée ; le domaine
+ * expose l'état le plus grave de manière déterministe.
+ */
+export type ConsentStatus =
+  | { readonly kind: 'all_accepted_current' }
+  | {
+      readonly kind: 'major_bump_requires_reacceptance';
+      readonly outdated: ReadonlyArray<DocumentKind>;
+    }
+  | {
+      readonly kind: 'never_accepted';
+      readonly missing: ReadonlyArray<DocumentKind>;
+    };
+
+/**
+ * RM9 — Extrait le numéro major d'une version semver stricte.
+ *
+ * Accepte exactement trois segments entiers non négatifs, séparés par `.`.
+ * Aucun préfixe, aucune pre-release, aucune tolérance.
+ *
+ * @throws {DomainError} `RM9_INVALID_VERSION_FORMAT` si le format diverge.
+ */
+export function parseMajorVersion(version: string): number {
+  return parseSemverOrThrow(version).major;
+}
+
+interface ParsedSemver {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+}
+
+const SEMVER_STRICT_REGEX = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/;
+
+function parseSemverOrThrow(version: string): ParsedSemver {
+  if (typeof version !== 'string' || version.length === 0) {
+    throw new DomainError('RM9_INVALID_VERSION_FORMAT', 'Version is empty or not a string.', {
+      reason: 'empty',
+    });
+  }
+
+  const match = SEMVER_STRICT_REGEX.exec(version);
+  if (match === null) {
+    throw new DomainError(
+      'RM9_INVALID_VERSION_FORMAT',
+      `Version "${version}" is not in strict MAJOR.MINOR.PATCH format.`,
+      { reason: 'format' },
+    );
+  }
+
+  // Les trois groupes sont garantis par le regex ; on convertit sans risque.
+  const [, majorStr, minorStr, patchStr] = match;
+  return {
+    major: Number.parseInt(majorStr as string, 10),
+    minor: Number.parseInt(minorStr as string, 10),
+    patch: Number.parseInt(patchStr as string, 10),
+  };
+}
+
+function tryParseSemver(version: string): ParsedSemver | null {
+  try {
+    return parseSemverOrThrow(version);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * RM9 — Évalue l'état global de consentement d'un utilisateur par rapport
+ * aux versions courantes publiées des documents. Fonction **pure** :
+ * inputs non mutés.
+ *
+ * Sélection de l'acceptation pertinente : pour un `kind` donné, si
+ * plusieurs acceptations existent dans la liste (cas normal à chaque
+ * ré-acceptation post-major), la plus récente par `acceptedAtUtc` est
+ * retenue. Les acceptations d'un `kind` absent de `currentVersions` sont
+ * ignorées (cohérent avec un retrait progressif d'un document obsolète).
+ */
+export function evaluateConsentStatus(options: {
+  readonly currentVersions: ReadonlyArray<DocumentVersion>;
+  readonly acceptances: ReadonlyArray<DocumentAcceptance>;
+}): ConsentStatus {
+  const { currentVersions, acceptances } = options;
+
+  const latestByKind = new Map<DocumentKind, DocumentAcceptance>();
+  for (const acceptance of acceptances) {
+    const previous = latestByKind.get(acceptance.kind);
+    if (
+      previous === undefined ||
+      acceptance.acceptedAtUtc.getTime() > previous.acceptedAtUtc.getTime()
+    ) {
+      latestByKind.set(acceptance.kind, acceptance);
+    }
+  }
+
+  const missing: DocumentKind[] = [];
+  const outdated: DocumentKind[] = [];
+
+  for (const kind of DOCUMENT_KINDS_CANONICAL_ORDER) {
+    const current = currentVersions.find((v) => v.kind === kind);
+    if (current === undefined) {
+      continue;
+    }
+
+    const latest = latestByKind.get(kind);
+    if (latest === undefined) {
+      missing.push(kind);
+      continue;
+    }
+
+    const currentParsed = tryParseSemver(current.version);
+    const acceptedParsed = tryParseSemver(latest.acceptedVersion);
+
+    // Versions invalides côté config : on ne peut pas certifier la validité
+    // → on remonte comme jamais accepté, solution conservative.
+    if (currentParsed === null || acceptedParsed === null) {
+      missing.push(kind);
+      continue;
+    }
+
+    if (acceptedParsed.major < currentParsed.major) {
+      outdated.push(kind);
+    }
+    // Cas acceptedParsed.major > currentParsed.major : donnée suspecte,
+    // mais `evaluateConsentStatus` ne lève pas — on considère l'utilisateur
+    // à jour par défaut (pas de blocage UX), tandis que
+    // `ensureAcceptanceValid` refuse à l'écriture.
+  }
+
+  if (missing.length > 0) {
+    return { kind: 'never_accepted', missing };
+  }
+  if (outdated.length > 0) {
+    return { kind: 'major_bump_requires_reacceptance', outdated };
+  }
+  return { kind: 'all_accepted_current' };
+}
+
+/** Options partagées par {@link ensureAcceptanceValid} et {@link isAcceptanceValid}. */
+interface AcceptanceValidationOptions {
+  readonly acceptance: DocumentAcceptance;
+  readonly currentVersion: DocumentVersion;
+  readonly nowUtc: Date;
+}
+
+/**
+ * RM9 — prédicat : l'acceptation est-elle valide vis-à-vis de la version
+ * courante du document ? Retourne un boolean, jamais de lève.
+ */
+export function isAcceptanceValid(options: AcceptanceValidationOptions): boolean {
+  try {
+    ensureAcceptanceValid(options);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * RM9 — assertion : refuse une acceptation invalide au moment de
+ * l'enregistrement par l'API.
+ *
+ * Contrats d'erreur :
+ * - `RM9_INVALID_VERSION_FORMAT` : `acceptedVersion` (ou `currentVersion`)
+ *   n'est pas au format `MAJOR.MINOR.PATCH`.
+ * - `RM9_INVALID_ACCEPTANCE_TIMESTAMP` : `acceptedAtUtc > nowUtc` au-delà
+ *   de la tolérance NTP {@link CLOCK_SKEW_TOLERANCE_MS} partagée avec RM14
+ *   et RM22. Un écart inférieur est accepté silencieusement (bruit NTP).
+ * - `RM9_VERSION_MISMATCH` : le `kind` de l'acceptation diffère du `kind`
+ *   de la version courante (incohérence de flux), OU le major accepté est
+ *   strictement supérieur au major courant (tricherie / mauvaise config),
+ *   OU le major accepté est strictement inférieur au major courant (major
+ *   bump en cours, l'utilisateur doit ré-accepter la version courante).
+ *
+ * Le `context` d'erreur ne contient **jamais** `userId`. Il expose
+ * uniquement le `kind` et les versions impliquées pour debug côté API.
+ *
+ * Ce contrat couvre le chemin d'écriture. Pour la décision de blocage
+ * globale (« faut-il forcer l'utilisateur à ré-accepter avant toute
+ * action ? »), utiliser {@link evaluateConsentStatus}.
+ */
+export function ensureAcceptanceValid(options: AcceptanceValidationOptions): void {
+  const { acceptance, currentVersion, nowUtc } = options;
+
+  // 1. `kind` cohérent — on ne mélange pas TOS et PP à l'enregistrement.
+  if (acceptance.kind !== currentVersion.kind) {
+    throw new DomainError(
+      'RM9_VERSION_MISMATCH',
+      `Acceptance kind "${acceptance.kind}" does not match current version kind "${currentVersion.kind}".`,
+      {
+        acceptedKind: acceptance.kind,
+        currentKind: currentVersion.kind,
+      },
+    );
+  }
+
+  // 2. Formats semver stricts des deux côtés.
+  const currentParsed = parseSemverOrThrow(currentVersion.version);
+  const acceptedParsed = parseSemverOrThrow(acceptance.acceptedVersion);
+
+  // 3. Tricherie d'horloge : acceptance pas dans le futur au-delà de la
+  //    tolérance partagée RM14/RM22.
+  if (acceptance.acceptedAtUtc.getTime() > nowUtc.getTime() + CLOCK_SKEW_TOLERANCE_MS) {
+    throw new DomainError(
+      'RM9_INVALID_ACCEPTANCE_TIMESTAMP',
+      'acceptedAtUtc is in the future beyond the accepted clock-skew tolerance.',
+      {
+        kind: acceptance.kind,
+        acceptedVersion: acceptance.acceptedVersion,
+      },
+    );
+  }
+
+  // 4. Major strictement supérieur côté acceptance : suspicieux (client
+  //    tente d'accepter une version qui n'existe pas encore).
+  if (acceptedParsed.major > currentParsed.major) {
+    throw new DomainError(
+      'RM9_VERSION_MISMATCH',
+      `Accepted major ${acceptedParsed.major} is greater than current major ${currentParsed.major} for ${acceptance.kind}.`,
+      {
+        kind: acceptance.kind,
+        acceptedVersion: acceptance.acceptedVersion,
+        currentVersion: currentVersion.version,
+      },
+    );
+  }
+
+  // 5. Major strictement inférieur : bump majeur intervenu, il faut
+  //    ré-accepter la version courante.
+  if (acceptedParsed.major < currentParsed.major) {
+    throw new DomainError(
+      'RM9_VERSION_MISMATCH',
+      `Accepted major ${acceptedParsed.major} is lower than current major ${currentParsed.major} for ${acceptance.kind} — re-acceptance required.`,
+      {
+        kind: acceptance.kind,
+        acceptedVersion: acceptance.acceptedVersion,
+        currentVersion: currentVersion.version,
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Résumé

Dixième lot de travaux dans `@kinhale/domain`. Lot **D4 — foyer & enfant** :

- **RM9** — Consentement CGU + Politique de Confidentialité (semver, major bump = ré-acceptation)
- **RM13** — Un seul enfant par foyer en v1.0 (contrainte levée en v1.1)

**58 nouveaux tests** (17 RM13 + 41 RM9). Total domain : 385 → **443 tests** tous verts.

## Workflow pré-PR appliqué

Conforme à `CLAUDE.md §Méthodologie` :

- **kz-review** (qualité/design) → APPROUVÉ AVEC RÉSERVES MINEURES, 0 MAJEUR bloquant
- Pas de kz-securite (zone non-sensible : pas de crypto, pas d'I/O, pas de payload externe)

Corrections intégrées dans le commit `3d19855` :
- **M1** : `as string` sur captures regex RM9 → groupes nommés `(?<major>)/(?<minor>)/(?<patch>)` avec default `''`
- **M2** : docstring `RM9_VERSION_MISMATCH` aligné sur les 3 cas levés (kind mismatch, major > courant, major < courant)
- **M3** : `DOCUMENT_KINDS_CANONICAL_ORDER` promu `export const` + test invariant dédié
- **S1** : test symétrique ajouté pour `never_accepted` (PP major bumpé + TOS jamais acceptée)

## API RM9

```ts
export type DocumentKind = 'terms_of_service' | 'privacy_policy';
export const DOCUMENT_KINDS_CANONICAL_ORDER: ReadonlyArray<DocumentKind>;

export type ConsentStatus =
  | { kind: 'all_accepted_current' }
  | { kind: 'major_bump_requires_reacceptance'; outdated: ReadonlyArray<DocumentKind> }
  | { kind: 'never_accepted'; missing: ReadonlyArray<DocumentKind> };

export function parseMajorVersion(version: string): number;

export function evaluateConsentStatus({currentVersions, acceptances}): ConsentStatus;
export function ensureAcceptanceValid({acceptance, currentVersion, nowUtc}): void;
export function isAcceptanceValid({acceptance, currentVersion, nowUtc}): boolean;
```

**Semver strict** : `/^(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)\.(?<patch>0|[1-9][0-9]*)$/` — refus `v` préfixé, pre-release, leading zero, négatifs. ReDoS-safe.

**Granularité** : CGU et PC sont 2 documents indépendants avec leurs propres versions et acceptances.

**Bump majeur** ⇒ ré-acceptation requise (`major_bump_requires_reacceptance`). **Minor/patch** ⇒ ignorés (`all_accepted_current`).

**Priorité** : `never_accepted` > `major_bump_requires_reacceptance` (choix documenté, test dédié).

**Asymétrie lecture/écriture** :
- `evaluateConsentStatus` (lecture) permissif : ne lève jamais, status `all_accepted_current` sur major accepté > major courant
- `ensureAcceptanceValid` (écriture) strict : lève `RM9_VERSION_MISMATCH`

**Tolérance NTP** : import direct de `CLOCK_SKEW_TOLERANCE_MS` depuis RM14 (cohérent RM22).

## API RM13

```ts
export const CHILDREN_PER_HOUSEHOLD_LIMIT_V1 = 1;

export function countChildrenInHousehold(children: readonly Child[], householdId: string): number;
export function canAddChild({existingChildren, householdId}): boolean;
export function ensureCanAddChild({existingChildren, householdId}): void;
```

Filtre strict par `householdId`. Error context `{householdId, currentCount, limit}` — aucune donnée nominative (prénom, id enfant).

## Codes d'erreur ajoutés

- `RM9_INVALID_VERSION_FORMAT` — version semver invalide
- `RM9_INVALID_ACCEPTANCE_TIMESTAMP` — `acceptedAtUtc > nowUtc + CLOCK_SKEW_TOLERANCE_MS`
- `RM9_VERSION_MISMATCH` — kind mismatch OU major accepté ≠ major courant
- `RM13_CHILD_LIMIT_REACHED` — mapping HTTP 409 `feature_not_yet_available`

## Choix sémantiques verrouillés

- **RM9 semver strict** — aucune tolérance de format
- **RM9 granularité** — TOS et PC acceptés indépendamment, versions distinctes
- **RM9 asymétrie permissive/stricte** — lecture UX, écriture data integrity
- **RM9 priorité** `never_accepted` > `major_bump` (le plus grave remonte)
- **RM9 tolérance NTP 1 s** partagée avec RM14 et RM22
- **RM13 limite = 1** via `CHILDREN_PER_HOUSEHOLD_LIMIT_V1` (suffixe `_V1` signale versionnement)
- **RM13 filtrage `householdId`** — un enfant d'un autre foyer ne compte jamais
- **Contexts d'erreur** — aucune donnée nominative (tests de non-fuite dédiés)

## Vérifications

- [x] `pnpm --filter @kinhale/domain typecheck` : vert
- [x] `pnpm --filter @kinhale/domain lint` : vert
- [x] `pnpm --filter @kinhale/domain test` : **443/443**
- [x] `pnpm format:check` : vert
- [x] `pnpm lint:root` : vert (checklist CI apprise KIN-012)
- [x] kz-review passé pré-PR : 0 MAJEUR bloquant
- [x] Pas de `Date.now()`, `Math.random()`, `console.*`, `!` non-null
- [x] Aucune règle existante modifiée, additifs uniquement
- [x] Aucune donnée nominative dans les contexts d'erreur

## Points de vigilance pour la revue humaine

Deux points **non-bloquants** signalés par kz-review méritent arbitrage produit :

1. **J1 — Asymétrie sur major accepté > major courant** : `evaluateConsentStatus` remonte `all_accepted_current` pour une acceptance de version ultérieure à la version publiée (scenario rollback CGU ou fixture devtest). Canari silencieux, aucune observabilité domaine. **Option future** : ajouter un 4e kind `unknown_accepted_version` pour tracer sans bloquer. Ou ADR documenté si le comportement est conservé.

2. **J2 — Absence de signal `minor_change_only`** : conforme à la spec RM9 (« bump mineur ignoré »). Si un jour l'UI veut afficher « nos CGU ont été mises à jour — voir les changements », le domaine devra être étendu. Pas de dette technique actuelle, juste une anticipation roadmap.

## Taille de PR

1 075 insertions (dont ~660 de tests, ratio test/prod ~1.6x). Au-dessus des 400 lignes CLAUDE.md mais justifiée : 2 règles atomiques d'une même famille (foyer/enfant) avec tests exhaustifs (semver, NTP, granularité, confidentialité).

## Avancement v1.0 domaine

**22/28 règles après merge (79%)** : RM1-9, RM13, RM14-18, RM21-22, RM24-28.

**6 restantes** : RM10, RM11, RM12, RM19, RM20, RM23.

## Ce qui arrive ensuite

- **Lot D2 — Lifecycle pompe** : RM19 (péremption) + RM20 (offline 30j) — 2 règles
- **Lot D3 — Rôles & sessions** : RM10 + RM11 + RM12 — 3 règles
- **Lot E — Géolocalisation** : RM23 — 1 règle unitaire

## Test plan

- [ ] Cloner + `pnpm install` + `pnpm test` → 443/443 vert
- [ ] `pnpm lint:root` + `pnpm format:check` → verts
- [ ] Valider l'asymétrie lecture/écriture RM9 sur major > courant (J1)
- [ ] Statuer sur la création d'un ADR RM9 pour J1/J2

---

Refs : KIN-014

🤖 Generated with [Claude Code](https://claude.com/claude-code)