### PR TITLE
feat(KIN-015): RM19 péremption pompe + RM20 mode offline

### DIFF
--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -52,6 +52,8 @@ export type DomainErrorCode =
   | 'RM18_NOT_AUTHORIZED'
   /** RM18 — hors fenêtre libre : `voidedReason` non vide obligatoire. */
   | 'RM18_VOIDED_REASON_REQUIRED'
+  /** RM19 — tentative d'usage d'une pompe expirée sans justification Admin. */
+  | 'RM19_PUMP_EXPIRED'
   /** RM25 — `alreadySentSteps` contient une valeur hors {1, 2}. */
   | 'RM25_INVALID_STEP'
   /** RM21 — le foyer a déjà atteint la limite d'invitations actives simultanées. */

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -65,6 +65,21 @@ export {
 } from './rm18-void-dose';
 export type { VoidDoseOptions, VoidRequester } from './rm18-void-dose';
 export {
+  canUsePumpForDose,
+  daysUntilExpiration,
+  ensurePumpUsableForDose,
+  evaluatePumpExpiration,
+  PUMP_EXPIRING_WARNING_WINDOW_DAYS,
+} from './rm19-pump-expiration';
+export type { PumpLifecycleEvent, PumpLifecycleUpdate } from './rm19-pump-expiration';
+export {
+  decideOfflineReadAccess,
+  decideOfflineWriteAccess,
+  filterDosesAvailableOffline,
+  OFFLINE_READ_WINDOW_DAYS,
+} from './rm20-offline-access';
+export type { OfflineReadDecision, OfflineWriteDecision } from './rm20-offline-access';
+export {
   nextReminderRetry,
   planReminderRetries,
   REMINDER_RETRY_DELAYS_MS,

--- a/packages/domain/src/rules/rm19-pump-expiration.test.ts
+++ b/packages/domain/src/rules/rm19-pump-expiration.test.ts
@@ -156,7 +156,9 @@ describe('RM19 — evaluatePumpExpiration — expiration effective', () => {
     expect(update.pump.status).toBe('expired');
   });
 
-  it('pompe à J-1 avec previousRemainingDays=2 : franchissement seulement si > 30, donc rien pour le seuil — mais expire dans 1 j donc pas expired', () => {
+  it('pas de franchissement de seuil si previous déjà ≤ 30', () => {
+    // previousRemainingDays=2 et nouveau=1 : déjà bien en dessous de 30,
+    // donc aucun événement `pump_expiring_threshold_crossed` n'est émis.
     const pump = makePump({ expiresAt: offsetDays(NOW, 1), status: 'active' });
     const update = evaluatePumpExpiration({
       pump,
@@ -164,6 +166,17 @@ describe('RM19 — evaluatePumpExpiration — expiration effective', () => {
       nowUtc: NOW,
     });
     expect(update.events).toEqual([]);
+  });
+
+  it('pas de transition vers expired tant que J-0 n’est pas atteint', () => {
+    // À J-1 la pompe reste `active` — seule la bascule à J-0 la passe en
+    // `expired`.
+    const pump = makePump({ expiresAt: offsetDays(NOW, 1), status: 'active' });
+    const update = evaluatePumpExpiration({
+      pump,
+      previousRemainingDays: 2,
+      nowUtc: NOW,
+    });
     expect(update.pump.status).toBe('active');
   });
 

--- a/packages/domain/src/rules/rm19-pump-expiration.test.ts
+++ b/packages/domain/src/rules/rm19-pump-expiration.test.ts
@@ -1,0 +1,358 @@
+import { describe, expect, it } from 'vitest';
+import type { Pump } from '../entities/pump';
+import { DomainError } from '../errors';
+import {
+  canUsePumpForDose,
+  daysUntilExpiration,
+  ensurePumpUsableForDose,
+  evaluatePumpExpiration,
+  PUMP_EXPIRING_WARNING_WINDOW_DAYS,
+} from './rm19-pump-expiration';
+
+const NOW = new Date('2026-04-19T12:00:00Z');
+const ONE_DAY_MS = 86_400_000;
+
+function offsetDays(base: Date, days: number): Date {
+  return new Date(base.getTime() + days * ONE_DAY_MS);
+}
+
+function makePump(overrides: Partial<Pump> = {}): Pump {
+  return {
+    id: 'pump-1',
+    householdId: 'h1',
+    type: 'maintenance',
+    status: 'active',
+    label: 'Flovent HFA 125',
+    dosesRemaining: 50,
+    expiresAt: offsetDays(NOW, 60),
+    createdAt: offsetDays(NOW, -30),
+    ...overrides,
+  };
+}
+
+describe('RM19 — constante', () => {
+  it('expose la fenêtre d avertissement de 30 jours', () => {
+    expect(PUMP_EXPIRING_WARNING_WINDOW_DAYS).toBe(30);
+  });
+});
+
+describe('RM19 — daysUntilExpiration', () => {
+  it('retourne null pour une pompe sans date de péremption', () => {
+    const pump = makePump({ expiresAt: null });
+    expect(daysUntilExpiration(pump, NOW)).toBeNull();
+  });
+
+  it('retourne 60 pour une pompe qui expire dans 60 jours', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, 60) });
+    expect(daysUntilExpiration(pump, NOW)).toBe(60);
+  });
+
+  it('retourne 30 à J-30 pile', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, 30) });
+    expect(daysUntilExpiration(pump, NOW)).toBe(30);
+  });
+
+  it('retourne 0 le jour même de l expiration', () => {
+    const pump = makePump({ expiresAt: NOW });
+    expect(daysUntilExpiration(pump, NOW)).toBe(0);
+  });
+
+  it('retourne une valeur négative après expiration', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, -5) });
+    expect(daysUntilExpiration(pump, NOW)).toBe(-5);
+  });
+
+  it('utilise Math.floor : 30 j et 1 min reste 30 j', () => {
+    const pump = makePump({
+      expiresAt: new Date(NOW.getTime() + 30 * ONE_DAY_MS + 60_000),
+    });
+    expect(daysUntilExpiration(pump, NOW)).toBe(30);
+  });
+});
+
+describe('RM19 — evaluatePumpExpiration — pompe sans date', () => {
+  it('pompe sans expiresAt : pas d événement, status inchangé', () => {
+    const pump = makePump({ expiresAt: null, status: 'active' });
+    const update = evaluatePumpExpiration({ pump, nowUtc: NOW });
+    expect(update.events).toEqual([]);
+    expect(update.pump).toBe(pump);
+  });
+
+  it('pompe sans expiresAt : un previousRemainingDays passé est ignoré', () => {
+    const pump = makePump({ expiresAt: null });
+    const update = evaluatePumpExpiration({
+      pump,
+      previousRemainingDays: 100,
+      nowUtc: NOW,
+    });
+    expect(update.events).toEqual([]);
+  });
+});
+
+describe('RM19 — evaluatePumpExpiration — franchissement J-30', () => {
+  it('pompe à J-100 : aucun événement', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, 100), status: 'active' });
+    const update = evaluatePumpExpiration({
+      pump,
+      previousRemainingDays: 101,
+      nowUtc: NOW,
+    });
+    expect(update.events).toEqual([]);
+    expect(update.pump.status).toBe('active');
+  });
+
+  it('pompe à J-30 pile avec previousRemainingDays=31 : pump_expiring émis', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, 30), status: 'active' });
+    const update = evaluatePumpExpiration({
+      pump,
+      previousRemainingDays: 31,
+      nowUtc: NOW,
+    });
+    expect(update.events).toEqual(['pump_expiring_threshold_crossed']);
+    expect(update.pump.status).toBe('active');
+  });
+
+  it('pompe à J-29 avec previousRemainingDays=31 : franchissement émis', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, 29), status: 'active' });
+    const update = evaluatePumpExpiration({
+      pump,
+      previousRemainingDays: 31,
+      nowUtc: NOW,
+    });
+    expect(update.events).toEqual(['pump_expiring_threshold_crossed']);
+  });
+
+  it('pompe à J-25 avec previousRemainingDays=28 : pas d événement (déjà sous seuil)', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, 25), status: 'active' });
+    const update = evaluatePumpExpiration({
+      pump,
+      previousRemainingDays: 28,
+      nowUtc: NOW,
+    });
+    expect(update.events).toEqual([]);
+  });
+
+  it('pompe à J-30 sans previousRemainingDays : conservatif, pas d événement', () => {
+    // Choix sémantique : sans previous, on ne spam pas. L'UI peut rafraîchir
+    // via une autre voie. Protège contre les répétitions à chaque appel.
+    const pump = makePump({ expiresAt: offsetDays(NOW, 30), status: 'active' });
+    const update = evaluatePumpExpiration({ pump, nowUtc: NOW });
+    expect(update.events).toEqual([]);
+  });
+});
+
+describe('RM19 — evaluatePumpExpiration — expiration effective', () => {
+  it('pompe à J-0 (expires == now) : pump_expired émis + status=expired', () => {
+    const pump = makePump({ expiresAt: NOW, status: 'active' });
+    const update = evaluatePumpExpiration({ pump, nowUtc: NOW });
+    expect(update.events).toEqual(['pump_expired']);
+    expect(update.pump.status).toBe('expired');
+  });
+
+  it('pompe à J+5 avec status encore active : pump_expired + status corrigé', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, -5), status: 'active' });
+    const update = evaluatePumpExpiration({ pump, nowUtc: NOW });
+    expect(update.events).toEqual(['pump_expired']);
+    expect(update.pump.status).toBe('expired');
+  });
+
+  it('pompe à J-1 avec previousRemainingDays=2 : franchissement seulement si > 30, donc rien pour le seuil — mais expire dans 1 j donc pas expired', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, 1), status: 'active' });
+    const update = evaluatePumpExpiration({
+      pump,
+      previousRemainingDays: 2,
+      nowUtc: NOW,
+    });
+    expect(update.events).toEqual([]);
+    expect(update.pump.status).toBe('active');
+  });
+
+  it('pompe déjà en status expired : pas d événement (état final)', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, -10), status: 'expired' });
+    const update = evaluatePumpExpiration({ pump, nowUtc: NOW });
+    expect(update.events).toEqual([]);
+    expect(update.pump).toBe(pump);
+  });
+
+  it('pompe archived à J+5 : pas de transition vers expired (archived est terminal)', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, -5), status: 'archived' });
+    const update = evaluatePumpExpiration({ pump, nowUtc: NOW });
+    expect(update.events).toEqual([]);
+    expect(update.pump.status).toBe('archived');
+  });
+
+  it('pompe empty à J+5 : pas de transition vers expired (empty est terminal pour le cycle de prise)', () => {
+    const pump = makePump({
+      expiresAt: offsetDays(NOW, -5),
+      status: 'empty',
+      dosesRemaining: 0,
+    });
+    const update = evaluatePumpExpiration({ pump, nowUtc: NOW });
+    expect(update.events).toEqual([]);
+    expect(update.pump.status).toBe('empty');
+  });
+
+  it('expiration : franchissement 30j + expiré ne double pas (expired seul émis)', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, -1), status: 'active' });
+    const update = evaluatePumpExpiration({
+      pump,
+      previousRemainingDays: 50,
+      nowUtc: NOW,
+    });
+    expect(update.events).toEqual(['pump_expired']);
+  });
+});
+
+describe('RM19 — evaluatePumpExpiration — pureté', () => {
+  it('ne mute pas la pompe source', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, -1), status: 'active' });
+    const snapshot = { ...pump };
+    evaluatePumpExpiration({ pump, nowUtc: NOW });
+    expect(pump).toEqual(snapshot);
+  });
+
+  it('retourne une nouvelle instance quand le statut change', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, -1), status: 'active' });
+    const update = evaluatePumpExpiration({ pump, nowUtc: NOW });
+    expect(update.pump).not.toBe(pump);
+    expect(update.pump.status).toBe('expired');
+  });
+
+  it('retourne la même instance quand aucun changement', () => {
+    const pump = makePump({ expiresAt: offsetDays(NOW, 100), status: 'active' });
+    const update = evaluatePumpExpiration({ pump, nowUtc: NOW });
+    expect(update.pump).toBe(pump);
+  });
+});
+
+describe('RM19 — canUsePumpForDose', () => {
+  it('autorise une pompe active', () => {
+    const pump = makePump({ status: 'active', expiresAt: offsetDays(NOW, 60) });
+    expect(canUsePumpForDose({ pump, nowUtc: NOW })).toBe(true);
+  });
+
+  it('autorise une pompe low', () => {
+    const pump = makePump({ status: 'low' });
+    expect(canUsePumpForDose({ pump, nowUtc: NOW })).toBe(true);
+  });
+
+  it('refuse une pompe expired sans justification', () => {
+    const pump = makePump({ status: 'expired', expiresAt: offsetDays(NOW, -1) });
+    expect(canUsePumpForDose({ pump, nowUtc: NOW })).toBe(false);
+  });
+
+  it('autorise une pompe expired avec justification non vide', () => {
+    const pump = makePump({ status: 'expired', expiresAt: offsetDays(NOW, -1) });
+    expect(
+      canUsePumpForDose({
+        pump,
+        nowUtc: NOW,
+        adminForcedJustification: 'ordonnance en renouvellement',
+      }),
+    ).toBe(true);
+  });
+
+  it('refuse avec une justification whitespace (considérée vide)', () => {
+    const pump = makePump({ status: 'expired', expiresAt: offsetDays(NOW, -1) });
+    expect(canUsePumpForDose({ pump, nowUtc: NOW, adminForcedJustification: '   \t\n' })).toBe(
+      false,
+    );
+  });
+
+  it('refuse une pompe empty (RM7 prend le relais, pas un cas RM19)', () => {
+    const pump = makePump({ status: 'empty', dosesRemaining: 0 });
+    expect(canUsePumpForDose({ pump, nowUtc: NOW })).toBe(false);
+  });
+
+  it('refuse une pompe archived', () => {
+    const pump = makePump({ status: 'archived' });
+    expect(canUsePumpForDose({ pump, nowUtc: NOW })).toBe(false);
+  });
+
+  it('refuse une pompe active mais déjà expirée par la date', () => {
+    // La pompe n'a pas encore été "réconciliée" par evaluatePumpExpiration
+    // mais son expiresAt est déjà passé : la règle doit traiter le cas.
+    const pump = makePump({ status: 'active', expiresAt: offsetDays(NOW, -2) });
+    expect(canUsePumpForDose({ pump, nowUtc: NOW })).toBe(false);
+  });
+
+  it('autorise une pompe active expirée par la date avec justification Admin', () => {
+    const pump = makePump({ status: 'active', expiresAt: offsetDays(NOW, -2) });
+    expect(
+      canUsePumpForDose({
+        pump,
+        nowUtc: NOW,
+        adminForcedJustification: 'dépannage jusqu à pharmacie',
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('RM19 — ensurePumpUsableForDose', () => {
+  it('ne lève pas pour une pompe active', () => {
+    const pump = makePump({ status: 'active' });
+    expect(() => ensurePumpUsableForDose({ pump, nowUtc: NOW })).not.toThrow();
+  });
+
+  it('lève RM19_PUMP_EXPIRED pour une pompe expired sans justification', () => {
+    const pump = makePump({ status: 'expired', expiresAt: offsetDays(NOW, -1) });
+    try {
+      ensurePumpUsableForDose({ pump, nowUtc: NOW });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      const domainErr = err as DomainError;
+      expect(domainErr.code).toBe('RM19_PUMP_EXPIRED');
+    }
+  });
+
+  it('lève RM19_PUMP_EXPIRED pour une pompe active avec date passée sans justification', () => {
+    const pump = makePump({ status: 'active', expiresAt: offsetDays(NOW, -5) });
+    try {
+      ensurePumpUsableForDose({ pump, nowUtc: NOW });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM19_PUMP_EXPIRED');
+    }
+  });
+
+  it('ne lève pas pour une pompe expired avec justification Admin', () => {
+    const pump = makePump({ status: 'expired', expiresAt: offsetDays(NOW, -1) });
+    expect(() =>
+      ensurePumpUsableForDose({
+        pump,
+        nowUtc: NOW,
+        adminForcedJustification: 'renouvellement prescription',
+      }),
+    ).not.toThrow();
+  });
+
+  it('ne lève PAS RM19 pour une pompe empty ou archived (déléguée à RM7)', () => {
+    // RM19 ne doit pas empiler les erreurs avec RM7. Ici, on teste que
+    // la fonction ne lève pas RM19_PUMP_EXPIRED pour ces statuts :
+    // l'appelant devra consulter RM7 pour avoir le bon code.
+    const emptyPump = makePump({ status: 'empty', dosesRemaining: 0 });
+    const archivedPump = makePump({ status: 'archived' });
+    expect(() => ensurePumpUsableForDose({ pump: emptyPump, nowUtc: NOW })).not.toThrow();
+    expect(() => ensurePumpUsableForDose({ pump: archivedPump, nowUtc: NOW })).not.toThrow();
+  });
+
+  it('lève avec un contexte riche (pumpId, status, expiresAt, nowUtc)', () => {
+    const pump = makePump({
+      id: 'pump-42',
+      status: 'expired',
+      expiresAt: offsetDays(NOW, -3),
+    });
+    try {
+      ensurePumpUsableForDose({ pump, nowUtc: NOW });
+      throw new Error('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      const context = (err as DomainError).context;
+      expect(context).toBeDefined();
+      expect(context?.['pumpId']).toBe('pump-42');
+      expect(context?.['status']).toBe('expired');
+    }
+  });
+});

--- a/packages/domain/src/rules/rm19-pump-expiration.ts
+++ b/packages/domain/src/rules/rm19-pump-expiration.ts
@@ -1,0 +1,228 @@
+import type { Pump } from '../entities/pump';
+import { DomainError } from '../errors';
+
+/**
+ * Fenêtre d'avertissement (en jours) avant la date de péremption d'une pompe.
+ * À 30 j de l'échéance, un événement `pump_expiring_threshold_crossed` est
+ * émis pour déclencher la notification `pump_expiring` (SPECS §6 RM19).
+ *
+ * Borne **inclusive** : une pompe à exactement J-30 déclenche l'événement
+ * (convention cohérente avec les autres bornes du domaine, RM2/RM17/RM18/RM20).
+ */
+export const PUMP_EXPIRING_WARNING_WINDOW_DAYS = 30;
+
+const ONE_DAY_MS = 86_400_000;
+
+/**
+ * Événements métier émis par {@link evaluatePumpExpiration} pour notifier les
+ * transitions du cycle de vie « péremption » d'une pompe. Consommés côté
+ * `apps/api` pour mapper vers la notification `pump_expiring` (SPECS §3.10).
+ *
+ * - `pump_expiring_threshold_crossed` : la pompe vient de franchir (descendant)
+ *   le seuil J-30. Émis **une seule fois** au franchissement, jamais réémis.
+ *   Similaire à la sémantique edge-triggered de RM7 (`pump_low_threshold_crossed`).
+ * - `pump_expired` : la date de péremption est atteinte ou dépassée. Émis une
+ *   fois, au passage en statut `expired`. L'instance de pompe renvoyée a son
+ *   `status` corrigé à `'expired'`.
+ */
+export type PumpLifecycleEvent = 'pump_expiring_threshold_crossed' | 'pump_expired';
+
+/**
+ * Résultat de l'évaluation du cycle de vie péremption d'une pompe : pompe
+ * (éventuellement avec `status` mis à jour) + liste d'événements à propager.
+ */
+export interface PumpLifecycleUpdate {
+  readonly pump: Pump;
+  readonly events: ReadonlyArray<PumpLifecycleEvent>;
+}
+
+/**
+ * RM19 — calcule le nombre de jours restants avant la péremption. Retourne
+ * `null` si la pompe n'a pas de date de péremption (`expiresAt === null`),
+ * ce qui correspond à l'usage de dépannage où le flacon n'affiche pas de
+ * date lisible.
+ *
+ * Convention d'arrondi : `Math.floor` sur la différence en millisecondes. À
+ * 30 j et 1 minute, on est encore à `30` (la pompe vient juste d'entrer dans
+ * la fenêtre, pas d'urgence à afficher J-29). À J-0, retourne `0`. Après
+ * expiration, valeur négative.
+ *
+ * Comparaison en UTC pur — cohérent avec RM14.
+ */
+export function daysUntilExpiration(pump: Pump, nowUtc: Date): number | null {
+  if (pump.expiresAt === null) {
+    return null;
+  }
+  const deltaMs = pump.expiresAt.getTime() - nowUtc.getTime();
+  return Math.floor(deltaMs / ONE_DAY_MS);
+}
+
+/**
+ * Statuts « terminaux » du cycle de vie pompe : `empty` et `archived` ne
+ * doivent pas être réconciliés en `expired` par RM19. Une pompe vidée ou
+ * archivée l'est définitivement ; la péremption devient sans objet.
+ */
+const TERMINAL_STATUSES = new Set<Pump['status']>(['empty', 'archived', 'expired']);
+
+/**
+ * RM19 — évalue l'état d'expiration d'une pompe à un instant donné et émet
+ * les événements métier correspondants.
+ *
+ * Sémantique edge-triggered (comme RM7) :
+ * - `pump_expiring_threshold_crossed` n'est émis **qu'au franchissement**
+ *   descendant du seuil J-30. Détecté via `previousRemainingDays` : si la
+ *   précédente évaluation était strictement > 30 et la nouvelle ≤ 30, on
+ *   émet. Sans `previousRemainingDays`, on reste conservatif — aucune
+ *   émission, pour éviter le spam de notification à chaque appel.
+ * - `pump_expired` est émis au passage à `status = 'expired'`. Si la pompe
+ *   est déjà `expired` / `empty` / `archived`, rien n'est émis et le status
+ *   est préservé.
+ *
+ * Si `pump_expired` est levé, il prend le pas sur `pump_expiring_*` (une
+ * pompe expirée n'a plus besoin d'avertissement préventif).
+ *
+ * Fonction pure. Retourne la même instance si aucun changement ; nouvelle
+ * instance avec `status` mis à jour si passage à `expired`.
+ */
+export function evaluatePumpExpiration(options: {
+  readonly pump: Pump;
+  readonly previousRemainingDays?: number;
+  readonly nowUtc: Date;
+}): PumpLifecycleUpdate {
+  const { pump, previousRemainingDays, nowUtc } = options;
+
+  // Pompe sans date : hors du cycle RM19.
+  if (pump.expiresAt === null) {
+    return { pump, events: [] };
+  }
+
+  // Pompes en statut terminal (empty / archived / déjà expired) : pas de
+  // réconciliation. La péremption devient sans objet dès qu'une pompe est
+  // sortie du cycle normal.
+  if (TERMINAL_STATUSES.has(pump.status)) {
+    return { pump, events: [] };
+  }
+
+  const remainingDays = Math.floor((pump.expiresAt.getTime() - nowUtc.getTime()) / ONE_DAY_MS);
+
+  // Cas 1 : expirée (J-0 ou au-delà). Passage en `expired`, événement unique
+  // `pump_expired` qui prime sur l'avertissement J-30.
+  if (remainingDays <= 0) {
+    const updatedPump: Pump = { ...pump, status: 'expired' };
+    return { pump: updatedPump, events: ['pump_expired'] };
+  }
+
+  // Cas 2 : franchissement descendant du seuil J-30. Nécessite un état
+  // précédent pour être edge-triggered, sinon pas d'émission (conservatif).
+  if (
+    previousRemainingDays !== undefined &&
+    previousRemainingDays > PUMP_EXPIRING_WARNING_WINDOW_DAYS &&
+    remainingDays <= PUMP_EXPIRING_WARNING_WINDOW_DAYS
+  ) {
+    return { pump, events: ['pump_expiring_threshold_crossed'] };
+  }
+
+  return { pump, events: [] };
+}
+
+/**
+ * RM19 — normalise une justification Admin : retourne `null` si absente,
+ * vide ou whitespace-only ; sinon la chaîne trimée.
+ */
+function normalizeJustification(raw: string | undefined): string | null {
+  if (raw === undefined) {
+    return null;
+  }
+  const trimmed = raw.trim();
+  return trimmed.length === 0 ? null : trimmed;
+}
+
+/**
+ * RM19 — détermine si une pompe a effectivement dépassé sa date de
+ * péremption (expiresAt ≤ nowUtc), indépendamment du statut courant. Utilisé
+ * par {@link canUsePumpForDose} pour refuser une prise même quand le statut
+ * n'a pas encore été réconcilié par {@link evaluatePumpExpiration}.
+ */
+function isEffectivelyExpired(pump: Pump, nowUtc: Date): boolean {
+  if (pump.status === 'expired') {
+    return true;
+  }
+  if (pump.expiresAt === null) {
+    return false;
+  }
+  return pump.expiresAt.getTime() <= nowUtc.getTime();
+}
+
+/**
+ * RM19 — vrai ssi la pompe peut accueillir une nouvelle prise. Cas bloquants
+ * RM19 :
+ * - pompe effectivement expirée (status `expired` OU date dépassée) sans
+ *   `adminForcedJustification` non vide.
+ *
+ * Cas délégués (renvoient `false` sans lever RM19) : `empty`, `archived`. Ces
+ * statuts relèvent de RM7 (`RM7_PUMP_ALREADY_EMPTY`, `RM7_PUMP_NOT_USABLE`).
+ * {@link ensurePumpUsableForDose} ne lèvera donc pas `RM19_PUMP_EXPIRED` pour
+ * ces cas — c'est à l'appelant de chaîner vers RM7 pour obtenir un message
+ * adapté.
+ */
+export function canUsePumpForDose(options: {
+  readonly pump: Pump;
+  readonly nowUtc: Date;
+  readonly adminForcedJustification?: string;
+}): boolean {
+  const { pump, nowUtc, adminForcedJustification } = options;
+
+  if (pump.status === 'empty' || pump.status === 'archived') {
+    return false;
+  }
+
+  if (isEffectivelyExpired(pump, nowUtc)) {
+    return normalizeJustification(adminForcedJustification) !== null;
+  }
+
+  return true;
+}
+
+/**
+ * RM19 — assertion : la pompe accepte une nouvelle prise. Lève
+ * `RM19_PUMP_EXPIRED` si la pompe est expirée sans override Admin valide.
+ *
+ * Ne lève **pas** pour les statuts `empty` / `archived` : ces cas sont
+ * portés par RM7 pour éviter la duplication de codes d'erreur. L'appelant
+ * doit ensuite passer par RM7 si besoin d'une vérification complémentaire.
+ *
+ * @throws {DomainError} `RM19_PUMP_EXPIRED` si la pompe est en status
+ *   `expired` (ou si sa date de péremption est déjà passée) et qu'aucune
+ *   justification Admin non vide n'est fournie.
+ */
+export function ensurePumpUsableForDose(options: {
+  readonly pump: Pump;
+  readonly nowUtc: Date;
+  readonly adminForcedJustification?: string;
+}): void {
+  const { pump, nowUtc, adminForcedJustification } = options;
+
+  if (pump.status === 'empty' || pump.status === 'archived') {
+    // Délégation à RM7 — on ne lève pas RM19 ici.
+    return;
+  }
+
+  if (!isEffectivelyExpired(pump, nowUtc)) {
+    return;
+  }
+
+  if (normalizeJustification(adminForcedJustification) !== null) {
+    return;
+  }
+
+  throw new DomainError(
+    'RM19_PUMP_EXPIRED',
+    `Pump ${pump.id} is expired; a new dose requires an admin-provided justification.`,
+    {
+      pumpId: pump.id,
+      status: pump.status,
+      expiresAt: pump.expiresAt?.toISOString() ?? null,
+      nowUtc: nowUtc.toISOString(),
+    },
+  );
+}

--- a/packages/domain/src/rules/rm19-pump-expiration.ts
+++ b/packages/domain/src/rules/rm19-pump-expiration.ts
@@ -58,11 +58,17 @@ export function daysUntilExpiration(pump: Pump, nowUtc: Date): number | null {
 }
 
 /**
- * Statuts « terminaux » du cycle de vie pompe : `empty` et `archived` ne
- * doivent pas être réconciliés en `expired` par RM19. Une pompe vidée ou
- * archivée l'est définitivement ; la péremption devient sans objet.
+ * Statuts dont l'état ne doit pas être modifié par RM19 : `empty` et
+ * `archived` sont des fins de vie (la péremption devient sans objet) ;
+ * `expired` est l'état cible lui-même (idempotence — pas de ré-émission
+ * de `pump_expired` sur une pompe déjà marquée). RM19 ne traite donc que
+ * les pompes en statut `active` ou `low`.
  */
-const TERMINAL_STATUSES = new Set<Pump['status']>(['empty', 'archived', 'expired']);
+const PUMP_STATUSES_NOT_RECONCILED_BY_RM19 = new Set<Pump['status']>([
+  'empty',
+  'archived',
+  'expired',
+]);
 
 /**
  * RM19 — évalue l'état d'expiration d'une pompe à un instant donné et émet
@@ -99,7 +105,7 @@ export function evaluatePumpExpiration(options: {
   // Pompes en statut terminal (empty / archived / déjà expired) : pas de
   // réconciliation. La péremption devient sans objet dès qu'une pompe est
   // sortie du cycle normal.
-  if (TERMINAL_STATUSES.has(pump.status)) {
+  if (PUMP_STATUSES_NOT_RECONCILED_BY_RM19.has(pump.status)) {
     return { pump, events: [] };
   }
 

--- a/packages/domain/src/rules/rm20-offline-access.test.ts
+++ b/packages/domain/src/rules/rm20-offline-access.test.ts
@@ -6,6 +6,7 @@ import {
   decideOfflineWriteAccess,
   filterDosesAvailableOffline,
   OFFLINE_READ_WINDOW_DAYS,
+  type OfflineWriteDecision,
 } from './rm20-offline-access';
 
 const NOW = new Date('2026-04-19T12:00:00Z');
@@ -240,12 +241,22 @@ describe('RM20 — decideOfflineWriteAccess', () => {
     expect(pump).toEqual(snapshot);
   });
 
-  it('cases exhaustifs : chaque PumpStatus produit une décision', () => {
-    const statuses: PumpStatus[] = ['active', 'low', 'empty', 'expired', 'archived'];
-    for (const status of statuses) {
+  it('décision par statut de pompe (matrice explicite)', () => {
+    // Couverture stricte par Record : toute modification silencieuse
+    // d'un mapping statut→décision casse le test, contrairement à une
+    // assertion "∈ {allowed, refused}" qui laisserait passer une
+    // régression (ex: active → refused par erreur).
+    const expected: Record<PumpStatus, OfflineWriteDecision['kind']> = {
+      active: 'allowed',
+      low: 'allowed',
+      empty: 'refused',
+      expired: 'refused',
+      archived: 'refused',
+    };
+    for (const status of Object.keys(expected) as PumpStatus[]) {
       const pump = makePump({ status });
       const decision = decideOfflineWriteAccess({ pump, nowUtc: NOW });
-      expect(['allowed', 'refused']).toContain(decision.kind);
+      expect(decision.kind).toBe(expected[status]);
     }
   });
 });

--- a/packages/domain/src/rules/rm20-offline-access.test.ts
+++ b/packages/domain/src/rules/rm20-offline-access.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+import type { Dose } from '../entities/dose';
+import type { Pump, PumpStatus } from '../entities/pump';
+import {
+  decideOfflineReadAccess,
+  decideOfflineWriteAccess,
+  filterDosesAvailableOffline,
+  OFFLINE_READ_WINDOW_DAYS,
+} from './rm20-offline-access';
+
+const NOW = new Date('2026-04-19T12:00:00Z');
+const ONE_DAY_MS = 86_400_000;
+
+function offsetDays(base: Date, days: number): Date {
+  return new Date(base.getTime() + days * ONE_DAY_MS);
+}
+
+function makePump(overrides: Partial<Pump> = {}): Pump {
+  return {
+    id: 'pump-1',
+    householdId: 'h1',
+    type: 'maintenance',
+    status: 'active',
+    label: 'Flovent HFA 125',
+    dosesRemaining: 50,
+    expiresAt: new Date('2027-01-01T00:00:00Z'),
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+function makeDose(overrides: Partial<Dose> = {}): Dose {
+  return {
+    id: 'dose-1',
+    householdId: 'h1',
+    childId: 'c1',
+    pumpId: 'pump-1',
+    caregiverId: 'u1',
+    type: 'maintenance',
+    status: 'confirmed',
+    source: 'manual',
+    dosesAdministered: 1,
+    administeredAtUtc: NOW,
+    recordedAtUtc: NOW,
+    symptoms: [],
+    circumstances: [],
+    freeFormTag: null,
+    voidedReason: null,
+    ...overrides,
+  };
+}
+
+describe('RM20 — constante', () => {
+  it('expose la fenêtre offline de 30 jours', () => {
+    expect(OFFLINE_READ_WINDOW_DAYS).toBe(30);
+  });
+});
+
+describe('RM20 — decideOfflineReadAccess', () => {
+  it('accepte une prise récente (1 jour)', () => {
+    const decision = decideOfflineReadAccess({
+      doseRecordedAtUtc: offsetDays(NOW, -1),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('available_offline');
+    expect(decision.ageDays).toBe(1);
+  });
+
+  it('accepte une prise à 29 jours', () => {
+    const decision = decideOfflineReadAccess({
+      doseRecordedAtUtc: offsetDays(NOW, -29),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('available_offline');
+    expect(decision.ageDays).toBe(29);
+  });
+
+  it('accepte une prise à 30 jours pile (borne inclusive)', () => {
+    const decision = decideOfflineReadAccess({
+      doseRecordedAtUtc: offsetDays(NOW, -30),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('available_offline');
+    expect(decision.ageDays).toBe(30);
+  });
+
+  it('refuse une prise à 31 jours', () => {
+    const decision = decideOfflineReadAccess({
+      doseRecordedAtUtc: offsetDays(NOW, -31),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('requires_network');
+    expect(decision.ageDays).toBe(31);
+  });
+
+  it('clampe l age à 0 pour une prise future (sync tardive)', () => {
+    const decision = decideOfflineReadAccess({
+      doseRecordedAtUtc: offsetDays(NOW, 2),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('available_offline');
+    expect(decision.ageDays).toBe(0);
+  });
+
+  it('age de 0 quand la prise est à l instant nowUtc', () => {
+    const decision = decideOfflineReadAccess({
+      doseRecordedAtUtc: NOW,
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('available_offline');
+    expect(decision.ageDays).toBe(0);
+  });
+
+  it('arrondit à la journée pleine inférieure (12 h = jour 0)', () => {
+    const decision = decideOfflineReadAccess({
+      doseRecordedAtUtc: new Date(NOW.getTime() - 12 * 60 * 60_000),
+      nowUtc: NOW,
+    });
+    expect(decision.kind).toBe('available_offline');
+    expect(decision.ageDays).toBe(0);
+  });
+});
+
+describe('RM20 — filterDosesAvailableOffline', () => {
+  it('retourne un tableau vide pour une liste vide', () => {
+    const result = filterDosesAvailableOffline([], NOW);
+    expect(result).toEqual([]);
+  });
+
+  it('garde uniquement les prises des 30 derniers jours, ordre préservé', () => {
+    const recent = makeDose({ id: 'd-recent', recordedAtUtc: offsetDays(NOW, -5) });
+    const edge = makeDose({ id: 'd-edge', recordedAtUtc: offsetDays(NOW, -30) });
+    const tooOld = makeDose({ id: 'd-old', recordedAtUtc: offsetDays(NOW, -31) });
+    const veryOld = makeDose({ id: 'd-very-old', recordedAtUtc: offsetDays(NOW, -120) });
+
+    const result = filterDosesAvailableOffline([recent, edge, tooOld, veryOld], NOW);
+    expect(result.map((d) => d.id)).toEqual(['d-recent', 'd-edge']);
+  });
+
+  it('inclut une prise sans recordedAtUtc (retombe sur administeredAtUtc)', () => {
+    const dose = makeDose({
+      id: 'd-offline',
+      recordedAtUtc: null,
+      administeredAtUtc: offsetDays(NOW, -2),
+    });
+    const result = filterDosesAvailableOffline([dose], NOW);
+    expect(result.map((d) => d.id)).toEqual(['d-offline']);
+  });
+
+  it('ne mute pas l input (pureté)', () => {
+    const doses: readonly Dose[] = [
+      makeDose({ id: 'd1', recordedAtUtc: offsetDays(NOW, -1) }),
+      makeDose({ id: 'd2', recordedAtUtc: offsetDays(NOW, -60) }),
+    ];
+    const snapshot = JSON.stringify(doses);
+    filterDosesAvailableOffline(doses, NOW);
+    expect(JSON.stringify(doses)).toBe(snapshot);
+  });
+});
+
+describe('RM20 — decideOfflineWriteAccess', () => {
+  it('autorise la saisie sur une pompe active', () => {
+    const pump = makePump({ status: 'active' });
+    const decision = decideOfflineWriteAccess({ pump, nowUtc: NOW });
+    expect(decision.kind).toBe('allowed');
+  });
+
+  it('autorise la saisie sur une pompe low', () => {
+    const pump = makePump({ status: 'low' });
+    const decision = decideOfflineWriteAccess({ pump, nowUtc: NOW });
+    expect(decision.kind).toBe('allowed');
+  });
+
+  it('refuse la saisie sur une pompe expired sans override', () => {
+    const pump = makePump({
+      status: 'expired',
+      expiresAt: offsetDays(NOW, -1),
+    });
+    const decision = decideOfflineWriteAccess({ pump, nowUtc: NOW });
+    expect(decision.kind).toBe('refused');
+    if (decision.kind === 'refused') {
+      expect(decision.reason).toBe('pump_not_usable');
+    }
+  });
+
+  it('autorise la saisie sur une pompe expired avec override Admin justifié', () => {
+    const pump = makePump({
+      status: 'expired',
+      expiresAt: offsetDays(NOW, -1),
+    });
+    const decision = decideOfflineWriteAccess({
+      pump,
+      nowUtc: NOW,
+      adminForcedJustification: 'ordonnance renouvelée en attente',
+    });
+    expect(decision.kind).toBe('allowed');
+  });
+
+  it('refuse la saisie avec justification whitespace (vide)', () => {
+    const pump = makePump({
+      status: 'expired',
+      expiresAt: offsetDays(NOW, -1),
+    });
+    const decision = decideOfflineWriteAccess({
+      pump,
+      nowUtc: NOW,
+      adminForcedJustification: '   ',
+    });
+    expect(decision.kind).toBe('refused');
+  });
+
+  it('refuse la saisie sur une pompe empty', () => {
+    const pump = makePump({ status: 'empty', dosesRemaining: 0 });
+    const decision = decideOfflineWriteAccess({ pump, nowUtc: NOW });
+    expect(decision.kind).toBe('refused');
+    if (decision.kind === 'refused') {
+      expect(decision.reason).toBe('pump_not_usable');
+    }
+  });
+
+  it('refuse la saisie sur une pompe archived', () => {
+    const pump = makePump({ status: 'archived' });
+    const decision = decideOfflineWriteAccess({ pump, nowUtc: NOW });
+    expect(decision.kind).toBe('refused');
+  });
+
+  it('refuse la saisie sur une pompe expired par date même si status=active (cohérence RM19)', () => {
+    const pump = makePump({
+      status: 'active',
+      expiresAt: offsetDays(NOW, -5),
+    });
+    const decision = decideOfflineWriteAccess({ pump, nowUtc: NOW });
+    expect(decision.kind).toBe('refused');
+  });
+
+  it('pureté : ne mute pas la pompe', () => {
+    const pump = makePump({ status: 'active' });
+    const snapshot = { ...pump };
+    decideOfflineWriteAccess({ pump, nowUtc: NOW });
+    expect(pump).toEqual(snapshot);
+  });
+
+  it('cases exhaustifs : chaque PumpStatus produit une décision', () => {
+    const statuses: PumpStatus[] = ['active', 'low', 'empty', 'expired', 'archived'];
+    for (const status of statuses) {
+      const pump = makePump({ status });
+      const decision = decideOfflineWriteAccess({ pump, nowUtc: NOW });
+      expect(['allowed', 'refused']).toContain(decision.kind);
+    }
+  });
+});

--- a/packages/domain/src/rules/rm20-offline-access.ts
+++ b/packages/domain/src/rules/rm20-offline-access.ts
@@ -1,0 +1,126 @@
+import type { Dose } from '../entities/dose';
+import type { Pump } from '../entities/pump';
+import { canUsePumpForDose } from './rm19-pump-expiration';
+
+/**
+ * Fenêtre de consultation hors-ligne (en jours) — l'historique des 30 derniers
+ * jours est disponible offline (SPECS §6 RM20). Au-delà, l'affichage nécessite
+ * une connexion pour charger la page depuis le relais.
+ *
+ * Borne **inclusive** : une prise à exactement 30 jours reste consultable.
+ */
+export const OFFLINE_READ_WINDOW_DAYS = 30;
+
+const ONE_DAY_MS = 86_400_000;
+const OFFLINE_READ_WINDOW_MS = OFFLINE_READ_WINDOW_DAYS * ONE_DAY_MS;
+
+/**
+ * Décision RM20 côté lecture : la prise est-elle disponible dans le cache
+ * local offline ? `ageDays` est fourni pour l'UI (badge « il y a N jours »).
+ *
+ * - `available_offline` : la prise est dans la fenêtre (0 ≤ âge ≤ 30 j).
+ * - `requires_network` : la prise est plus ancienne ; l'UI doit annoncer la
+ *   nécessité d'une connexion pour l'afficher.
+ */
+export interface OfflineReadDecision {
+  readonly kind: 'available_offline' | 'requires_network';
+  readonly ageDays: number;
+}
+
+/**
+ * RM20 — détermine si une prise donnée est consultable en mode offline. La
+ * règle ne considère **pas** l'état réseau courant (hors-domaine) ; elle
+ * décide seulement si la prise doit figurer dans la projection locale des 30
+ * derniers jours.
+ *
+ * `ageDays` est calculé avec `Math.floor` sur la différence en millisecondes :
+ * une prise vieille de 29 j 23 h reste « jour 29 ». Une prise postérieure à
+ * `nowUtc` (cas d'une synchronisation tardive ou d'un léger décalage
+ * d'horloge) est clampée à `ageDays = 0` et reste disponible.
+ *
+ * Fonction pure : aucun I/O, aucune mutation.
+ */
+export function decideOfflineReadAccess(options: {
+  readonly doseRecordedAtUtc: Date;
+  readonly nowUtc: Date;
+}): OfflineReadDecision {
+  const elapsedMs = options.nowUtc.getTime() - options.doseRecordedAtUtc.getTime();
+  const ageDays = elapsedMs <= 0 ? 0 : Math.floor(elapsedMs / ONE_DAY_MS);
+
+  if (elapsedMs <= OFFLINE_READ_WINDOW_MS) {
+    return { kind: 'available_offline', ageDays };
+  }
+
+  return { kind: 'requires_network', ageDays };
+}
+
+/**
+ * RM20 — filtre une collection de prises pour ne conserver que celles
+ * consultables en mode offline (30 derniers jours). L'ordre d'entrée est
+ * préservé.
+ *
+ * Référence temporelle : `recordedAtUtc` (horodatage serveur, RM14). Si
+ * absent — cas d'une prise encore dans la file offline, jamais confirmée par
+ * le serveur — on retombe sur `administeredAtUtc` pour ne pas masquer les
+ * saisies locales qui n'ont pas encore rejoint le relais.
+ *
+ * Fonction pure : retourne une **nouvelle** liste (readonly), ne mute pas
+ * l'input.
+ */
+export function filterDosesAvailableOffline(
+  doses: readonly Dose[],
+  nowUtc: Date,
+): ReadonlyArray<Dose> {
+  return doses.filter((dose) => {
+    const reference = dose.recordedAtUtc ?? dose.administeredAtUtc;
+    return (
+      decideOfflineReadAccess({
+        doseRecordedAtUtc: reference,
+        nowUtc,
+      }).kind === 'available_offline'
+    );
+  });
+}
+
+/**
+ * Décision RM20 côté écriture. La règle est simple : la saisie est toujours
+ * autorisée offline **tant que la pompe le permet** (RM7 / RM19). La seule
+ * raison de refus est donc côté pompe — jamais le réseau. Le domaine ne
+ * connaît pas l'état de la connexion.
+ */
+export type OfflineWriteDecision =
+  | { readonly kind: 'allowed' }
+  | { readonly kind: 'refused'; readonly reason: 'pump_not_usable' };
+
+/**
+ * RM20 — détermine si une saisie de prise est autorisée. La règle délègue
+ * l'évaluation de l'état de la pompe à RM19 ({@link canUsePumpForDose}) :
+ * pompes `active` et `low` acceptent la saisie ; les pompes `expired` sans
+ * override Admin, `empty` ou `archived` sont refusées.
+ *
+ * Point important de conception : **RM20 ne bloque jamais une saisie pour
+ * cause de réseau absent.** La promesse produit est « saisie offline
+ * toujours possible » (SPECS §6 RM20). Le seul frein est l'intégrité du
+ * cycle de vie pompe.
+ *
+ * Fonction pure.
+ */
+export function decideOfflineWriteAccess(options: {
+  readonly pump: Pump;
+  readonly nowUtc: Date;
+  readonly adminForcedJustification?: string;
+}): OfflineWriteDecision {
+  const usable = canUsePumpForDose({
+    pump: options.pump,
+    nowUtc: options.nowUtc,
+    ...(options.adminForcedJustification !== undefined
+      ? { adminForcedJustification: options.adminForcedJustification }
+      : {}),
+  });
+
+  if (usable) {
+    return { kind: 'allowed' };
+  }
+
+  return { kind: 'refused', reason: 'pump_not_usable' };
+}


### PR DESCRIPTION
## Résumé

Onzième lot de travaux dans `@kinhale/domain`. Lot **D2 — lifecycle pompe + offline** :

- **RM19** — Expiration de pompe : événements edge-triggered J-30 et J-0, refus d'usage sauf override Admin justifié
- **RM20** — Mode hors-ligne : lecture historique 30j offline, saisie toujours possible tant que la pompe le permet

**62 nouveaux tests** (40 RM19 + 22 RM20). Total domain : 443 → **505 tests** tous verts.

## Workflow pré-PR appliqué

- **kz-review** → APPROUVÉ AVEC RÉSERVES MINEURES, 0 MAJEUR
- Pas de kz-securite (zone non-sensible : pas de crypto, pas de payload externe)

Corrections intégrées dans le commit `ca16146` :
- **M1** : renommage `TERMINAL_STATUSES` → `PUMP_STATUSES_NOT_RECONCILED_BY_RM19` avec JSDoc clarifiée
- **M5** : test long scindé en 2 tests atomiques (franchissement seuil vs transition expired)
- **M6** : test "cases exhaustifs" renforcé via `Record<PumpStatus, OfflineWriteDecision['kind']>` (matrice explicite)

Autres MINEURS (M2-M4) non-bloquants conservés en l'état.

## API RM19

```ts
export const PUMP_EXPIRING_WARNING_WINDOW_DAYS = 30;

export type PumpLifecycleEvent = 'pump_expiring_threshold_crossed' | 'pump_expired';

export interface PumpLifecycleUpdate {
  readonly pump: Pump;
  readonly events: ReadonlyArray<PumpLifecycleEvent>;
}

export function evaluatePumpExpiration({pump, previousRemainingDays?, nowUtc}): PumpLifecycleUpdate;
export function daysUntilExpiration(pump, nowUtc): number | null;
export function canUsePumpForDose({pump, nowUtc, adminForcedJustification?}): boolean;
export function ensurePumpUsableForDose({pump, nowUtc, adminForcedJustification?}): void;
```

**Sémantique edge-triggered** (cohérent pattern RM7) :
- `pump_expiring_threshold_crossed` uniquement si `previousRemainingDays > 30 && new <= 30`
- Sans `previousRemainingDays` fourni → aucun événement (conservatif anti-spam)
- `pump_expired` inclusif à J-0
- Priorité `pump_expired` > `pump_expiring_threshold_crossed` (pas de double émission sur saut direct)

**Override Admin** : `adminForcedJustification` trim, whitespace rejeté. Cohérent RM18 (void).

**Délégation claire** : RM19 ne gère QUE la péremption. Pompe `empty`/`archived` relève de RM7 (`RM7_PUMP_NOT_USABLE`). L'appelant doit chaîner RM19 → RM7.

## API RM20

```ts
export const OFFLINE_READ_WINDOW_DAYS = 30;

export type OfflineReadDecision = { kind: 'available_offline' | 'requires_network'; ageDays: number };
export type OfflineWriteDecision = { kind: 'allowed' } | { kind: 'refused'; reason: 'pump_not_usable' };

export function decideOfflineReadAccess({doseRecordedAtUtc, nowUtc}): OfflineReadDecision;
export function filterDosesAvailableOffline(doses, nowUtc): ReadonlyArray<Dose>;
export function decideOfflineWriteAccess({pump, nowUtc, adminForcedJustification?}): OfflineWriteDecision;
```

**Asymétrie assumée** :
- **Lecture** : bornée à 30j (cache local)
- **Écriture** : toujours autorisée tant que la pompe est utilisable (délégation à RM19 `canUsePumpForDose`). Le domaine ne connaît PAS le réseau — c'est à l'infra de décider en ligne/hors ligne, mais la règle ne bloque jamais sur ce critère.

**Clamp `ageDays = 0` pour doses futures** : synchro tardive RM14 ne produit pas "il y a -2 jours".

**Fallback `recordedAtUtc ?? administeredAtUtc`** : cohérent RM18 pour les doses offline non encore synchronisées.

## Code d'erreur ajouté

- `RM19_PUMP_EXPIRED` — prise tentée sur pompe expirée sans override Admin. Context : `{pumpId, status, expiresAt, nowUtc}` — aucun `pumpLabel` ni donnée nominative.

## Choix sémantiques verrouillés

- **RM19 `daysUntilExpiration`** : `Math.floor(deltaMs / 86_400_000)` — jours pleins restants (J-30 + 1 min reste J-30)
- **RM19 edge-triggered conservatif** : sans `previousRemainingDays`, aucune émission (évite spam sur polling)
- **RM19 fuseau UTC pur** cohérent RM14
- **RM19 délégation RM7** : pompe `empty`/`archived` traitée par RM7, pas RM19
- **RM20 borne 30j inclusive** (cohérent RM2/RM18)
- **RM20 ne connaît pas le réseau** : délègue à l'état pompe, la décision réseau est infra
- **Override Admin** : justification trim, whitespace rejeté (cohérent RM18)

## Points à documenter côté appelant API (non bloquants)

1. **Chaînage d'ordre** recommandé côté API : RM19 (expiration + override) → RM17 (backfill) → RM14 (timestamp) → RM6 (dup) → RM7 (count + empty) → RM5 (notif).
2. **Persistence `previousRemainingDays`** : le job cron qui scanne les pompes doit stocker le dernier `remainingDays` en DB pour alimenter correctement `evaluatePumpExpiration` — sans cela, `pump_expiring_threshold_crossed` ne sera jamais émis.
3. **Justification Admin** : le domaine évalue la justification mais ne la persiste pas. L'API doit l'enregistrer dans l'audit log (RM24 / SPECS §audit).

Ces 3 points devraient être traités dans les ADRs `apps/api` correspondants lors de l'intégration.

## Vérifications

- [x] `pnpm --filter @kinhale/domain typecheck` : vert
- [x] `pnpm --filter @kinhale/domain lint` : vert
- [x] `pnpm --filter @kinhale/domain test` : **505/505**
- [x] `pnpm format:check` : vert
- [x] `pnpm lint:root` : vert
- [x] kz-review passé pré-PR : 0 MAJEUR
- [x] Pas de `Date.now()`, `Math.random()`, `console.*`, `!` non-null
- [x] Aucune règle existante modifiée, additifs uniquement
- [x] Aucune donnée nominative dans les contexts d'erreur

## Taille de PR

1 020 insertions (dont ~620 de tests, ratio test/prod ~1.8x). Au-dessus de 400 lignes mais justifiée : 2 règles lifecycle d'une même famille (pompe + offline), avec 61 tests couvrant bornes temporelles, états terminaux, override Admin.

## Avancement v1.0 domaine

**24/28 règles après merge (86%)** : RM1-9, RM13-22, RM24-28.

**4 restantes** : RM10, RM11, RM12, RM23.

## Ce qui arrive ensuite

- **Lot D3 — Rôles & sessions** : RM10 (suppression compte/foyer) + RM11 (sessions kiosque) + RM12 (transfert admin) — 3 règles
- **Lot E — Géolocalisation** : RM23 (opt-in géoloc) — règle unitaire

Ces 4 règles closent la v1.0 domaine. Ensuite place à l'intégration `apps/api`.

## Test plan

- [ ] Cloner + `pnpm install` + `pnpm test` → 505/505 vert
- [ ] `pnpm lint:root` + `pnpm format:check` → verts
- [ ] Valider le choix `Math.floor` pour `daysUntilExpiration`
- [ ] Valider le design conservatif `previousRemainingDays` (ou trancher : émettre toujours à J-30 même sans historique ?)

---

Refs : KIN-015

🤖 Generated with [Claude Code](https://claude.com/claude-code)