### PR TITLE
feat(KIN-017): RM23 géolocalisation opt-in — clôture v1.0 domaine (28/28)

### DIFF
--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -23,26 +23,36 @@ src/
 
 | Règle   | Description                                                        | Source specs |
 | ------- | ------------------------------------------------------------------ | ------------ |
-| **RM1** | Un foyer a au moins un Admin en permanence                         | §4, RM1      |
-| **RM2** | Fenêtre de confirmation \[10-120 min\] + rattrapage borné à 24 h    | §4, RM2      |
-| **RM3** | Pas de plan de traitement sur une pompe `rescue`                   | §4, RM3      |
-| **RM4** | Prise `rescue` exige symptôme, circonstance ou tag libre           | §4, RM4      |
-| **RM5** | Notification croisée aux autres aidants actifs non-restricted      | §4, RM5      |
-| **RM6** | Détection double saisie : même pompe + type à moins de 2 min       | §4, RM6      |
-| **RM7** | Décompte doses pompe + alertes `pump_low` / `pump_emptied`         | §4, RM7      |
-| **RM14**| Horodatage serveur autoritaire (`recordedAtUtc`) + flag sync tardive | §4, RM14     |
-| **RM15**| Idempotence des saisies via `clientEventId` (UUID v4)              | §4, RM15     |
-| **RM17**| Rattrapage borné : backfill ≤ 24 h, futur refusé, confirmation au-delà | §4, RM17 |
-| **RM18**| Annulation : 30 min libres pour l'auteur ou un Admin, puis Admin + raison | §4, RM18 |
-| **RM25**| Rappels bornés : 2 relances max (push T+15 min, e-mail T+30 min)   | §4, RM25     |
-| **RM26**| Regroupement notifications peer : ≥ 3 prises/h + cap 15 notif/jour | §4, RM26     |
-| **RM21**| Limite anti-spam : max 10 invitations actives simultanées par foyer | §4, RM21     |
-| **RM22**| Consentement aidant invité : propres données uniquement, pas l'enfant | §4, RM22   |
-| **RM24**| Intégrité rapport : SHA-256 du contenu + timestamp + générateur (pied PDF) | §4, RM24 |
-| **RM27**| Disclaimer omniprésent aux 4 surfaces (onboarding, CGU, rapport, À propos) | §4, RM27 |
-| **RM28**| Purge invitations : `expired > 30 j`, `consumed > 90 j`, `revoked > 30 j` | §4, RM28 |
+| **RM1**  | Un foyer a au moins un Admin en permanence                                  | §4, RM1  |
+| **RM2**  | Fenêtre de confirmation \[10-120 min\] + rattrapage borné à 24 h            | §4, RM2  |
+| **RM3**  | Pas de plan de traitement sur une pompe `rescue`                            | §4, RM3  |
+| **RM4**  | Prise `rescue` exige symptôme, circonstance ou tag libre                    | §4, RM4  |
+| **RM5**  | Notification croisée aux autres aidants actifs non-restricted               | §4, RM5  |
+| **RM6**  | Détection double saisie : même pompe + type à moins de 2 min                | §4, RM6  |
+| **RM7**  | Décompte doses pompe + alertes `pump_low` / `pump_emptied`                  | §4, RM7  |
+| **RM8**  | Rapport médecin : agrégation confirmed/voided, fréquence rescue hebdomadaire | §4, RM8 |
+| **RM9**  | Acceptation CGU / Politique : version semver, tolérance NTP, majeurs cohérents | §4, RM9 |
+| **RM10** | Suppression foyer : grâce 7 j, portabilité, pseudonymisation audit          | §4, RM10 |
+| **RM11** | Multi-tenant : anti-IDOR tenant + caregiver (token vs requête)              | §4, RM11 |
+| **RM12** | Session restreinte : TTL 8 h, révocation Admin, idempotente                 | §4, RM12 |
+| **RM13** | Un seul enfant par foyer en v1.0 (1:1, 1:N en v1.1)                         | §4, RM13 |
+| **RM14** | Horodatage serveur autoritaire (`recordedAtUtc`) + flag sync tardive        | §4, RM14 |
+| **RM15** | Idempotence des saisies via `clientEventId` (UUID v4)                       | §4, RM15 |
+| **RM16** | Push opaque : titre/corps génériques, zéro donnée santé dans le payload     | §4, RM16 |
+| **RM17** | Rattrapage borné : backfill ≤ 24 h, futur refusé, confirmation au-delà      | §4, RM17 |
+| **RM18** | Annulation : 30 min libres pour l'auteur ou un Admin, puis Admin + raison   | §4, RM18 |
+| **RM19** | Expiration pompe : warning J-30, blocage à échéance sauf override Admin     | §4, RM19 |
+| **RM20** | Hors-ligne : lecture 30 j + écriture toujours autorisée                     | §4, RM20 |
+| **RM21** | Limite anti-spam : max 10 invitations actives simultanées par foyer         | §4, RM21 |
+| **RM22** | Consentement aidant invité : propres données uniquement, pas l'enfant       | §4, RM22 |
+| **RM23** | Opt-in géoloc par aidant, jamais pour `restricted_contributor`              | §4, RM23 |
+| **RM24** | Intégrité rapport : SHA-256 du contenu + timestamp + générateur (pied PDF)  | §4, RM24 |
+| **RM25** | Rappels bornés : 2 relances max (push T+15 min, e-mail T+30 min)            | §4, RM25 |
+| **RM26** | Regroupement notifications peer : ≥ 3 prises/h + cap 15 notif/jour          | §4, RM26 |
+| **RM27** | Disclaimer omniprésent aux 4 surfaces (onboarding, CGU, rapport, À propos)  | §4, RM27 |
+| **RM28** | Purge invitations : `expired > 30 j`, `consumed > 90 j`, `revoked > 30 j`   | §4, RM28 |
 
-Les règles RM8-RM13, RM16, RM19, RM20, RM23 arrivent dans les PRs suivantes.
+La v1.0 du domaine est **complète à 28/28** : toutes les règles métier définies dans SPECS §4 sont implémentées, testées (`packages/domain/src/rules/`) et exportées par `@kinhale/domain`.
 
 ## Usage
 

--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -70,6 +70,21 @@ export type DomainErrorCode =
   | 'RM22_CONSENT_INVITATION_MISMATCH'
   /** RM22 — `consentedAtUtc` est strictement postérieur à `nowUtc` (tricherie d'horloge). */
   | 'RM22_INVALID_CONSENT_TIMESTAMP'
+  /** RM23 — géoloc fournie alors que l'aidant n'a pas opt-in. */
+  | 'RM23_OPT_IN_MISSING'
+  /**
+   * RM23 — géoloc fournie par un `restricted_contributor` : refus strict du
+   * domaine, quelle que soit la préférence prétendue (règle souveraine).
+   */
+  | 'RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE'
+  /** RM23 — coordonnées hors bornes (`lat ∉ [-90,90]` ou `lon ∉ [-180,180]`, ou non finies). */
+  | 'RM23_INVALID_COORDINATES'
+  /**
+   * RM23 — la préférence fournie ne concerne pas l'auteur de la prise
+   * (`authorPreference.caregiverId !== dose.caregiverId`). Vérification
+   * défensive contre un bug d'intégration API.
+   */
+  | 'RM23_PREFERENCE_MISMATCH'
   /** RM24 — `generator` fourni vide ou whitespace-only lors du calcul du pied d'intégrité. */
   | 'RM24_INVALID_GENERATOR'
   /** RM8 — période invalide (ex: `fromUtc` strictement postérieur à `toUtc`). */

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -106,6 +106,17 @@ export {
 export { ensureInviteeConsentValid, isInviteeConsentValid } from './rm22-invitee-consent';
 export type { InviteeConsent } from './rm22-invitee-consent';
 export {
+  ensureGeolocationAllowed,
+  isGeolocationAllowed,
+  isValidGeolocation,
+  sanitizeDoseGeolocation,
+} from './rm23-geolocation-opt-in';
+export type {
+  CaregiverGeolocationPreference,
+  DoseWithOptionalGeolocation,
+  Geolocation,
+} from './rm23-geolocation-opt-in';
+export {
   findInvitationsToPurge,
   PURGE_CONSUMED_AFTER_DAYS,
   PURGE_EXPIRED_AFTER_DAYS,

--- a/packages/domain/src/rules/rm23-geolocation-opt-in.test.ts
+++ b/packages/domain/src/rules/rm23-geolocation-opt-in.test.ts
@@ -1,0 +1,487 @@
+import { describe, expect, it } from 'vitest';
+import { DomainError } from '../errors';
+import type { Role } from '../entities/role';
+import {
+  type CaregiverGeolocationPreference,
+  type DoseWithOptionalGeolocation,
+  type Geolocation,
+  ensureGeolocationAllowed,
+  isGeolocationAllowed,
+  isValidGeolocation,
+  sanitizeDoseGeolocation,
+} from './rm23-geolocation-opt-in';
+
+function makeDose(
+  overrides: Partial<DoseWithOptionalGeolocation> & { caregiverId: string },
+): DoseWithOptionalGeolocation {
+  return {
+    geolocation: null,
+    ...overrides,
+  };
+}
+
+function makePreference(
+  overrides: Partial<CaregiverGeolocationPreference> & { caregiverId: string; role: Role },
+): CaregiverGeolocationPreference {
+  return {
+    geolocationOptIn: false,
+    ...overrides,
+  };
+}
+
+describe('RM23 — isValidGeolocation', () => {
+  it('accepte les bornes inclusives {lat: 90, lon: 180}', () => {
+    expect(isValidGeolocation({ lat: 90, lon: 180 })).toBe(true);
+  });
+
+  it('accepte les bornes inclusives {lat: -90, lon: -180}', () => {
+    expect(isValidGeolocation({ lat: -90, lon: -180 })).toBe(true);
+  });
+
+  it('accepte les coordonnées usuelles', () => {
+    expect(isValidGeolocation({ lat: 45.5, lon: -73.5 })).toBe(true);
+    expect(isValidGeolocation({ lat: 0, lon: 0 })).toBe(true);
+  });
+
+  it('rejette lat > 90', () => {
+    expect(isValidGeolocation({ lat: 91, lon: 0 })).toBe(false);
+  });
+
+  it('rejette lat < -90', () => {
+    expect(isValidGeolocation({ lat: -91, lon: 0 })).toBe(false);
+  });
+
+  it('rejette lon > 180', () => {
+    expect(isValidGeolocation({ lat: 0, lon: 181 })).toBe(false);
+  });
+
+  it('rejette lon < -180', () => {
+    expect(isValidGeolocation({ lat: 0, lon: -181 })).toBe(false);
+  });
+
+  it('rejette NaN sur lat', () => {
+    expect(isValidGeolocation({ lat: Number.NaN, lon: 0 })).toBe(false);
+  });
+
+  it('rejette NaN sur lon', () => {
+    expect(isValidGeolocation({ lat: 0, lon: Number.NaN })).toBe(false);
+  });
+
+  it('rejette Infinity', () => {
+    expect(isValidGeolocation({ lat: Number.POSITIVE_INFINITY, lon: 0 })).toBe(false);
+    expect(isValidGeolocation({ lat: 0, lon: Number.NEGATIVE_INFINITY })).toBe(false);
+  });
+
+  it('considère `null` et `undefined` comme valides (absence = safe)', () => {
+    expect(isValidGeolocation(null)).toBe(true);
+    expect(isValidGeolocation(undefined)).toBe(true);
+  });
+});
+
+describe('RM23 — isGeolocationAllowed', () => {
+  it('OK : pas de géoloc + opt-in true + contributor', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: null });
+    const pref = makePreference({ caregiverId: 'c1', role: 'contributor', geolocationOptIn: true });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(true);
+  });
+
+  it('OK : pas de géoloc + opt-in false', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: null });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(true);
+  });
+
+  it('OK : pas de géoloc + restricted_contributor', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: null });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: false,
+    });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(true);
+  });
+
+  it('OK : géoloc + opt-in true + admin', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(true);
+  });
+
+  it('OK : géoloc + opt-in true + contributor', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'contributor', geolocationOptIn: true });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(true);
+  });
+
+  it('KO : géoloc + opt-in false + contributor', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(false);
+  });
+
+  it('KO : géoloc + opt-in true + restricted_contributor', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(false);
+  });
+
+  it('KO : géoloc + coords hors bornes', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 91, lon: 0 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(false);
+  });
+
+  it('KO : préférence rattachée à un autre caregiver (mismatch défensif)', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c2', role: 'admin', geolocationOptIn: true });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(false);
+  });
+});
+
+describe('RM23 — ensureGeolocationAllowed', () => {
+  it('ne lève pas pour une dose sans géoloc, quel que soit le rôle/opt-in', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: null });
+
+    expect(() =>
+      ensureGeolocationAllowed({
+        dose,
+        authorPreference: makePreference({
+          caregiverId: 'c1',
+          role: 'admin',
+          geolocationOptIn: true,
+        }),
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      ensureGeolocationAllowed({
+        dose,
+        authorPreference: makePreference({
+          caregiverId: 'c1',
+          role: 'restricted_contributor',
+          geolocationOptIn: false,
+        }),
+      }),
+    ).not.toThrow();
+  });
+
+  it('ne lève pas pour une dose avec géoloc valide + opt-in + rôle non restreint', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+
+    for (const role of ['admin', 'contributor'] as const) {
+      expect(() =>
+        ensureGeolocationAllowed({
+          dose,
+          authorPreference: makePreference({
+            caregiverId: 'c1',
+            role,
+            geolocationOptIn: true,
+          }),
+        }),
+      ).not.toThrow();
+    }
+  });
+
+  it('lève RM23_OPT_IN_MISSING quand géoloc fournie sans opt-in (contributor)', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM23_OPT_IN_MISSING');
+      expect((err as DomainError).context).toMatchObject({
+        caregiverId: 'c1',
+        role: 'contributor',
+      });
+    }
+  });
+
+  it('lève RM23_OPT_IN_MISSING quand géoloc fournie sans opt-in (admin)', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: false });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_OPT_IN_MISSING');
+    }
+  });
+
+  it('lève RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE même si opt-in=true (règle souveraine)', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE');
+      expect((err as DomainError).context).toMatchObject({
+        caregiverId: 'c1',
+        role: 'restricted_contributor',
+      });
+    }
+  });
+
+  it('lève RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE en priorité sur OPT_IN_MISSING', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: false,
+    });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      // Priorité : role restreint > opt-in manquant (rôle plus spécifique)
+      expect((err as DomainError).code).toBe('RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE');
+    }
+  });
+
+  it('lève RM23_INVALID_COORDINATES pour lat > 90', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 91, lon: 0 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_INVALID_COORDINATES');
+    }
+  });
+
+  it('lève RM23_INVALID_COORDINATES pour lat < -90', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: -91, lon: 0 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_INVALID_COORDINATES');
+    }
+  });
+
+  it('lève RM23_INVALID_COORDINATES pour lon > 180 ou lon < -180', () => {
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    expect(() =>
+      ensureGeolocationAllowed({
+        dose: makeDose({ caregiverId: 'c1', geolocation: { lat: 0, lon: 181 } }),
+        authorPreference: pref,
+      }),
+    ).toThrowError(DomainError);
+
+    expect(() =>
+      ensureGeolocationAllowed({
+        dose: makeDose({ caregiverId: 'c1', geolocation: { lat: 0, lon: -181 } }),
+        authorPreference: pref,
+      }),
+    ).toThrowError(DomainError);
+  });
+
+  it('lève RM23_INVALID_COORDINATES pour NaN ou Infinity', () => {
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    const cases: Geolocation[] = [
+      { lat: Number.NaN, lon: 0 },
+      { lat: 0, lon: Number.NaN },
+      { lat: Number.POSITIVE_INFINITY, lon: 0 },
+      { lat: 0, lon: Number.NEGATIVE_INFINITY },
+    ];
+
+    for (const geolocation of cases) {
+      try {
+        ensureGeolocationAllowed({
+          dose: makeDose({ caregiverId: 'c1', geolocation }),
+          authorPreference: pref,
+        });
+        expect.fail(`should have thrown for ${JSON.stringify(geolocation)}`);
+      } catch (err) {
+        expect((err as DomainError).code).toBe('RM23_INVALID_COORDINATES');
+      }
+    }
+  });
+
+  it('priorité des refus : role restreint > opt-in manquant > coords invalides', () => {
+    // role restreint > coords invalides : même avec coords KO, c'est le rôle qui tranche
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 999, lon: 999 } });
+    const prefRestricted = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: prefRestricted });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE');
+    }
+
+    // opt-in manquant > coords invalides
+    const prefNoOptIn = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: prefNoOptIn });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_OPT_IN_MISSING');
+    }
+  });
+
+  it('lève RM23_PREFERENCE_MISMATCH si la préférence ne correspond pas au caregiver auteur', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c2', role: 'admin', geolocationOptIn: true });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_PREFERENCE_MISMATCH');
+    }
+  });
+
+  it('ne fuite pas de coordonnées dans le context des erreurs', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5012, lon: -73.5678 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      const raw = JSON.stringify((err as DomainError).context ?? {});
+      expect(raw).not.toContain('45.5012');
+      expect(raw).not.toContain('-73.5678');
+      expect(raw).not.toContain('lat');
+      expect(raw).not.toContain('lon');
+    }
+  });
+});
+
+describe('RM23 — sanitizeDoseGeolocation', () => {
+  it('retourne la dose inchangée si géoloc autorisée', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toEqual({ lat: 45.5, lon: -73.5 });
+  });
+
+  it('retourne la dose inchangée si absence de géoloc', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: null });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: false,
+    });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+  });
+
+  it('strip la géoloc si opt-in manquant', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+  });
+
+  it('strip la géoloc si restricted_contributor (même avec opt-in)', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+  });
+
+  it('strip la géoloc si coords hors bornes', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 91, lon: 0 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+  });
+
+  it('strip la géoloc si mismatch de caregiver', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c2', role: 'admin', geolocationOptIn: true });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+  });
+
+  it('est pur : ne mute pas `dose` ni `authorPreference`', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+    const doseSnapshot = JSON.stringify(dose);
+    const prefSnapshot = JSON.stringify(pref);
+
+    sanitizeDoseGeolocation({ dose, authorPreference: pref });
+
+    expect(JSON.stringify(dose)).toBe(doseSnapshot);
+    expect(JSON.stringify(pref)).toBe(prefSnapshot);
+  });
+
+  it('préserve les autres champs de la dose', () => {
+    const dose: DoseWithOptionalGeolocation & { readonly extra: string } = {
+      caregiverId: 'c1',
+      geolocation: { lat: 45.5, lon: -73.5 },
+      extra: 'should-survive',
+    };
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+    expect((result as { extra?: string }).extra).toBe('should-survive');
+  });
+});

--- a/packages/domain/src/rules/rm23-geolocation-opt-in.test.ts
+++ b/packages/domain/src/rules/rm23-geolocation-opt-in.test.ts
@@ -370,6 +370,27 @@ describe('RM23 — ensureGeolocationAllowed', () => {
     }
   });
 
+  it('PREFERENCE_MISMATCH prime sur RESTRICTED_CAREGIVER (ordre des refus formalisé)', () => {
+    // Si la préférence ne correspond pas au caregiver auteur ET que le
+    // rôle fourni est restricted_contributor, on remonte MISMATCH d'abord
+    // (la cohérence du flux est le premier invariant — si l'input est
+    // incohérent, les autres checks n'ont pas de base fiable pour se
+    // prononcer).
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c2',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_PREFERENCE_MISMATCH');
+    }
+  });
+
   it('ne fuite pas de coordonnées dans le context des erreurs', () => {
     const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5012, lon: -73.5678 } });
     const pref = makePreference({

--- a/packages/domain/src/rules/rm23-geolocation-opt-in.ts
+++ b/packages/domain/src/rules/rm23-geolocation-opt-in.ts
@@ -1,0 +1,200 @@
+import type { Role } from '../entities/role';
+import { DomainError } from '../errors';
+
+/**
+ * Coordonnées géographiques attachées à une prise (opt-in strict, RM23).
+ *
+ * Ces coordonnées sont déclarées côté client et stockées **chiffrées
+ * E2EE** : le relais Kamez ne les voit jamais en clair. Le domaine se
+ * limite à valider la structure et les contraintes métier (bornes
+ * standard du géoïde). La précision (arrondi, bucketing pour réduire la
+ * fingerprintabilité) est une décision d'UI/API, hors scope du domaine.
+ */
+export interface Geolocation {
+  /** Latitude en degrés décimaux, plage inclusive `[-90, 90]`. */
+  readonly lat: number;
+  /** Longitude en degrés décimaux, plage inclusive `[-180, 180]`. */
+  readonly lon: number;
+}
+
+/**
+ * Vue minimale d'une prise pour l'évaluation RM23. Le domaine ne
+ * s'intéresse ici qu'au `caregiverId` auteur et à la présence
+ * éventuelle d'une géolocalisation. Les autres champs de la prise
+ * restent gérés par les règles dédiées (RM2, RM4, RM6…).
+ */
+export interface DoseWithOptionalGeolocation {
+  readonly caregiverId: string;
+  readonly geolocation?: Geolocation | null;
+}
+
+/**
+ * Préférence opt-in géoloc d'un aidant. Par défaut `geolocationOptIn =
+ * false`. Stockée côté profil aidant (infra), lue par le domaine lors
+ * de la validation d'une saisie.
+ *
+ * Invariant souverain domaine : quand `role === 'restricted_contributor'`,
+ * le domaine refuse la géoloc **quel que soit** `geolocationOptIn` —
+ * une session restreinte ne peut jamais opt-in légalement (garderie,
+ * nounou, session 8 h). Voir {@link ensureGeolocationAllowed}.
+ */
+export interface CaregiverGeolocationPreference {
+  readonly caregiverId: string;
+  readonly role: Role;
+  readonly geolocationOptIn: boolean;
+}
+
+/** Options partagées par {@link ensureGeolocationAllowed} et {@link isGeolocationAllowed}. */
+interface GeolocationOptions {
+  readonly dose: DoseWithOptionalGeolocation;
+  readonly authorPreference: CaregiverGeolocationPreference;
+}
+
+type GeolocationErrorCode =
+  | 'RM23_OPT_IN_MISSING'
+  | 'RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE'
+  | 'RM23_INVALID_COORDINATES'
+  | 'RM23_PREFERENCE_MISMATCH';
+
+type GeolocationDecision =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly code: GeolocationErrorCode; readonly detail: string };
+
+/**
+ * RM23 — valide que les coordonnées respectent les bornes standard du
+ * géoïde : `lat ∈ [-90, 90]` et `lon ∈ [-180, 180]`, bornes inclusives,
+ * valeurs finies (rejette NaN / Infinity).
+ *
+ * `null` et `undefined` sont considérés valides car l'absence de
+ * géolocalisation est toujours un état safe (RM23 refuse l'ajout, pas
+ * l'absence).
+ */
+export function isValidGeolocation(geo: Geolocation | null | undefined): boolean {
+  if (geo === null || geo === undefined) {
+    return true;
+  }
+  const { lat, lon } = geo;
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return false;
+  }
+  return lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+}
+
+/**
+ * RM23 — prédicat : la dose peut-elle porter cette géolocalisation ?
+ * Retourne `true` si la règle accepte (dont : absence de géoloc),
+ * `false` sinon. Ne lève jamais.
+ */
+export function isGeolocationAllowed(options: GeolocationOptions): boolean {
+  return evaluateGeolocation(options).ok;
+}
+
+/**
+ * RM23 — assertion : la dose respecte la politique d'opt-in
+ * géolocalisation. Refuse dans l'ordre de priorité suivant :
+ *
+ * 1. `RM23_PREFERENCE_MISMATCH` — `authorPreference.caregiverId` ne
+ *    correspond pas à `dose.caregiverId`. Vérification défensive :
+ *    l'API est responsable de passer la bonne préférence, mais le
+ *    domaine ferme la porte plutôt que d'appliquer une préférence
+ *    étrangère à l'auteur.
+ * 2. `RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE` — l'auteur est un
+ *    `restricted_contributor`. **Règle souveraine** : le domaine
+ *    refuse même si `geolocationOptIn === true` (une préférence qui
+ *    prétendrait l'opt-in sur ce rôle est un bug amont à clore ici).
+ * 3. `RM23_OPT_IN_MISSING` — l'auteur n'a pas opt-in.
+ * 4. `RM23_INVALID_COORDINATES` — coordonnées hors bornes ou non
+ *    finies.
+ *
+ * L'absence de géolocalisation (`geolocation` null/undefined) est
+ * toujours acceptée, quel que soit le rôle ou l'opt-in. Le
+ * `context` d'erreur ne contient **jamais** les coordonnées elles-mêmes
+ * (pas plus que `lat`/`lon` comme clés), uniquement `caregiverId` et
+ * `role` — métadonnées déjà connues de l'appelant légitime.
+ *
+ * @throws {DomainError} avec l'un des codes ci-dessus.
+ */
+export function ensureGeolocationAllowed(options: GeolocationOptions): void {
+  const decision = evaluateGeolocation(options);
+  if (decision.ok) {
+    return;
+  }
+
+  throw new DomainError(decision.code, decision.detail, {
+    caregiverId: options.dose.caregiverId,
+    role: options.authorPreference.role,
+  });
+}
+
+/**
+ * RM23 — sanitize une prise candidate : retourne une nouvelle dose
+ * avec `geolocation: null` si la règle ne permet pas d'attacher la
+ * géolocalisation, sinon retourne la dose inchangée.
+ *
+ * Utile côté ingestion pour forcer l'invariant « jamais de géoloc non
+ * autorisée » plutôt que rejeter l'ensemble de la prise — si un client
+ * buggé joint une géoloc sans opt-in, le domaine préfère strip
+ * silencieusement que perdre la prise (qui, elle, est précieuse pour
+ * le suivi santé).
+ *
+ * Fonction **pure** : ne mute ni `dose` ni `authorPreference`.
+ */
+export function sanitizeDoseGeolocation<D extends DoseWithOptionalGeolocation>(options: {
+  readonly dose: D;
+  readonly authorPreference: CaregiverGeolocationPreference;
+}): D {
+  const { dose, authorPreference } = options;
+  if (isGeolocationAllowed({ dose, authorPreference })) {
+    return dose;
+  }
+  return { ...dose, geolocation: null };
+}
+
+function evaluateGeolocation(options: GeolocationOptions): GeolocationDecision {
+  const { dose, authorPreference } = options;
+
+  // Absence de géoloc : toujours safe, court-circuit toutes les vérifications
+  // (pas de mismatch à valider tant qu'on n'attache rien).
+  if (dose.geolocation === null || dose.geolocation === undefined) {
+    return { ok: true };
+  }
+
+  // 1. Check défensif : la préférence doit concerner l'auteur de la prise.
+  if (authorPreference.caregiverId !== dose.caregiverId) {
+    return {
+      ok: false,
+      code: 'RM23_PREFERENCE_MISMATCH',
+      detail: 'authorPreference.caregiverId does not match dose.caregiverId.',
+    };
+  }
+
+  // 2. Règle souveraine : un restricted_contributor ne peut jamais géolocaliser,
+  //    même si la préférence prétend l'opt-in (bug amont ignoré).
+  if (authorPreference.role === 'restricted_contributor') {
+    return {
+      ok: false,
+      code: 'RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE',
+      detail: 'Restricted contributors cannot attach geolocation to a dose.',
+    };
+  }
+
+  // 3. Opt-in explicite requis, absent par défaut.
+  if (!authorPreference.geolocationOptIn) {
+    return {
+      ok: false,
+      code: 'RM23_OPT_IN_MISSING',
+      detail: 'Caregiver has not opted in to attach geolocation to doses.',
+    };
+  }
+
+  // 4. Bornes du géoïde — dernière ligne de défense.
+  if (!isValidGeolocation(dose.geolocation)) {
+    return {
+      ok: false,
+      code: 'RM23_INVALID_COORDINATES',
+      detail: 'Geolocation coordinates are out of bounds or not finite.',
+    };
+  }
+
+  return { ok: true };
+}


### PR DESCRIPTION
## 🎉 Clôture de la v1.0 domaine — 28/28 règles

**PR finale du chantier domaine** : cette PR livre la 28ème et dernière règle métier, complétant 100% du backlog domaine v1.0.

- **RM23** — Opt-in géolocalisation par aidant, jamais pour `restricted_contributor`, validation stricte des coordonnées

**42 nouveaux tests** (41 initiaux + 1 formalisation priorité). Total domain : 585 → **627 tests** tous verts.

## Workflow pré-PR appliqué

- **kz-review** → **APPROVED**, 0 MAJEUR, 0 MINEUR, 1 nit optionnel
- Pas de kz-securite (zone non-crypto, privacy validée via tests anti-fuite dédiés)

Commit `c832607` ajoute le test nit formalisant la priorité des refus.

## API RM23

```ts
export interface Geolocation {
  readonly lat: number;   // [-90, 90]
  readonly lon: number;   // [-180, 180]
}

export interface CaregiverGeolocationPreference {
  readonly caregiverId: string;
  readonly role: Role;
  readonly geolocationOptIn: boolean;  // défaut false côté infra
}

export function isValidGeolocation(geo): boolean;
export function isGeolocationAllowed(options): boolean;
export function ensureGeolocationAllowed(options): void;
export function sanitizeDoseGeolocation<D extends DoseWithOptionalGeolocation>(options): D;
```

## Règles de décision

| Input | Décision |
|---|---|
| Pas de géoloc (null/undefined) | OK — court-circuit |
| restricted_contributor + géoloc + opt-in=true | **REFUS** (invariant souverain) |
| opt-in=false + géoloc | `RM23_OPT_IN_MISSING` |
| Préférence caregiverId ≠ dose caregiverId | `RM23_PREFERENCE_MISMATCH` |
| Coords hors bornes / NaN / Infinity | `RM23_INVALID_COORDINATES` |
| Tout OK + coords valides | OK |

**Priorité des refus** (documentée + testée) :
1. `RM23_PREFERENCE_MISMATCH` (cohérence de flux)
2. `RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE` (invariant souverain de rôle)
3. `RM23_OPT_IN_MISSING`
4. `RM23_INVALID_COORDINATES`

## Privacy by design — geoloc = PII

Le domaine traite la géoloc comme la PII qu'elle est :
- **Aucun `lat`/`lon` dans les `DomainError.context`** — seulement `caregiverId` (UUID opaque) + `role` (enum 3 valeurs)
- **Test anti-fuite dédié** : coordonnées réalistes Montréal `{45.5012, -73.5678}` + `JSON.stringify(ctx).not.toContain(...)`
- **Bucketing/arrondi anti-fingerprinting** : explicitement délégué à UI/API (hors scope domaine)

## 4 codes d'erreur ajoutés

- `RM23_OPT_IN_MISSING`
- `RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE` (invariant souverain)
- `RM23_INVALID_COORDINATES`
- `RM23_PREFERENCE_MISMATCH` (check défensif — ferme un bug de routing API possible)

## Vérifications

- [x] `pnpm --filter @kinhale/domain typecheck` : vert
- [x] `pnpm --filter @kinhale/domain lint` : vert
- [x] `pnpm --filter @kinhale/domain test` : **627/627** en ~1.1s
- [x] `pnpm format:check` : vert
- [x] `pnpm lint:root` : vert
- [x] kz-review APPROVED
- [x] Aucune règle existante modifiée (additifs seulement)
- [x] Pas de `Date.now()`, `Math.random()`, `console.*`, `!` non-null, `any`
- [x] Privacy contexts verrouillée par test

## README domaine mis à jour

- Tableau des règles : **28/28 lignes**
- Mention « 28/28 règles v1.0 complètes » remplace l'ancien « à venir dans les PRs suivantes »

---

## 🎯 Bilan chantier domaine v1.0

**13 PRs, 28 règles, 627 tests.**

| PR | Règles | Tests cumul |
|---|---|---|
| KIN-004 | RM1 | 7 |
| KIN-005 | Dose + Plan + RM2/3/4 | 31 |
| KIN-007 | RM6 | 55 |
| KIN-008 | RM7 | 93 |
| KIN-009 | RM14/15/17/18 | 172 |
| KIN-010 | RM5/25/26 | 223 |
| KIN-011 | RM21/22/28 + entité Invitation | 274 |
| KIN-012 | scaffold `@kinhale/crypto` + RM24/27 | 316 |
| KIN-013 | RM8/16 | 385 |
| KIN-014 | RM9/13 | 443 |
| KIN-015 | RM19/20 | 505 |
| KIN-016 | RM10/11/12 | 585 |
| **KIN-017** | **RM23** | **627** |

### Fondations posées

- **Packages** : `@kinhale/domain` (28 règles + 9 entités) + `@kinhale/crypto` (SHA-256 Web Crypto native)
- **Discipline TDD** : rouge → vert → refactor appliquée sur 627 tests
- **Privacy by design** : 0 donnée santé ni nominative dans les contexts d'erreur
- **Ligne rouge DM** préservée : zéro recommandation/diagnostic/alerte santé auto-générée
- **Workflow pré-PR** éprouvé : kz-review (+ kz-securite sur zones sensibles) avant chaque PR
- **Historique git linéaire** : squash-merges verrouillés côté GitHub, 0 merge commit sur `develop`

### Choix structurants tracés

- Semver strict RM9 (groupes nommés), fenêtres inclusives cohérentes RM2/RM18/RM20, tolérance NTP partagée `CLOCK_SKEW_TOLERANCE_MS` (RM14/RM22/RM9)
- Pattern edge-triggered pour événements (RM7, RM19)
- Encodage canonique collision-safe par préfixe longueur UTF-8 (RM24, RM10)
- Domain-separation tag sur pseudonymisation (`kinhale:rm10:audit:v1`)
- Défense anti-IDOR en couches (RM11 domaine + middleware API)
- Asymétrie lecture/écriture sur consentements (RM9) documentée

### ADRs à rédiger côté `apps/api` / architecture

Points tracés dans les PR descriptions pour suivi :
- ADR encodage canonique rapports (RM24)
- ADR timing-safety UUIDs (RM11)
- ADR pseudonymisation v1 (RM10)
- ADR push opacity — modèle de menace RM16
- ADR offline read/write asymmetry (RM20)
- ADR asymétrie lecture/écriture RM9 major bump

## Ce qui arrive ensuite

Le domaine est prêt pour l'intégration. Prochaines phases suggérées :
- **KIN-018+** : scaffold `apps/api` Fastify avec mapping des 28 règles vers les endpoints REST + WebSocket
- **`apps/mobile`** et **`apps/web`** : consommation des tokens design (sprint design sprint déjà livré)
- **`packages/sync`** : moteur Automerge + mailbox E2EE
- **Infra** : scaffold CDK + docker-compose local

## Test plan

- [ ] Cloner + `pnpm install` + `pnpm test` → **627/627 vert**
- [ ] `pnpm lint:root` + `pnpm format:check` → verts
- [ ] Valider que le tableau 28/28 du README est juste
- [ ] Célébrer la clôture du domaine v1.0 🎉

---

Refs : KIN-017 — clôt le chantier domaine v1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)