### PR TITLE
feat(api): Sprint 0 — apps/api Fastify 5 skeleton (KIN-017)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Copier vers .env et remplir les valeurs
+# cp .env.example .env
+
+# Base de données
+DATABASE_URL=postgresql://kinhale:kinhale_dev_secret@localhost:5434/kinhale_dev
+
+# Redis
+REDIS_URL=redis://:kinhale_redis_dev@localhost:6379
+
+# Stockage blobs (MinIO local = équivalent Cloudflare R2)
+STORAGE_ENDPOINT=http://localhost:9000
+STORAGE_BUCKET=kinhale-relay-blobs
+STORAGE_ACCESS_KEY_ID=kinhale
+STORAGE_SECRET_ACCESS_KEY=kinhale_minio_dev
+STORAGE_REGION=us-east-1
+
+# Email (Mailpit local = équivalent Resend)
+EMAIL_PROVIDER=smtp
+SMTP_HOST=localhost
+SMTP_PORT=1027
+EMAIL_FROM=noreply@kinhale.health
+
+# JWT
+JWT_SECRET=dev_jwt_secret_change_in_production_minimum_32_chars
+
+# App
+NODE_ENV=development
+PORT=3000

--- a/apps/api/eslint.config.js
+++ b/apps/api/eslint.config.js
@@ -1,4 +1,4 @@
-import kinhale from '@kinhale/eslint-config'
+import kinhale from '@kinhale/eslint-config';
 
 export default [
   ...kinhale,
@@ -14,4 +14,4 @@ export default [
       '@typescript-eslint/no-non-null-assertion': 'off',
     },
   },
-]
+];

--- a/apps/api/eslint.config.js
+++ b/apps/api/eslint.config.js
@@ -1,0 +1,17 @@
+import kinhale from '@kinhale/eslint-config'
+
+export default [
+  ...kinhale,
+  {
+    files: ['src/**/*.ts'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+  {
+    files: ['src/**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@kinhale/api",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "description": "Relais Kinhale — Fastify 5, zero-knowledge, E2EE WebSocket",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "lint": "eslint --max-warnings=0 .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@fastify/cors": "^10.0.0",
+    "@fastify/jwt": "^9.0.0",
+    "@fastify/websocket": "^11.0.0",
+    "@kinhale/crypto": "workspace:*",
+    "drizzle-orm": "^0.38.0",
+    "fastify": "^5.0.0",
+    "fastify-plugin": "^5.0.0",
+    "pg": "^8.13.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@kinhale/eslint-config": "workspace:*",
+    "@kinhale/tsconfig": "workspace:*",
+    "@types/node": "^22.10.5",
+    "@types/pg": "^8.11.0",
+    "@types/ws": "^8.5.0",
+    "drizzle-kit": "^0.30.0",
+    "eslint": "^9.18.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.2",
+    "ws": "^8.18.0"
+  }
+}

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -16,7 +16,11 @@ declare module 'fastify' {
 }
 
 export interface BuildAppOverrides {
-  /** Injecter un db mocké pour les tests (évite une vraie connexion Postgres) */
+  /**
+   * DB mocké pour les tests unitaires. Si fourni, skip le plugin dbPlugin
+   * (pas de connexion Postgres réelle). Utiliser `{} as DrizzleDb` si les
+   * routes testées n'accèdent pas à la DB.
+   */
   db?: DrizzleDb
 }
 
@@ -25,14 +29,12 @@ export function buildApp(env: Env, overrides: BuildAppOverrides = {}): FastifyIn
     logger: env.NODE_ENV !== 'test',
   })
 
-  // Env accessible via app.env dans toute l'application
   app.decorate('env', env)
 
   // Plugins transversaux
   void app.register(fastifyCors, { origin: true })
   void app.register(fastifyWebsocket)
 
-  // DB : injecter le mock si fourni, sinon le vrai plugin
   if (overrides.db !== undefined) {
     app.decorate('db', overrides.db)
   } else {

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,17 +1,17 @@
-import Fastify, { type FastifyInstance } from 'fastify'
-import fastifyCors from '@fastify/cors'
-import fastifyWebsocket from '@fastify/websocket'
-import type { Env } from './env.js'
-import dbPlugin, { type DrizzleDb } from './plugins/db.js'
-import jwtPlugin from './plugins/jwt.js'
-import healthRoute from './routes/health.js'
-import authRoute from './routes/auth.js'
-import relayRoute from './routes/relay.js'
+import Fastify, { type FastifyInstance } from 'fastify';
+import fastifyCors from '@fastify/cors';
+import fastifyWebsocket from '@fastify/websocket';
+import type { Env } from './env.js';
+import dbPlugin, { type DrizzleDb } from './plugins/db.js';
+import jwtPlugin from './plugins/jwt.js';
+import healthRoute from './routes/health.js';
+import authRoute from './routes/auth.js';
+import relayRoute from './routes/relay.js';
 
 declare module 'fastify' {
   interface FastifyInstance {
-    env: Env
-    db: DrizzleDb
+    env: Env;
+    db: DrizzleDb;
   }
 }
 
@@ -21,33 +21,33 @@ export interface BuildAppOverrides {
    * (pas de connexion Postgres réelle). Utiliser `{} as DrizzleDb` si les
    * routes testées n'accèdent pas à la DB.
    */
-  db?: DrizzleDb
+  db?: DrizzleDb;
 }
 
 export function buildApp(env: Env, overrides: BuildAppOverrides = {}): FastifyInstance {
   const app = Fastify({
     logger: env.NODE_ENV !== 'test',
-  })
+  });
 
-  app.decorate('env', env)
+  app.decorate('env', env);
 
   // Plugins transversaux
-  void app.register(fastifyCors, { origin: true })
-  void app.register(fastifyWebsocket)
+  void app.register(fastifyCors, { origin: true });
+  void app.register(fastifyWebsocket);
 
   if (overrides.db !== undefined) {
-    app.decorate('db', overrides.db)
+    app.decorate('db', overrides.db);
   } else {
-    void app.register(dbPlugin)
+    void app.register(dbPlugin);
   }
 
   // JWT
-  void app.register(jwtPlugin)
+  void app.register(jwtPlugin);
 
   // Routes
-  void app.register(healthRoute)
-  void app.register(authRoute, { prefix: '/auth' })
-  void app.register(relayRoute, { prefix: '/relay' })
+  void app.register(healthRoute);
+  void app.register(authRoute, { prefix: '/auth' });
+  void app.register(relayRoute, { prefix: '/relay' });
 
-  return app
+  return app;
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,51 @@
+import Fastify, { type FastifyInstance } from 'fastify'
+import fastifyCors from '@fastify/cors'
+import fastifyWebsocket from '@fastify/websocket'
+import type { Env } from './env.js'
+import dbPlugin, { type DrizzleDb } from './plugins/db.js'
+import jwtPlugin from './plugins/jwt.js'
+import healthRoute from './routes/health.js'
+import authRoute from './routes/auth.js'
+import relayRoute from './routes/relay.js'
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    env: Env
+    db: DrizzleDb
+  }
+}
+
+export interface BuildAppOverrides {
+  /** Injecter un db mocké pour les tests (évite une vraie connexion Postgres) */
+  db?: DrizzleDb
+}
+
+export function buildApp(env: Env, overrides: BuildAppOverrides = {}): FastifyInstance {
+  const app = Fastify({
+    logger: env.NODE_ENV !== 'test',
+  })
+
+  // Env accessible via app.env dans toute l'application
+  app.decorate('env', env)
+
+  // Plugins transversaux
+  void app.register(fastifyCors, { origin: true })
+  void app.register(fastifyWebsocket)
+
+  // DB : injecter le mock si fourni, sinon le vrai plugin
+  if (overrides.db !== undefined) {
+    app.decorate('db', overrides.db)
+  } else {
+    void app.register(dbPlugin)
+  }
+
+  // JWT
+  void app.register(jwtPlugin)
+
+  // Routes
+  void app.register(healthRoute)
+  void app.register(authRoute, { prefix: '/auth' })
+  void app.register(relayRoute, { prefix: '/relay' })
+
+  return app
+}

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,10 +1,4 @@
-import {
-  pgTable,
-  uuid,
-  text,
-  timestamp,
-  bigint,
-} from 'drizzle-orm/pg-core'
+import { pgTable, uuid, text, timestamp, bigint } from 'drizzle-orm/pg-core';
 
 /**
  * Comptes utilisateurs. L'email n'est jamais stocké en clair —
@@ -14,7 +8,7 @@ export const accounts = pgTable('accounts', {
   id: uuid('id').defaultRandom().primaryKey(),
   emailHash: text('email_hash').notNull().unique(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
-})
+});
 
 /**
  * Devices enregistrés. Chaque device porte une clé publique Ed25519
@@ -29,7 +23,7 @@ export const devices = pgTable('devices', {
   publicKeyHex: text('public_key_hex').notNull(),
   householdId: uuid('household_id').notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
-})
+});
 
 /**
  * Magic links d'authentification. Le token n'est stocké que sous forme
@@ -43,7 +37,7 @@ export const magicLinks = pgTable('magic_links', {
   expiresAt: timestamp('expires_at').notNull(),
   usedAt: timestamp('used_at'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
-})
+});
 
 /**
  * Messages de la mailbox E2EE. Le blob est le JSON de EncryptedBlob
@@ -59,4 +53,4 @@ export const mailboxMessages = pgTable('mailbox_messages', {
   sentAtMs: bigint('sent_at_ms', { mode: 'number' }).notNull(),
   expiresAt: timestamp('expires_at').notNull(),
   ackedAt: timestamp('acked_at'),
-})
+});

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,0 +1,2 @@
+// Schéma Drizzle — implémenté en Task 4
+export {}

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,2 +1,62 @@
-// Schéma Drizzle — implémenté en Task 4
-export {}
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  bigint,
+} from 'drizzle-orm/pg-core'
+
+/**
+ * Comptes utilisateurs. L'email n'est jamais stocké en clair —
+ * uniquement son SHA-256 (pseudonymisation Loi 25 / RGPD).
+ */
+export const accounts = pgTable('accounts', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  emailHash: text('email_hash').notNull().unique(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})
+
+/**
+ * Devices enregistrés. Chaque device porte une clé publique Ed25519
+ * qui authentifie ses messages. Le householdId lie le device à un foyer.
+ * Aucune donnée santé ici.
+ */
+export const devices = pgTable('devices', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  accountId: uuid('account_id')
+    .notNull()
+    .references(() => accounts.id, { onDelete: 'cascade' }),
+  publicKeyHex: text('public_key_hex').notNull(),
+  householdId: uuid('household_id').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})
+
+/**
+ * Magic links d'authentification. Le token n'est stocké que sous forme
+ * de hash SHA-256 pour éviter toute réutilisation en cas de fuite DB.
+ * TTL : 10 minutes (RM conformité).
+ */
+export const magicLinks = pgTable('magic_links', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  emailHash: text('email_hash').notNull(),
+  tokenHash: text('token_hash').notNull().unique(),
+  expiresAt: timestamp('expires_at').notNull(),
+  usedAt: timestamp('used_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})
+
+/**
+ * Messages de la mailbox E2EE. Le blob est le JSON de EncryptedBlob
+ * (@kinhale/sync) — le relais ne peut pas déchiffrer son contenu.
+ * TTL : 90 jours, purgé après ack du device destinataire.
+ */
+export const mailboxMessages = pgTable('mailbox_messages', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  householdId: uuid('household_id').notNull(),
+  senderDeviceId: uuid('sender_device_id').notNull(),
+  blobJson: text('blob_json').notNull(),
+  seq: bigint('seq', { mode: 'number' }).notNull(),
+  sentAtMs: bigint('sent_at_ms', { mode: 'number' }).notNull(),
+  expiresAt: timestamp('expires_at').notNull(),
+  ackedAt: timestamp('acked_at'),
+})

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod'
+import { z } from 'zod';
 
 export const EnvSchema = z.object({
   NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
@@ -7,12 +7,12 @@ export const EnvSchema = z.object({
   JWT_SECRET: z.string().min(32),
   JWT_ACCESS_TTL: z.string().default('15m'),
   JWT_REFRESH_TTL: z.string().default('14d'),
-})
+});
 
-export type Env = z.infer<typeof EnvSchema>
+export type Env = z.infer<typeof EnvSchema>;
 
 export function parseEnv(raw: NodeJS.ProcessEnv = process.env): Env {
-  return EnvSchema.parse(raw)
+  return EnvSchema.parse(raw);
 }
 
 /** Env de test — toutes les valeurs minimales valides */
@@ -25,5 +25,5 @@ export function testEnv(overrides: Partial<Env> = {}): Env {
     JWT_ACCESS_TTL: '15m',
     JWT_REFRESH_TTL: '14d',
     ...overrides,
-  }
+  };
 }

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod'
+
+export const EnvSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  PORT: z.coerce.number().int().min(1).max(65535).default(3000),
+  DATABASE_URL: z.string().min(1),
+  JWT_SECRET: z.string().min(32),
+  JWT_ACCESS_TTL: z.string().default('15m'),
+  JWT_REFRESH_TTL: z.string().default('14d'),
+})
+
+export type Env = z.infer<typeof EnvSchema>
+
+export function parseEnv(raw: NodeJS.ProcessEnv = process.env): Env {
+  return EnvSchema.parse(raw)
+}
+
+/** Env de test — toutes les valeurs minimales valides */
+export function testEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    NODE_ENV: 'test',
+    PORT: 3000,
+    DATABASE_URL: 'postgresql://kinhale:kinhale_dev_secret@localhost:5434/kinhale_dev',
+    JWT_SECRET: 'test-jwt-secret-minimum-32-characters-long',
+    JWT_ACCESS_TTL: '15m',
+    JWT_REFRESH_TTL: '14d',
+    ...overrides,
+  }
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,13 +1,13 @@
-import { parseEnv } from './env.js'
-import { buildApp } from './app.js'
+import { parseEnv } from './env.js';
+import { buildApp } from './app.js';
 
-const env = parseEnv()
-const app = buildApp(env)
+const env = parseEnv();
+const app = buildApp(env);
 
 try {
-  await app.listen({ port: env.PORT, host: '0.0.0.0' })
-  app.log.info(`Kinhale API démarrée sur http://0.0.0.0:${env.PORT}`)
+  await app.listen({ port: env.PORT, host: '0.0.0.0' });
+  app.log.info(`Kinhale API démarrée sur http://0.0.0.0:${env.PORT}`);
 } catch (err) {
-  app.log.error(err)
-  process.exit(1)
+  app.log.error(err);
+  process.exit(1);
 }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ const app = buildApp(env)
 
 try {
   await app.listen({ port: env.PORT, host: '0.0.0.0' })
+  app.log.info(`Kinhale API démarrée sur http://0.0.0.0:${env.PORT}`)
 } catch (err) {
   app.log.error(err)
   process.exit(1)

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,12 @@
+import { parseEnv } from './env.js'
+import { buildApp } from './app.js'
+
+const env = parseEnv()
+const app = buildApp(env)
+
+try {
+  await app.listen({ port: env.PORT, host: '0.0.0.0' })
+} catch (err) {
+  app.log.error(err)
+  process.exit(1)
+}

--- a/apps/api/src/plugins/db.ts
+++ b/apps/api/src/plugins/db.ts
@@ -1,0 +1,9 @@
+import fp from 'fastify-plugin'
+import { type NodePgDatabase } from 'drizzle-orm/node-postgres'
+import type * as schema from '../db/schema.js'
+
+export type DrizzleDb = NodePgDatabase<typeof schema>
+
+export default fp(async function dbPlugin(_app) {
+  // Implémenté en Task 4
+})

--- a/apps/api/src/plugins/db.ts
+++ b/apps/api/src/plugins/db.ts
@@ -1,20 +1,20 @@
-import fp from 'fastify-plugin'
-import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres'
-import { Pool } from 'pg'
-import * as schema from '../db/schema.js'
+import fp from 'fastify-plugin';
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { Pool } from 'pg';
+import * as schema from '../db/schema.js';
 
-export type DrizzleDb = NodePgDatabase<typeof schema>
+export type DrizzleDb = NodePgDatabase<typeof schema>;
 
 export default fp(async function dbPlugin(app) {
-  const pool = new Pool({ connectionString: app.env.DATABASE_URL })
+  const pool = new Pool({ connectionString: app.env.DATABASE_URL });
 
-  const client = await pool.connect()
-  client.release()
+  const client = await pool.connect();
+  client.release();
 
-  const db = drizzle(pool, { schema })
-  app.decorate('db', db)
+  const db = drizzle(pool, { schema });
+  app.decorate('db', db);
 
   app.addHook('onClose', async () => {
-    await pool.end()
-  })
-})
+    await pool.end();
+  });
+});

--- a/apps/api/src/plugins/db.ts
+++ b/apps/api/src/plugins/db.ts
@@ -1,9 +1,20 @@
 import fp from 'fastify-plugin'
-import { type NodePgDatabase } from 'drizzle-orm/node-postgres'
-import type * as schema from '../db/schema.js'
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres'
+import { Pool } from 'pg'
+import * as schema from '../db/schema.js'
 
 export type DrizzleDb = NodePgDatabase<typeof schema>
 
-export default fp(async function dbPlugin(_app) {
-  // Implémenté en Task 4
+export default fp(async function dbPlugin(app) {
+  const pool = new Pool({ connectionString: app.env.DATABASE_URL })
+
+  const client = await pool.connect()
+  client.release()
+
+  const db = drizzle(pool, { schema })
+  app.decorate('db', db)
+
+  app.addHook('onClose', async () => {
+    await pool.end()
+  })
 })

--- a/apps/api/src/plugins/jwt.ts
+++ b/apps/api/src/plugins/jwt.ts
@@ -1,22 +1,22 @@
-import fp from 'fastify-plugin'
-import fastifyJwt from '@fastify/jwt'
+import fp from 'fastify-plugin';
+import fastifyJwt from '@fastify/jwt';
 
 export interface JwtPayload {
-  sub: string // accountId
-  deviceId: string
-  householdId: string
-  type: 'access' | 'refresh'
+  sub: string; // accountId
+  deviceId: string;
+  householdId: string;
+  type: 'access' | 'refresh';
 }
 
 declare module '@fastify/jwt' {
   interface FastifyJWT {
-    payload: JwtPayload
-    user: JwtPayload
+    payload: JwtPayload;
+    user: JwtPayload;
   }
 }
 
 export default fp(async function jwtPlugin(app) {
   await app.register(fastifyJwt, {
     secret: app.env.JWT_SECRET,
-  })
-})
+  });
+});

--- a/apps/api/src/plugins/jwt.ts
+++ b/apps/api/src/plugins/jwt.ts
@@ -1,0 +1,5 @@
+import fp from 'fastify-plugin'
+
+export default fp(async function jwtPlugin(_app) {
+  // Implémenté en Task 5
+})

--- a/apps/api/src/plugins/jwt.ts
+++ b/apps/api/src/plugins/jwt.ts
@@ -1,5 +1,22 @@
 import fp from 'fastify-plugin'
+import fastifyJwt from '@fastify/jwt'
 
-export default fp(async function jwtPlugin(_app) {
-  // Implémenté en Task 5
+export interface JwtPayload {
+  sub: string // accountId
+  deviceId: string
+  householdId: string
+  type: 'access' | 'refresh'
+}
+
+declare module '@fastify/jwt' {
+  interface FastifyJWT {
+    payload: JwtPayload
+    user: JwtPayload
+  }
+}
+
+export default fp(async function jwtPlugin(app) {
+  await app.register(fastifyJwt, {
+    secret: app.env.JWT_SECRET,
+  })
 })

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1,17 +1,19 @@
-import { describe, it, expect, vi } from 'vitest'
-import { buildApp } from '../app.js'
-import { testEnv } from '../env.js'
-import type { DrizzleDb } from '../plugins/db.js'
+import { describe, it, expect, vi } from 'vitest';
+import { buildApp } from '../app.js';
+import { testEnv } from '../env.js';
+import type { DrizzleDb } from '../plugins/db.js';
 
 function makeMockDb(): DrizzleDb {
   return {
     insert: vi.fn().mockReturnValue({
       values: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([{
-          id: 'account-001',
-          emailHash: 'hash-of-test@example.com',
-          createdAt: new Date(),
-        }]),
+        returning: vi.fn().mockResolvedValue([
+          {
+            id: 'account-001',
+            emailHash: 'hash-of-test@example.com',
+            createdAt: new Date(),
+          },
+        ]),
       }),
     }),
     select: vi.fn().mockReturnValue({
@@ -24,75 +26,75 @@ function makeMockDb(): DrizzleDb {
         where: vi.fn().mockResolvedValue([]),
       }),
     }),
-  } as unknown as DrizzleDb
+  } as unknown as DrizzleDb;
 }
 
 describe('POST /auth/magic-link', () => {
   it('retourne 200 avec message de confirmation', async () => {
-    const app = buildApp(testEnv(), { db: makeMockDb() })
-    await app.ready()
+    const app = buildApp(testEnv(), { db: makeMockDb() });
+    await app.ready();
     const res = await app.inject({
       method: 'POST',
       url: '/auth/magic-link',
       payload: { email: 'test@example.com' },
-    })
-    expect(res.statusCode).toBe(200)
-    expect(res.json<{ message: string }>().message).toBe('Magic link envoyé')
-    await app.close()
-  })
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ message: string }>().message).toBe('Magic link envoyé');
+    await app.close();
+  });
 
   it('retourne 400 si email manquant', async () => {
-    const app = buildApp(testEnv(), { db: makeMockDb() })
-    await app.ready()
+    const app = buildApp(testEnv(), { db: makeMockDb() });
+    await app.ready();
     const res = await app.inject({
       method: 'POST',
       url: '/auth/magic-link',
       payload: {},
-    })
-    expect(res.statusCode).toBe(400)
-    await app.close()
-  })
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
 
   it('retourne 400 si email invalide', async () => {
-    const app = buildApp(testEnv(), { db: makeMockDb() })
-    await app.ready()
+    const app = buildApp(testEnv(), { db: makeMockDb() });
+    await app.ready();
     const res = await app.inject({
       method: 'POST',
       url: '/auth/magic-link',
       payload: { email: 'not-an-email' },
-    })
-    expect(res.statusCode).toBe(400)
-    await app.close()
-  })
-})
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+});
 
 describe('GET /auth/verify', () => {
   it('retourne 400 si token absent', async () => {
-    const app = buildApp(testEnv(), { db: makeMockDb() })
-    await app.ready()
+    const app = buildApp(testEnv(), { db: makeMockDb() });
+    await app.ready();
     const res = await app.inject({
       method: 'GET',
       url: '/auth/verify',
-    })
-    expect(res.statusCode).toBe(400)
-    await app.close()
-  })
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
 
   it('retourne 401 si token inconnu (hash non trouvé en DB)', async () => {
-    const db = makeMockDb()
+    const db = makeMockDb();
     vi.mocked(db.select).mockReturnValue({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([]),
       }),
-    } as ReturnType<typeof db.select>)
+    } as ReturnType<typeof db.select>);
 
-    const app = buildApp(testEnv(), { db })
-    await app.ready()
+    const app = buildApp(testEnv(), { db });
+    await app.ready();
     const res = await app.inject({
       method: 'GET',
       url: '/auth/verify?token=unknown-token-64-chars-padding-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-    })
-    expect(res.statusCode).toBe(401)
-    await app.close()
-  })
-})
+    });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/auth.test.ts
+++ b/apps/api/src/routes/auth.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest'
+import { buildApp } from '../app.js'
+import { testEnv } from '../env.js'
+import type { DrizzleDb } from '../plugins/db.js'
+
+function makeMockDb(): DrizzleDb {
+  return {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: 'account-001',
+          emailHash: 'hash-of-test@example.com',
+          createdAt: new Date(),
+        }]),
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+  } as unknown as DrizzleDb
+}
+
+describe('POST /auth/magic-link', () => {
+  it('retourne 200 avec message de confirmation', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/magic-link',
+      payload: { email: 'test@example.com' },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json<{ message: string }>().message).toBe('Magic link envoyé')
+    await app.close()
+  })
+
+  it('retourne 400 si email manquant', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/magic-link',
+      payload: {},
+    })
+    expect(res.statusCode).toBe(400)
+    await app.close()
+  })
+
+  it('retourne 400 si email invalide', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/magic-link',
+      payload: { email: 'not-an-email' },
+    })
+    expect(res.statusCode).toBe(400)
+    await app.close()
+  })
+})
+
+describe('GET /auth/verify', () => {
+  it('retourne 400 si token absent', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/auth/verify',
+    })
+    expect(res.statusCode).toBe(400)
+    await app.close()
+  })
+
+  it('retourne 401 si token inconnu (hash non trouvé en DB)', async () => {
+    const db = makeMockDb()
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    } as ReturnType<typeof db.select>)
+
+    const app = buildApp(testEnv(), { db })
+    await app.ready()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/auth/verify?token=unknown-token-64-chars-padding-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    })
+    expect(res.statusCode).toBe(401)
+    await app.close()
+  })
+})

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,0 +1,6 @@
+import type { FastifyPluginAsync } from 'fastify'
+
+const authRoute: FastifyPluginAsync = async (_app) => {
+  // Implémenté en Task 5
+}
+export default authRoute

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,6 +1,118 @@
 import type { FastifyPluginAsync } from 'fastify'
+import { z } from 'zod'
+import { sha256HexFromString, randomBytes } from '@kinhale/crypto'
+import { magicLinks, accounts } from '../db/schema.js'
+import { eq, and, gt } from 'drizzle-orm'
 
-const authRoute: FastifyPluginAsync = async (_app) => {
-  // Implémenté en Task 5
+const MagicLinkBodySchema = z.object({
+  email: z.string().email(),
+})
+
+const VerifyQuerySchema = z.object({
+  token: z.string().min(64),
+})
+
+const authRoute: FastifyPluginAsync = async (app) => {
+  app.post<{ Body: z.infer<typeof MagicLinkBodySchema> }>(
+    '/magic-link',
+    async (request, reply) => {
+      const result = MagicLinkBodySchema.safeParse(request.body)
+      if (!result.success) {
+        return reply.status(400).send({ error: 'Email invalide' })
+      }
+
+      const { email } = result.data
+      const emailHash = await sha256HexFromString(email.toLowerCase().trim())
+
+      const tokenBytes = await randomBytes(32)
+      const token = Buffer.from(tokenBytes).toString('hex')
+      const tokenHash = await sha256HexFromString(token)
+
+      const expiresAt = new Date(Date.now() + 10 * 60 * 1000)
+
+      await app.db.insert(magicLinks).values({
+        emailHash,
+        tokenHash,
+        expiresAt,
+      })
+
+      const magicUrl = `http://localhost:${app.env.PORT}/auth/verify?token=${token}`
+      app.log.info({ magicUrl }, 'Magic link généré (dev only)')
+
+      return reply.status(200).send({ message: 'Magic link envoyé' })
+    },
+  )
+
+  app.get<{ Querystring: z.infer<typeof VerifyQuerySchema> }>(
+    '/verify',
+    async (request, reply) => {
+      const result = VerifyQuerySchema.safeParse(request.query)
+      if (!result.success) {
+        return reply.status(400).send({ error: 'Token manquant ou invalide' })
+      }
+
+      const { token } = result.data
+      const tokenHash = await sha256HexFromString(token)
+
+      const rows = await app.db
+        .select()
+        .from(magicLinks)
+        .where(
+          and(
+            eq(magicLinks.tokenHash, tokenHash),
+            gt(magicLinks.expiresAt, new Date()),
+          ),
+        )
+
+      if (rows.length === 0) {
+        return reply.status(401).send({ error: 'Token invalide ou expiré' })
+      }
+
+      const link = rows[0]
+      if (link === undefined) {
+        return reply.status(401).send({ error: 'Token invalide ou expiré' })
+      }
+      if (link.usedAt !== null) {
+        return reply.status(401).send({ error: 'Token déjà utilisé' })
+      }
+
+      await app.db
+        .update(magicLinks)
+        .set({ usedAt: new Date() })
+        .where(eq(magicLinks.id, link.id))
+
+      const accountRows = await app.db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.emailHash, link.emailHash))
+
+      let accountId: string
+      const existingAccount = accountRows[0]
+      if (existingAccount !== undefined) {
+        accountId = existingAccount.id
+      } else {
+        const newAccount = await app.db
+          .insert(accounts)
+          .values({ emailHash: link.emailHash })
+          .returning()
+        const created = newAccount[0]
+        if (created === undefined) {
+          return reply.status(500).send({ error: 'Erreur création compte' })
+        }
+        accountId = created.id
+      }
+
+      const householdId = accountId
+      const deviceId = accountId
+
+      const accessToken = app.jwt.sign(
+        { sub: accountId, deviceId, householdId, type: 'access' },
+        { expiresIn: app.env.JWT_ACCESS_TTL },
+      )
+
+      return reply.status(200).send({ accessToken })
+    },
+  )
 }
+
 export default authRoute

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -1,120 +1,106 @@
-import type { FastifyPluginAsync } from 'fastify'
-import { z } from 'zod'
-import { sha256HexFromString, randomBytes } from '@kinhale/crypto'
-import { magicLinks, accounts } from '../db/schema.js'
-import { eq, and, gt } from 'drizzle-orm'
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { sha256HexFromString, randomBytes } from '@kinhale/crypto';
+import { magicLinks, accounts } from '../db/schema.js';
+import { eq, and, gt } from 'drizzle-orm';
 
 const MagicLinkBodySchema = z.object({
   email: z.string().email(),
-})
+});
 
 const VerifyQuerySchema = z.object({
   token: z.string().min(64),
-})
+});
 
 const authRoute: FastifyPluginAsync = async (app) => {
-  app.post<{ Body: z.infer<typeof MagicLinkBodySchema> }>(
-    '/magic-link',
-    async (request, reply) => {
-      const result = MagicLinkBodySchema.safeParse(request.body)
-      if (!result.success) {
-        return reply.status(400).send({ error: 'Email invalide' })
+  app.post<{ Body: z.infer<typeof MagicLinkBodySchema> }>('/magic-link', async (request, reply) => {
+    const result = MagicLinkBodySchema.safeParse(request.body);
+    if (!result.success) {
+      return reply.status(400).send({ error: 'Email invalide' });
+    }
+
+    const { email } = result.data;
+    const emailHash = await sha256HexFromString(email.toLowerCase().trim());
+
+    const tokenBytes = await randomBytes(32);
+    const token = Buffer.from(tokenBytes).toString('hex');
+    const tokenHash = await sha256HexFromString(token);
+
+    const expiresAt = new Date(Date.now() + 10 * 60 * 1000);
+
+    await app.db.insert(magicLinks).values({
+      emailHash,
+      tokenHash,
+      expiresAt,
+    });
+
+    if (app.env.NODE_ENV === 'development') {
+      const magicUrl = `http://localhost:${app.env.PORT}/auth/verify?token=${token}`;
+      app.log.info({ magicUrl }, 'Magic link généré (dev only)');
+    }
+
+    return reply.status(200).send({ message: 'Magic link envoyé' });
+  });
+
+  app.get<{ Querystring: z.infer<typeof VerifyQuerySchema> }>('/verify', async (request, reply) => {
+    const result = VerifyQuerySchema.safeParse(request.query);
+    if (!result.success) {
+      return reply.status(400).send({ error: 'Token manquant ou invalide' });
+    }
+
+    const { token } = result.data;
+    const tokenHash = await sha256HexFromString(token);
+
+    const rows = await app.db
+      .select()
+      .from(magicLinks)
+      .where(and(eq(magicLinks.tokenHash, tokenHash), gt(magicLinks.expiresAt, new Date())));
+
+    if (rows.length === 0) {
+      return reply.status(401).send({ error: 'Token invalide ou expiré' });
+    }
+
+    const link = rows[0];
+    if (link === undefined) {
+      return reply.status(401).send({ error: 'Token invalide ou expiré' });
+    }
+    if (link.usedAt !== null) {
+      return reply.status(401).send({ error: 'Token déjà utilisé' });
+    }
+
+    await app.db.update(magicLinks).set({ usedAt: new Date() }).where(eq(magicLinks.id, link.id));
+
+    const accountRows = await app.db
+      .select()
+      .from(accounts)
+      .where(eq(accounts.emailHash, link.emailHash));
+
+    let accountId: string;
+    const existingAccount = accountRows[0];
+    if (existingAccount !== undefined) {
+      accountId = existingAccount.id;
+    } else {
+      const newAccount = await app.db
+        .insert(accounts)
+        .values({ emailHash: link.emailHash })
+        .returning();
+      const created = newAccount[0];
+      if (created === undefined) {
+        return reply.status(500).send({ error: 'Erreur création compte' });
       }
+      accountId = created.id;
+    }
 
-      const { email } = result.data
-      const emailHash = await sha256HexFromString(email.toLowerCase().trim())
+    const householdId = accountId;
+    const deviceId = accountId;
 
-      const tokenBytes = await randomBytes(32)
-      const token = Buffer.from(tokenBytes).toString('hex')
-      const tokenHash = await sha256HexFromString(token)
+    const accessToken = app.jwt.sign(
+      { sub: accountId, deviceId, householdId, type: 'access' },
+      { expiresIn: app.env.JWT_ACCESS_TTL },
+    );
 
-      const expiresAt = new Date(Date.now() + 10 * 60 * 1000)
+    return reply.status(200).send({ accessToken });
+  });
+};
 
-      await app.db.insert(magicLinks).values({
-        emailHash,
-        tokenHash,
-        expiresAt,
-      })
-
-      if (app.env.NODE_ENV === 'development') {
-        const magicUrl = `http://localhost:${app.env.PORT}/auth/verify?token=${token}`
-        app.log.info({ magicUrl }, 'Magic link généré (dev only)')
-      }
-
-      return reply.status(200).send({ message: 'Magic link envoyé' })
-    },
-  )
-
-  app.get<{ Querystring: z.infer<typeof VerifyQuerySchema> }>(
-    '/verify',
-    async (request, reply) => {
-      const result = VerifyQuerySchema.safeParse(request.query)
-      if (!result.success) {
-        return reply.status(400).send({ error: 'Token manquant ou invalide' })
-      }
-
-      const { token } = result.data
-      const tokenHash = await sha256HexFromString(token)
-
-      const rows = await app.db
-        .select()
-        .from(magicLinks)
-        .where(
-          and(
-            eq(magicLinks.tokenHash, tokenHash),
-            gt(magicLinks.expiresAt, new Date()),
-          ),
-        )
-
-      if (rows.length === 0) {
-        return reply.status(401).send({ error: 'Token invalide ou expiré' })
-      }
-
-      const link = rows[0]
-      if (link === undefined) {
-        return reply.status(401).send({ error: 'Token invalide ou expiré' })
-      }
-      if (link.usedAt !== null) {
-        return reply.status(401).send({ error: 'Token déjà utilisé' })
-      }
-
-      await app.db
-        .update(magicLinks)
-        .set({ usedAt: new Date() })
-        .where(eq(magicLinks.id, link.id))
-
-      const accountRows = await app.db
-        .select()
-        .from(accounts)
-        .where(eq(accounts.emailHash, link.emailHash))
-
-      let accountId: string
-      const existingAccount = accountRows[0]
-      if (existingAccount !== undefined) {
-        accountId = existingAccount.id
-      } else {
-        const newAccount = await app.db
-          .insert(accounts)
-          .values({ emailHash: link.emailHash })
-          .returning()
-        const created = newAccount[0]
-        if (created === undefined) {
-          return reply.status(500).send({ error: 'Erreur création compte' })
-        }
-        accountId = created.id
-      }
-
-      const householdId = accountId
-      const deviceId = accountId
-
-      const accessToken = app.jwt.sign(
-        { sub: accountId, deviceId, householdId, type: 'access' },
-        { expiresIn: app.env.JWT_ACCESS_TTL },
-      )
-
-      return reply.status(200).send({ accessToken })
-    },
-  )
-}
-
-export default authRoute
+export default authRoute;

--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -36,8 +36,10 @@ const authRoute: FastifyPluginAsync = async (app) => {
         expiresAt,
       })
 
-      const magicUrl = `http://localhost:${app.env.PORT}/auth/verify?token=${token}`
-      app.log.info({ magicUrl }, 'Magic link généré (dev only)')
+      if (app.env.NODE_ENV === 'development') {
+        const magicUrl = `http://localhost:${app.env.PORT}/auth/verify?token=${token}`
+        app.log.info({ magicUrl }, 'Magic link généré (dev only)')
+      }
 
       return reply.status(200).send({ message: 'Magic link envoyé' })
     },

--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { buildApp } from '../app.js'
+import { testEnv } from '../env.js'
+import type { BuildAppOverrides } from '../app.js'
+
+const mockDb = {} as BuildAppOverrides['db']
+
+describe('GET /health', () => {
+  it('retourne 200 avec status ok', async () => {
+    const app = buildApp(testEnv(), { db: mockDb })
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/health' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json<{ status: string }>().status).toBe('ok')
+    await app.close()
+  })
+
+  it('retourne version et timestamp', async () => {
+    const app = buildApp(testEnv(), { db: mockDb })
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/health' })
+    const body = res.json<{ status: string; version: string; timestamp: string }>()
+    expect(body.version).toBe('0.1.0')
+    expect(new Date(body.timestamp).getTime()).toBeGreaterThan(0)
+    await app.close()
+  })
+
+  it('retourne 404 sur une route inconnue', async () => {
+    const app = buildApp(testEnv(), { db: mockDb })
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/not-found' })
+    expect(res.statusCode).toBe(404)
+    await app.close()
+  })
+})

--- a/apps/api/src/routes/health.test.ts
+++ b/apps/api/src/routes/health.test.ts
@@ -1,35 +1,35 @@
-import { describe, it, expect } from 'vitest'
-import { buildApp } from '../app.js'
-import { testEnv } from '../env.js'
-import type { BuildAppOverrides } from '../app.js'
+import { describe, it, expect } from 'vitest';
+import { buildApp } from '../app.js';
+import { testEnv } from '../env.js';
+import type { BuildAppOverrides } from '../app.js';
 
-const mockDb = {} as BuildAppOverrides['db']
+const mockDb = {} as BuildAppOverrides['db'];
 
 describe('GET /health', () => {
   it('retourne 200 avec status ok', async () => {
-    const app = buildApp(testEnv(), { db: mockDb })
-    await app.ready()
-    const res = await app.inject({ method: 'GET', url: '/health' })
-    expect(res.statusCode).toBe(200)
-    expect(res.json<{ status: string }>().status).toBe('ok')
-    await app.close()
-  })
+    const app = buildApp(testEnv(), { db: mockDb });
+    await app.ready();
+    const res = await app.inject({ method: 'GET', url: '/health' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json<{ status: string }>().status).toBe('ok');
+    await app.close();
+  });
 
   it('retourne version et timestamp', async () => {
-    const app = buildApp(testEnv(), { db: mockDb })
-    await app.ready()
-    const res = await app.inject({ method: 'GET', url: '/health' })
-    const body = res.json<{ status: string; version: string; timestamp: string }>()
-    expect(body.version).toBe('0.1.0')
-    expect(new Date(body.timestamp).getTime()).toBeGreaterThan(0)
-    await app.close()
-  })
+    const app = buildApp(testEnv(), { db: mockDb });
+    await app.ready();
+    const res = await app.inject({ method: 'GET', url: '/health' });
+    const body = res.json<{ status: string; version: string; timestamp: string }>();
+    expect(body.version).toBe('0.1.0');
+    expect(new Date(body.timestamp).getTime()).toBeGreaterThan(0);
+    await app.close();
+  });
 
   it('retourne 404 sur une route inconnue', async () => {
-    const app = buildApp(testEnv(), { db: mockDb })
-    await app.ready()
-    const res = await app.inject({ method: 'GET', url: '/not-found' })
-    expect(res.statusCode).toBe(404)
-    await app.close()
-  })
-})
+    const app = buildApp(testEnv(), { db: mockDb });
+    await app.ready();
+    const res = await app.inject({ method: 'GET', url: '/not-found' });
+    expect(res.statusCode).toBe(404);
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,0 +1,6 @@
+import type { FastifyPluginAsync } from 'fastify'
+
+const healthRoute: FastifyPluginAsync = async (app) => {
+  app.get('/health', async () => ({ status: 'ok' }))
+}
+export default healthRoute

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,6 +1,16 @@
 import type { FastifyPluginAsync } from 'fastify'
 
+interface HealthResponse {
+  status: 'ok'
+  version: string
+  timestamp: string
+}
+
 const healthRoute: FastifyPluginAsync = async (app) => {
-  app.get('/health', async () => ({ status: 'ok' }))
+  app.get<{ Reply: HealthResponse }>('/health', async () => ({
+    status: 'ok',
+    version: '0.1.0',
+    timestamp: new Date().toISOString(),
+  }))
 }
 export default healthRoute

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,9 +1,9 @@
-import type { FastifyPluginAsync } from 'fastify'
+import type { FastifyPluginAsync } from 'fastify';
 
 interface HealthResponse {
-  status: 'ok'
-  version: string
-  timestamp: string
+  status: 'ok';
+  version: string;
+  timestamp: string;
 }
 
 const healthRoute: FastifyPluginAsync = async (app) => {
@@ -11,6 +11,6 @@ const healthRoute: FastifyPluginAsync = async (app) => {
     status: 'ok',
     version: '0.1.0',
     timestamp: new Date().toISOString(),
-  }))
-}
-export default healthRoute
+  }));
+};
+export default healthRoute;

--- a/apps/api/src/routes/relay.test.ts
+++ b/apps/api/src/routes/relay.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import { buildApp } from '../app.js'
 import { testEnv } from '../env.js'
-import type { BuildAppOverrides } from '../app.js'
 import type { DrizzleDb } from '../plugins/db.js'
 
 function makeMockDb(): DrizzleDb {

--- a/apps/api/src/routes/relay.test.ts
+++ b/apps/api/src/routes/relay.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from 'vitest'
+import { buildApp } from '../app.js'
+import { testEnv } from '../env.js'
+import type { BuildAppOverrides } from '../app.js'
+import type { DrizzleDb } from '../plugins/db.js'
+
+function makeMockDb(): DrizzleDb {
+  return {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue([]),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+  } as unknown as DrizzleDb
+}
+
+describe('GET /relay (WebSocket upgrade)', () => {
+  it('retourne 400 sans header Upgrade (inject ne supporte pas WS)', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/relay',
+    })
+    // Sans header Upgrade: websocket, @fastify/websocket retourne 404
+    // (la route WS ne répond pas aux requêtes HTTP ordinaires)
+    expect([400, 404]).toContain(res.statusCode)
+    await app.close()
+  })
+
+  it('retourne 400 si householdId absent dans la query', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/relay',
+      headers: { upgrade: 'websocket' },
+    })
+    expect([400, 101, 404]).toContain(res.statusCode)
+    await app.close()
+  })
+})

--- a/apps/api/src/routes/relay.test.ts
+++ b/apps/api/src/routes/relay.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect, vi } from 'vitest'
-import { buildApp } from '../app.js'
-import { testEnv } from '../env.js'
-import type { DrizzleDb } from '../plugins/db.js'
+import { describe, it, expect, vi } from 'vitest';
+import { buildApp } from '../app.js';
+import { testEnv } from '../env.js';
+import type { DrizzleDb } from '../plugins/db.js';
 
 function makeMockDb(): DrizzleDb {
   return {
@@ -13,33 +13,33 @@ function makeMockDb(): DrizzleDb {
         where: vi.fn().mockResolvedValue([]),
       }),
     }),
-  } as unknown as DrizzleDb
+  } as unknown as DrizzleDb;
 }
 
 describe('GET /relay (WebSocket upgrade)', () => {
   it('retourne 400 sans header Upgrade (inject ne supporte pas WS)', async () => {
-    const app = buildApp(testEnv(), { db: makeMockDb() })
-    await app.ready()
+    const app = buildApp(testEnv(), { db: makeMockDb() });
+    await app.ready();
 
     const res = await app.inject({
       method: 'GET',
       url: '/relay',
-    })
+    });
     // Sans header Upgrade: websocket, @fastify/websocket retourne 404
     // (la route WS ne répond pas aux requêtes HTTP ordinaires)
-    expect([400, 404]).toContain(res.statusCode)
-    await app.close()
-  })
+    expect([400, 404]).toContain(res.statusCode);
+    await app.close();
+  });
 
   it('retourne 400 si householdId absent dans la query', async () => {
-    const app = buildApp(testEnv(), { db: makeMockDb() })
-    await app.ready()
+    const app = buildApp(testEnv(), { db: makeMockDb() });
+    await app.ready();
     const res = await app.inject({
       method: 'GET',
       url: '/relay',
       headers: { upgrade: 'websocket' },
-    })
-    expect([400, 101, 404]).toContain(res.statusCode)
-    await app.close()
-  })
-})
+    });
+    expect([400, 101, 404]).toContain(res.statusCode);
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/relay.ts
+++ b/apps/api/src/routes/relay.ts
@@ -13,10 +13,9 @@ const relayRoute: FastifyPluginAsync = async (app) => {
     '/',
     { websocket: true },
     (socket: WebSocket, request) => {
-      const { householdId, deviceId } = request.query as {
-        householdId?: string
-        deviceId?: string
-      }
+      const query = (request.query ?? {}) as Record<string, unknown>
+      const householdId = typeof query['householdId'] === 'string' ? query['householdId'] : undefined
+      const deviceId = typeof query['deviceId'] === 'string' ? query['deviceId'] : undefined
 
       if (!householdId || !deviceId) {
         socket.close(1008, 'householdId et deviceId requis')
@@ -66,7 +65,11 @@ const relayRoute: FastifyPluginAsync = async (app) => {
         if (peers) {
           for (const peer of peers) {
             if (peer !== socket && peer.readyState === peer.OPEN) {
-              peer.send(raw.toString())
+              try {
+                peer.send(raw.toString())
+              } catch (sendErr) {
+                app.log.warn({ sendErr }, 'Échec envoi WS peer')
+              }
             }
           }
         }

--- a/apps/api/src/routes/relay.ts
+++ b/apps/api/src/routes/relay.ts
@@ -1,6 +1,89 @@
 import type { FastifyPluginAsync } from 'fastify'
+import type { WebSocket } from 'ws'
+import { mailboxMessages } from '../db/schema.js'
 
-const relayRoute: FastifyPluginAsync = async (_app) => {
-  // Implémenté en Task 6
+/**
+ * Map in-memory pour le routing WS multi-device d'un même foyer.
+ * Sprint 0 : mono-node. Sprint 1 : Redis pub/sub pour multi-node.
+ */
+const householdSockets = new Map<string, Set<WebSocket>>()
+
+const relayRoute: FastifyPluginAsync = async (app) => {
+  app.get(
+    '/',
+    { websocket: true },
+    (socket: WebSocket, request) => {
+      const { householdId, deviceId } = request.query as {
+        householdId?: string
+        deviceId?: string
+      }
+
+      if (!householdId || !deviceId) {
+        socket.close(1008, 'householdId et deviceId requis')
+        return
+      }
+
+      if (!householdSockets.has(householdId)) {
+        householdSockets.set(householdId, new Set())
+      }
+      householdSockets.get(householdId)!.add(socket)
+
+      socket.on('message', async (raw) => {
+        let msg: unknown
+        try {
+          msg = JSON.parse(raw.toString())
+        } catch {
+          socket.send(JSON.stringify({ error: 'JSON invalide' }))
+          return
+        }
+
+        if (
+          typeof msg !== 'object' ||
+          msg === null ||
+          typeof (msg as Record<string, unknown>)['blobJson'] !== 'string'
+        ) {
+          socket.send(JSON.stringify({ error: 'SyncMessage invalide' }))
+          return
+        }
+
+        const message = msg as {
+          blobJson: string
+          seq: number
+          sentAtMs: number
+        }
+
+        const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000)
+        await app.db.insert(mailboxMessages).values({
+          householdId,
+          senderDeviceId: deviceId,
+          blobJson: message.blobJson,
+          seq: message.seq ?? 0,
+          sentAtMs: message.sentAtMs ?? Date.now(),
+          expiresAt,
+        })
+
+        const peers = householdSockets.get(householdId)
+        if (peers) {
+          for (const peer of peers) {
+            if (peer !== socket && peer.readyState === peer.OPEN) {
+              peer.send(raw.toString())
+            }
+          }
+        }
+      })
+
+      socket.on('close', () => {
+        householdSockets.get(householdId)?.delete(socket)
+        if (householdSockets.get(householdId)?.size === 0) {
+          householdSockets.delete(householdId)
+        }
+      })
+
+      socket.on('error', (err) => {
+        app.log.error({ err }, 'WebSocket error')
+      })
+    },
+  )
 }
+
 export default relayRoute

--- a/apps/api/src/routes/relay.ts
+++ b/apps/api/src/routes/relay.ts
@@ -25,7 +25,10 @@ const relayRoute: FastifyPluginAsync = async (app) => {
       if (!householdSockets.has(householdId)) {
         householdSockets.set(householdId, new Set())
       }
-      householdSockets.get(householdId)!.add(socket)
+      const sockets = householdSockets.get(householdId)
+      if (sockets) {
+        sockets.add(socket)
+      }
 
       socket.on('message', async (raw) => {
         let msg: unknown

--- a/apps/api/src/routes/relay.ts
+++ b/apps/api/src/routes/relay.ts
@@ -1,95 +1,91 @@
-import type { FastifyPluginAsync } from 'fastify'
-import type { WebSocket } from 'ws'
-import { mailboxMessages } from '../db/schema.js'
+import type { FastifyPluginAsync } from 'fastify';
+import type { WebSocket } from 'ws';
+import { mailboxMessages } from '../db/schema.js';
 
 /**
  * Map in-memory pour le routing WS multi-device d'un même foyer.
  * Sprint 0 : mono-node. Sprint 1 : Redis pub/sub pour multi-node.
  */
-const householdSockets = new Map<string, Set<WebSocket>>()
+const householdSockets = new Map<string, Set<WebSocket>>();
 
 const relayRoute: FastifyPluginAsync = async (app) => {
-  app.get(
-    '/',
-    { websocket: true },
-    (socket: WebSocket, request) => {
-      const query = (request.query ?? {}) as Record<string, unknown>
-      const householdId = typeof query['householdId'] === 'string' ? query['householdId'] : undefined
-      const deviceId = typeof query['deviceId'] === 'string' ? query['deviceId'] : undefined
+  app.get('/', { websocket: true }, (socket: WebSocket, request) => {
+    const query = (request.query ?? {}) as Record<string, unknown>;
+    const householdId = typeof query['householdId'] === 'string' ? query['householdId'] : undefined;
+    const deviceId = typeof query['deviceId'] === 'string' ? query['deviceId'] : undefined;
 
-      if (!householdId || !deviceId) {
-        socket.close(1008, 'householdId et deviceId requis')
-        return
+    if (!householdId || !deviceId) {
+      socket.close(1008, 'householdId et deviceId requis');
+      return;
+    }
+
+    if (!householdSockets.has(householdId)) {
+      householdSockets.set(householdId, new Set());
+    }
+    const sockets = householdSockets.get(householdId);
+    if (sockets) {
+      sockets.add(socket);
+    }
+
+    socket.on('message', async (raw) => {
+      let msg: unknown;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        socket.send(JSON.stringify({ error: 'JSON invalide' }));
+        return;
       }
 
-      if (!householdSockets.has(householdId)) {
-        householdSockets.set(householdId, new Set())
+      if (
+        typeof msg !== 'object' ||
+        msg === null ||
+        typeof (msg as Record<string, unknown>)['blobJson'] !== 'string'
+      ) {
+        socket.send(JSON.stringify({ error: 'SyncMessage invalide' }));
+        return;
       }
-      const sockets = householdSockets.get(householdId)
-      if (sockets) {
-        sockets.add(socket)
-      }
 
-      socket.on('message', async (raw) => {
-        let msg: unknown
-        try {
-          msg = JSON.parse(raw.toString())
-        } catch {
-          socket.send(JSON.stringify({ error: 'JSON invalide' }))
-          return
-        }
+      const message = msg as {
+        blobJson: string;
+        seq: number;
+        sentAtMs: number;
+      };
 
-        if (
-          typeof msg !== 'object' ||
-          msg === null ||
-          typeof (msg as Record<string, unknown>)['blobJson'] !== 'string'
-        ) {
-          socket.send(JSON.stringify({ error: 'SyncMessage invalide' }))
-          return
-        }
+      const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000);
+      await app.db.insert(mailboxMessages).values({
+        householdId,
+        senderDeviceId: deviceId,
+        blobJson: message.blobJson,
+        seq: message.seq ?? 0,
+        sentAtMs: message.sentAtMs ?? Date.now(),
+        expiresAt,
+      });
 
-        const message = msg as {
-          blobJson: string
-          seq: number
-          sentAtMs: number
-        }
-
-        const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000)
-        await app.db.insert(mailboxMessages).values({
-          householdId,
-          senderDeviceId: deviceId,
-          blobJson: message.blobJson,
-          seq: message.seq ?? 0,
-          sentAtMs: message.sentAtMs ?? Date.now(),
-          expiresAt,
-        })
-
-        const peers = householdSockets.get(householdId)
-        if (peers) {
-          for (const peer of peers) {
-            if (peer !== socket && peer.readyState === peer.OPEN) {
-              try {
-                peer.send(raw.toString())
-              } catch (sendErr) {
-                app.log.warn({ sendErr }, 'Échec envoi WS peer')
-              }
+      const peers = householdSockets.get(householdId);
+      if (peers) {
+        for (const peer of peers) {
+          if (peer !== socket && peer.readyState === peer.OPEN) {
+            try {
+              peer.send(raw.toString());
+            } catch (sendErr) {
+              app.log.warn({ sendErr }, 'Échec envoi WS peer');
             }
           }
         }
-      })
+      }
+    });
 
-      socket.on('close', () => {
-        householdSockets.get(householdId)?.delete(socket)
-        if (householdSockets.get(householdId)?.size === 0) {
-          householdSockets.delete(householdId)
-        }
-      })
+    socket.on('close', () => {
+      householdSockets.get(householdId)?.delete(socket);
+      if (householdSockets.get(householdId)?.size === 0) {
+        householdSockets.delete(householdId);
+      }
+    });
 
-      socket.on('error', (err) => {
-        app.log.error({ err }, 'WebSocket error')
-      })
-    },
-  )
-}
+    socket.on('error', (err) => {
+      app.log.error({ err }, 'WebSocket error');
+    });
+  });
+};
 
-export default relayRoute
+export default relayRoute;

--- a/apps/api/src/routes/relay.ts
+++ b/apps/api/src/routes/relay.ts
@@ -1,0 +1,6 @@
+import type { FastifyPluginAsync } from 'fastify'
+
+const relayRoute: FastifyPluginAsync = async (_app) => {
+  // Implémenté en Task 6
+}
+export default relayRoute

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@kinhale/tsconfig/library.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,9 +1,7 @@
 {
-  "extends": "@kinhale/tsconfig/library.json",
+  "extends": "@kinhale/tsconfig/fastify.json",
   "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist",
-    "types": ["node"]
+    "rootDir": "src"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})

--- a/apps/api/vitest.config.ts
+++ b/apps/api/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
@@ -6,4 +6,4 @@ export default defineConfig({
     environment: 'node',
     include: ['src/**/*.test.ts'],
   },
-})
+});

--- a/docs/architecture/adr/ADR-D1-react-native-workflow.md
+++ b/docs/architecture/adr/ADR-D1-react-native-workflow.md
@@ -1,0 +1,108 @@
+# ADR-D1 — React Native Workflow : Bare + EAS Build vs Managed Workflow Expo
+
+**Date** : 2026-04-20
+**Statut** : Accepté
+**Décideurs** : Martial Kaljob (Kamez Conseils)
+
+## Contexte
+
+Kinhale est une application mobile iOS + Android + Web qui repose sur deux modules natifs absolument non-négociables : `react-native-libsodium` pour les opérations cryptographiques (Ed25519, X25519, XChaCha20-Poly1305, Argon2id) et `op-sqlite` avec SQLCipher pour le stockage local chiffré. Ces deux librairies compilent du code natif C/Rust et requièrent l'accès direct aux systèmes de build Xcode et Gradle.
+
+Expo propose deux modes de fonctionnement : le **Managed Workflow** (qui abstrait entièrement le build natif et limite l'app aux modules de l'écosystème Expo officiel) et le **Bare Workflow** (qui expose les dossiers `ios/` et `android/` et laisse le développeur gérer le build natif). Pour un solo dev, ce choix a des conséquences importantes sur la complexité quotidienne, la durée des cycles de build, la surface de maintenance, et la capacité à intégrer des dépendances critiques.
+
+Si cette décision n'est pas tranchée dès le Sprint 0, le risque est de commencer à construire en Managed Workflow — qui est la voie de moindre résistance pour le démarrage rapide — puis de devoir migrer en Bare au Sprint 2 ou 3 quand l'intégration crypto devient urgente. Cette migration a posteriori est coûteuse (2-5 jours-homme) et génère des régressions.
+
+## Options évaluées
+
+### Option A — Managed Workflow Expo (SDK 52)
+
+**Description** : Expo gère intégralement les builds natifs. Le développeur ne touche jamais à Xcode ni à Gradle directement. Les mises à jour Expo SDK couvrent 90 % des besoins courants. Les modules natifs non supportés passent par des "Config Plugins" qui injectent du code natif au moment du build cloud.
+
+**Avantages** :
+- Démarrage extrêmement rapide (< 30 min de scaffolding opérationnel).
+- Pas de maintenance des dossiers `ios/` et `android/`.
+- Mises à jour SDK simplifiées (la majorité des breaking changes sont absorbés par Expo).
+- Accès facile à EAS Build sans configuration particulière.
+- Idéal pour un MVP sans besoins natifs exotiques.
+
+**Inconvénients** :
+- `react-native-libsodium` **n'est pas supporté en Managed Workflow** — il n'existe pas de Config Plugin officiel et maintenu pour cette librairie.
+- `op-sqlite` avec SQLCipher n'est pas dans l'écosystème Expo officiel et son intégration en Config Plugin est non documentée et non testée à grande échelle.
+- Toute dépendance native hors Expo SDK impose l'éjection, ce qui annule tous les avantages de ce workflow.
+- Le "prebuild" Expo qui génère les dossiers natifs à la volée crée des dossiers non versionnés et difficiles à déboguer en cas de problème de compilation natif.
+
+**Risques** :
+- Blocage total sur l'intégration crypto au Sprint 1. L'architecture entière de Kinhale repose sur la crypto native — sans elle, on ne peut pas construire le produit.
+- Fausse sécurité : le démarrage facile masque une contrainte rédhibitoire qui se révèle trop tard.
+
+### Option B — Bare Workflow Expo + EAS Build
+
+**Description** : Les dossiers `ios/` et `android/` sont versionnés et configurés manuellement. Expo SDK reste utilisé pour ses composants de haut niveau (notifications, secure store, localization, etc.) mais le core natif est géré directement. EAS Build est utilisé pour les builds CI/CD cloud (évite d'avoir Xcode/Android Studio en local pour les builds de release).
+
+**Avantages** :
+- Accès total aux modules natifs — `react-native-libsodium`, `op-sqlite`/SQLCipher, et tout futur module natif sont intégrables sans friction.
+- EAS Build gère les builds iOS (signature certificats, provisioning) et Android (keystore) en cloud, ce qui compense l'absence de Mac en environnement CI.
+- La commande `expo prebuild` peut être utilisée ponctuellement pour régénérer les dossiers natifs après une mise à jour SDK, mais les dossiers sont versionnés pour un contrôle total.
+- Compatibilité totale avec les librairies React Native standard non-Expo.
+- Compatible avec les politiques Tamagui, react-navigation, et tout l'écosystème React Native.
+
+**Inconvénients** :
+- La première configuration (podfile, gradle, signing) prend 1-2 jours pour un solo dev.
+- Les mises à jour SDK majeures peuvent nécessiter des ajustements manuels dans les dossiers natifs (typiquement 2-4h par mise à jour majeure).
+- Les erreurs de build natif (erreurs Xcode, erreurs Gradle) sont plus difficiles à diagnostiquer que les erreurs JS — elles nécessitent une compréhension de base des systèmes de build iOS/Android.
+- Sans Mac local, le debug iOS en développement passe par Expo Go ou le simulateur via EAS, ce qui ralentit légèrement les cycles de feedback.
+
+**Risques** :
+- Risque d'incompatibilité entre une future version d'Expo SDK et un module natif tiers — gérable mais nécessite une veille active.
+- Risque de dérive de la configuration native si plusieurs développeurs contribuent sans discipline — acceptable pour un solo dev.
+
+### Option C — React Native pur (sans Expo)
+
+**Description** : Utiliser React Native CLI directement, sans aucune couche Expo.
+
+**Avantages** : Contrôle total absolu, pas de dépendance Expo.
+
+**Inconvénients** : On perd les avantages d'EAS Build (builds cloud signés), d'expo-notifications (notifications push multi-plateforme), d'expo-secure-store, d'expo-localization, etc. Ces modules sont matures et couvrent des besoins réels de Kinhale. Les recoder ou les remplacer coûte 5-10 jours-homme supplémentaires sans gain visible.
+
+**Risques** : Coût de développement inutilement élevé.
+
+## Critères de décision
+
+1. **Intégration non-négociable de `react-native-libsodium` et `op-sqlite`/SQLCipher** — c'est la contrainte technique bloquante.
+2. **Capacité à builder iOS sans Mac en CI** — EAS Build est la solution.
+3. **Coût de configuration initial acceptable pour un solo dev** — quelques jours sont acceptables.
+4. **Disponibilité des modules Expo utiles** (notifications, secure store, localization) — à conserver.
+5. **Maintenabilité long terme** — les dossiers natifs doivent être stables et versionnables.
+
+## Décision
+
+**Choix retenu : Option B — Bare Workflow Expo SDK 52 + EAS Build**
+
+La contrainte technique est sans appel : `react-native-libsodium` et `op-sqlite` ne fonctionnent pas en Managed Workflow. Ce n'est pas une préférence architecturale, c'est une impossibilité technique documentée. L'ensemble de la promesse produit de Kinhale — le E2EE zero-knowledge — repose sur ces deux librairies. Choisir Managed Workflow reviendrait à construire une maison sur des fondations que l'on sait incompatibles avec la structure portante.
+
+Le Bare Workflow conserve la totalité des avantages d'Expo qui nous intéressent : EAS Build pour les builds cloud signés iOS/Android, les packages Expo matures (`expo-notifications`, `expo-secure-store`, `expo-localization`, `expo-updates` pour les OTA). La seule chose que l'on perd, c'est l'abstraction des dossiers natifs — mais cette abstraction est précisément ce qui nous bloque.
+
+Ce qui a fait pencher la balance : un solo dev en Bare Workflow avec EAS Build est un profil très commun dans l'écosystème React Native en 2026. La documentation est abondante, les forums sont actifs, et les 1-2 jours de configuration initiale sont un investissement unique qui évite une migration coûteuse ultérieure.
+
+Ce choix serait invalidé si : EAS Build devenait payant à un niveau prohibitif pour un projet open source (un plan gratuit ou ~$15/mois suffit pour la v1.0), ou si une solution Managed Workflow avec Config Plugin pour libsodium devenait mature et auditée (peu probable à court terme).
+
+## Conséquences
+
+**Positives :**
+- Intégration crypto native dès le Sprint 0, sans contournement.
+- Builds iOS/Android reproductibles en CI via EAS Build, sans Mac local obligatoire.
+- Accès à tout l'écosystème React Native, sans restriction Expo Managed.
+- Les modules Expo utiles (`expo-notifications`, `expo-secure-store`) restent disponibles.
+- Meilleure transparence sur la configuration native — plus facile à auditer pour la revue de sécurité.
+
+**Négatives / compromis acceptés :**
+- 1-2 jours de configuration initiale (`ios/Podfile`, `android/build.gradle`, certificats EAS).
+- Chaque mise à jour majeure Expo SDK nécessite un ajustement manuel des dossiers natifs (2-4h estimées par mise à jour).
+- Le débogage des erreurs de build natif requiert une connaissance minimale de Xcode/Gradle — acceptable pour un dev senior.
+- Sans Mac local, le test iOS en développement se fait via Expo Go (pour les parties non-crypto) ou via TestFlight/simulateur EAS (pour les builds natifs complets).
+
+**Plan de fallback** : Si EAS Build crée des blocages inattendus (pricing, indisponibilité, limitations sur les modules natifs), le fallback est de configurer un runner macOS GitHub Actions (disponible en tarif horaire) pour les builds iOS. Coût estimé : ~$0.08/min, acceptable pour les releases (~$5-10 par release candidate).
+
+## Révision prévue
+
+À revisiter si : (1) Expo SDK 53+ intègre un support officiel de SQLCipher via Config Plugin maintenu, ou (2) le projet passe à une équipe de 3+ développeurs et la gestion des conflits sur les dossiers natifs devient problématique. Dans ce dernier cas, évaluer le passage à une architecture de "modules natifs partagés" avec Turbo Modules.

--- a/docs/architecture/adr/ADR-D2-crdt-engine.md
+++ b/docs/architecture/adr/ADR-D2-crdt-engine.md
@@ -1,0 +1,99 @@
+# ADR-D2 — Moteur CRDT : Automerge 2 vs Yjs
+
+**Date** : 2026-04-20
+**Statut** : Accepté
+**Décideurs** : Martial Kaljob (Kamez Conseils)
+
+## Contexte
+
+L'architecture local-first de Kinhale repose sur un principe fondamental : chaque device porte une copie complète et cohérente de toutes les données du foyer. Quand plusieurs aidants sont en ligne simultanément (parent + co-parent + éducatrice), leurs modifications doivent converger automatiquement vers un état identique sur tous les devices, sans passer par un serveur central arbitre. Quand un aidant est hors-ligne pendant des heures (garderie en sous-sol), ses modifications doivent s'intégrer proprement à son retour, sans écarter les modifications concurrentes des autres aidants.
+
+Ces exigences définissent exactement le problème que les CRDT (Conflict-free Replicated Data Types) résolvent. Sans CRDT, il faudrait implémenter un protocole de reconciliation personnalisé avec gestion des vecteurs de causalité, résolution de conflits sémantiques, et garantie de convergence — une tâche qui représente 3-6 mois de développement pour un solo dev, sans les garanties formelles d'un CRDT éprouvé.
+
+Le schéma de données de Kinhale est spécifique : des listes append-only d'événements signés (`DoseAdministered`, `SymptomReported`, `PumpReplaced`, `PlanUpdated`, `CaregiverInvited`, `CaregiverRevoked`), chaque événement signé Ed25519 par le device émetteur. Les entités dérivées (plan en cours, pompes actives, niveau de doses restantes) sont des projections calculées à la lecture, jamais stockées comme état concurrent. Ce schéma favorise les structures de listes append-only plutôt que les textes collaboratifs temps réel.
+
+## Options évaluées
+
+### Option A — Automerge 2
+
+**Description** : Automerge 2 est une implémentation CRDT de référence développée par Ink & Switch, le laboratoire de recherche derrière le manifeste "local-first software". Le format binaire 2.x est stable et compact. L'API expose des types riches (Maps, Lists, Text, Counter) qui correspondent naturellement aux entités métier de Kinhale.
+
+**Avantages** :
+- **Alignement conceptuel avec le projet** : Ink & Switch est l'origine intellectuelle du mouvement local-first. La communauté Automerge est celle des développeurs et chercheurs les plus sensibles aux problématiques de privacy et de possession des données.
+- **Modèle de données JSON-like** : `Doc<T>` avec types TypeScript génériques. Un `FoyerDoc` avec une liste `events: DoseEvent[]` est naturel et typé strictement.
+- **Sync incrémental efficace** : `getChanges(sinceHeads)` produit un delta minimal que l'on chiffre et publie dans la mailbox. Les devices ne rechargent que les changements depuis leur dernier head connu.
+- **Maturité du format 2.x** : le format binaire est stable, les migrations de schéma sont documentées.
+- **Auteur des changements** : chaque changement Automerge porte un `actorId` (UUID du device) — ce qui complète naturellement notre signature Ed25519.
+- **Performance** : le backend Rust (compilé en WASM) d'Automerge 2 est significativement plus rapide qu'Automerge 1 sur les opérations de merge et de sauvegarde/chargement. Tests publiés : merge de 10k opérations en < 50ms sur device mid-range.
+
+**Inconvénients** :
+- L'API peut surprendre : les mutations doivent se faire dans une fonction `change()` — les modifications directes sur l'objet ne sont pas réactives. Nécessite une discipline API spécifique.
+- Le WASM ajoute ~800Ko au bundle web (acceptable, mais à surveiller avec code-splitting).
+- Moins de ressources sur les patterns "append-only signés" spécifiquement — la documentation se concentre sur le collaboratif texte.
+
+**Risques** :
+- Faible. Automerge 2 est en production dans plusieurs apps local-first en 2026. Les breaking changes du format sont annoncés longtemps à l'avance.
+
+### Option B — Yjs
+
+**Description** : Yjs est le CRDT le plus utilisé en production pour la collaboration temps réel (ProseMirror, CodeMirror, Quill, Notion-like editors). Il utilise le YATA algorithm (Yet Another Transformation Approach) et propose des bindings pour de nombreux frameworks.
+
+**Avantages** :
+- **Performances temps réel exceptionnelles** : Yjs est optimisé pour les textes collaboratifs avec des milliers de petites opérations concurrentes par seconde — bien au-delà des besoins de Kinhale.
+- **Écosystème très large** : providers pour WebSocket, WebRTC, IndexedDB, nombreux bindings éditeurs de texte.
+- **Documentation abondante** sur les cas d'usage collaboratifs.
+- Léger : pas de WASM requis pour les cas simples.
+
+**Inconvénients** :
+- **Modèle de données plus bas niveau** : `Y.Map`, `Y.Array`, `Y.Text` — moins expressif qu'Automerge pour un schéma de données métier typé. Il faut mapper manuellement les entités métier sur les types Yjs, ce qui introduit une couche d'abstraction et des risques de bugs de sérialisation.
+- **Historique et causalité moins riches** : Yjs expose moins facilement l'historique des opérations et leurs auteurs, ce qui complique l'implémentation de l'audit trail client et de la vérification des signatures Ed25519 par opération.
+- **Optimisé pour un usage texte collaboratif** qui n'est pas notre cas principal. On paie un overhead d'abstraction pour un use-case (listes d'événements signés) que Yjs ne cible pas naturellement.
+- L'écosystème "privacy-first" et "local-first" est moins central dans la communauté Yjs que dans celle d'Automerge.
+
+**Risques** :
+- Risque de complexité accidentelle : mapper le schéma événementiel signé de Kinhale sur les types Yjs requiert une couche d'abstraction custom qui devient elle-même une surface de bug.
+
+### Option C — Solution CRDT custom
+
+Non évaluée sérieusement pour la v1.0. Implémenter un CRDT correct (causalité, commutativité, idempotence, convergence) est un problème de recherche. Pour un solo dev avec un budget de 13-15 semaines, c'est hors budget et hors compétence raisonnable.
+
+## Critères de décision
+
+1. **Adéquation au schéma événementiel signé** — le modèle de données (listes append-only d'événements Ed25519) doit être naturel à exprimer.
+2. **Typage TypeScript strict** — `strict: true`, `noUncheckedIndexedAccess: true` sont obligatoires.
+3. **Performance sur le profil de charge cible** — fusion de 10 devices × 1000 événements en < 100ms.
+4. **Sync incrémental compact** — les deltas à chiffrer et envoyer via mailbox doivent être minimaux.
+5. **Auditeur Ed25519 par événement** — chaque opération doit pouvoir porter la signature de son device émetteur.
+6. **Alignement communautaire** — l'écosystème et la communauté doivent être cohérents avec la posture privacy-first du projet.
+
+## Décision
+
+**Choix retenu : Option A — Automerge 2**
+
+La décision se fonde principalement sur l'adéquation naturelle entre le modèle de données d'Automerge 2 et le schéma événementiel signé de Kinhale. Un document Automerge `{ events: DoseEvent[], household: HouseholdConfig }` est typé strictement avec les generics TypeScript d'Automerge et correspond exactement à la structure que l'on veut : des listes append-only que tous les devices convergent vers le même état, avec l'historique de qui a émis quoi.
+
+Le modèle `actorId` natif d'Automerge complète parfaitement notre signature Ed25519 : chaque `change` Automerge est signé par un `actorId` qui correspond à notre `device_id`, et nous ajoutons la signature Ed25519 en tant que metadata du changement (`change.metadata.signature`). L'auditabilité est ainsi native.
+
+La communauté Ink & Switch / Automerge est aussi la communauté qui a théorisé le local-first software — Kinhale y trouve une documentation conceptuelle riche (notamment sur la gestion des conflits sémantiques dans les applications médicales) que la communauté Yjs, orientée éditeurs de texte, n'offre pas.
+
+Ce choix serait invalidé si : le benchmark Sprint 0 (10 devices × 1000 événements) révèle des latences > 100ms sur device mid-range Android, ou si le WASM Automerge crée des problèmes d'intégration avec React Native 0.74+ que le PoC ne parvient pas à résoudre.
+
+## Conséquences
+
+**Positives :**
+- Modèle de données TypeScript natif, strict, sans couche d'abstraction custom.
+- Audit trail client naturellement disponible via l'historique Automerge, complété par les signatures Ed25519.
+- Sync incrémental compact : `getChanges(sinceHeads)` produit des deltas binaires minimaux, idéaux pour chiffrer et envoyer via mailbox S3.
+- Convergence garantie : deux devices avec les mêmes changements Automerge arrivent toujours au même état, quelle que soit l'ordre de réception.
+- La vue consolidée multi-foyers (Marie, éducatrice CPE, sur 8 foyers) est un merge de N documents Automerge — opération native et performante.
+
+**Négatives / compromis acceptés :**
+- L'API `change()` d'Automerge impose une discipline de mutation différente du state React habituel — courbe d'apprentissage de 1-2 jours pour un dev React senior.
+- Le WASM ajoute ~800Ko au bundle web initial (mitigé par code-splitting et lazy loading).
+- Les migrations de schéma (ajout d'un champ à `DoseEvent`) nécessitent une stratégie de compatibilité explicite entre versions — documentée dès le Sprint 0 dans un fichier `packages/sync/SCHEMA_MIGRATION.md`.
+
+**Plan de fallback** : Si le PoC Automerge révèle des problèmes de performance ou d'intégration React Native insurmontables, le fallback est Yjs avec une couche d'abstraction `EventList<T>` custom autour de `Y.Array`. Coût estimé de la migration : 3-5 jours-homme (la couche `packages/sync` est suffisamment isolée). La décision de fallback doit être prise avant la fin du Sprint 0.
+
+## Révision prévue
+
+Après le benchmark Sprint 0 obligatoire : fusion de 10 devices × 1000 événements, latence médiane cible < 100ms. Si la cible n'est pas atteinte, réévaluer avec Yjs. À revoir également si Automerge 3.0 introduit des breaking changes majeurs du format binaire qui imposeraient une migration de données en production.

--- a/docs/architecture/adr/ADR-D3-groupe-e2ee-protocol.md
+++ b/docs/architecture/adr/ADR-D3-groupe-e2ee-protocol.md
@@ -1,0 +1,122 @@
+# ADR-D3 — Protocole de groupe E2EE : MLS (RFC 9420) vs Signal Protocol / Double Ratchet
+
+**Date** : 2026-04-20
+**Statut** : Accepté (sous réserve de validation du PoC Sprint 0)
+**Décideurs** : Martial Kaljob (Kamez Conseils)
+
+## Contexte
+
+C'est la décision architecturale la plus critique du projet. L'ensemble de la promesse produit de Kinhale — "vos données de santé ne quittent jamais vos appareils, même nous les créateurs ne pouvons pas les lire" — repose sur la robustesse du protocole de chiffrement de groupe. Un choix erroné ici ne se corrige pas sans une migration complète, une rotation de toutes les clés en production, et une communication de crise aux utilisateurs.
+
+Le problème à résoudre est le suivant : un foyer Kinhale est un groupe dynamique de 2 à ~10 devices (un ou plusieurs devices par aidant). Ces devices partagent un document Automerge chiffré. Pour que chaque device puisse chiffrer ses deltas Automerge de façon à ce que tous les autres devices du foyer puissent les déchiffrer, et pour que l'ajout ou la révocation d'un aidant soit proprement reflété dans les clés, il faut un protocole de gestion de clés de groupe.
+
+Deux propriétés de sécurité sont fondamentales :
+- **Forward Secrecy (FS)** : si la clé actuelle est compromise, les messages passés restent protégés. Les clés passées ne peuvent pas être dérivées depuis la clé actuelle.
+- **Post-Compromise Security (PCS)** : si la clé actuelle est compromise, la sécurité est rétablie après une rotation de clés (les messages futurs sont protégés même si l'attaquant a vu la clé actuelle).
+
+La révocation d'un aidant (ex : une garderie quitte le foyer) est le cas critique : après révocation, l'aidant révoqué ne doit plus pouvoir déchiffrer les nouveaux deltas. Cela implique une rotation de clé de groupe.
+
+Pour un solo dev sans auditeur crypto externe disponible avant Sprint 5-6, le risque d'une implémentation incorrecte d'un protocole complexe est réel et élevé.
+
+## Options évaluées
+
+### Option A — MLS (Messaging Layer Security, RFC 9420) via `openmls`
+
+**Description** : MLS est le standard IETF pour le chiffrement de groupe, publié en 2023 (RFC 9420). Il est conçu pour les groupes dynamiques avec des membres qui s'ajoutent et se retirent fréquemment. `openmls` est l'implémentation de référence en Rust, avec des bindings disponibles via WebAssembly. `mls-ts` est une implémentation TypeScript native en cours de développement.
+
+**Avantages** :
+- **Standard IETF auditée** : la spécification est rigoureusement formalisée. Un auditeur crypto externe peut valider l'implémentation par rapport à la RFC, sans avoir à auditer le design lui-même.
+- **Forward Secrecy et Post-Compromise Security natifs** : MLS est construit sur un arbre de ratchet (TreeKEM) qui garantit les deux propriétés avec une complexité logarithmique en fonction du nombre de membres.
+- **Révocation native** : un `Remove Proposal + Commit` crée un nouvel epoch avec un nouveau `group_secret`. Le membre révoqué ne peut pas dériver le secret du nouvel epoch. C'est exactement le comportement requis pour la révocation d'aidant Kinhale.
+- **Scalabilité logarithmique** : dans un groupe de N membres, la rotation de clé après révocation coûte O(log N) opérations cryptographiques, pas O(N). Pour un foyer de 10 membres, c'est ~4 opérations, pas 10.
+- **Auditabilité forte** : le `GroupInfo` MLS est signé par l'Admin, chaque membre peut vérifier son membership dans l'arbre. Impossible pour un device corrompu d'injecter silencieusement un faux membre.
+
+**Inconvénients** :
+- **Maturité des bindings mobile incertaine** : `openmls` est stable en Rust, mais les bindings React Native (via WASM ou JSI) sont expérimentaux en avril 2026. `mls-ts` est encore en développement actif. Le PoC Sprint 0 est obligatoire pour valider que les bindings compilent et fonctionnent sur iOS + Android.
+- **Complexité du protocole** : MLS introduit des concepts non triviaux (KeyPackages, Welcome messages, GroupInfo, epoch management, Commit/Proposal pipeline). L'implémentation correcte d'un client MLS — même en utilisant `openmls` — requiert une compréhension fine du protocole.
+- **Taille du bundle** : le WASM `openmls` compilé est significatif (~2-5 Mo avant optimisations). Sur mobile natif via JSI, la taille est moindre mais dépend des bindings disponibles.
+- **Gestion de l'état MLS** : chaque client doit persister l'état du groupe MLS (KeyPackage, groupe sécurisé, époque courante) de façon durables et chiffrée, indépendamment du document Automerge. C'est une couche de stockage supplémentaire à gérer.
+
+**Risques** :
+- **Risque principal** : les bindings React Native pour `openmls` ne sont pas encore stables en production mobile. Si le PoC échoue, on doit basculer sur le Double Ratchet, ce qui retarde le Sprint 0 de 1-2 semaines.
+- **Risque secondaire** : une erreur d'implémentation dans la gestion des epochs (ex : ne pas avancer correctement après un Commit) peut silencieusement briser la FS sans erreur apparente. Seul un test vector complet ou un audit externe peut détecter ce type de bug.
+
+### Option B — Signal Protocol simplifié (Double Ratchet par paires de devices)
+
+**Description** : Le Signal Protocol utilise deux mécanismes : le X3DH (Extended Triple Diffie-Hellman) pour l'échange de clés initial entre deux parties, et le Double Ratchet pour la rotation de clés au cours d'une conversation. Pour les groupes, Signal implémente un "Sender Key Protocol" : chaque membre génère une clé d'expédition, et les messages sont chiffrés avec cette clé puis distribués.
+
+Pour Kinhale, cela se traduirait par : chaque device génère une clé de groupe partagée via X3DH lors de l'invitation, et tous les deltas Automerge sont chiffrés avec cette clé partagée. À la révocation, une nouvelle clé est générée et distribuée à tous les membres restants via X3DH 1-à-1 avec chacun.
+
+**Avantages** :
+- **Protocole extrêmement bien documenté et audité** : le Signal Protocol a des dizaines d'analyses formelles publiées, et sa sécurité est considérée comme établie.
+- **Implémentation plus simple pour les groupes petits** : pour un foyer de 2-5 devices, la rotation de clé O(N) est acceptable (~5 échanges X3DH au maximum).
+- **Librairies disponibles** : `libsodium` couvre X25519 (base de X3DH) et XChaCha20-Poly1305 (chiffrement symétrique). Une implémentation Double Ratchet simplifiée peut être bâtie dessus avec ~500-800 lignes de code crypto.
+- **Pas de dépendance externe complexe** : pas de WASM lourd, pas de bindings React Native expérimentaux. Tout repose sur `react-native-libsodium` qui est déjà une dépendance requise.
+- **Forward Secrecy complète** via le ratchet : chaque message fait avancer le ratchet, les clés passées sont effacées.
+
+**Inconvénients** :
+- **Post-Compromise Security limitée** : le Double Ratchet offre une PCS partielle dans les échanges bilatéraux, mais dans la configuration "Sender Key" de groupe, un attaquant qui a compromis la clé de groupe ne sera exclu qu'à la prochaine révocation/rotation explicite.
+- **Révocation coûteuse** : à la révocation d'un aidant, il faut effectuer N-1 échanges X3DH (un par membre restant) pour distribuer la nouvelle clé. Pour 10 membres, c'est 9 échanges. Acceptables, mais avec une latence de ~2-5s vs ~200ms pour MLS.
+- **Gestion de la simultaneité complexe** : si deux aidants sont ajoutés quasi-simultanément (cas éducatrice CPE sur 8 foyers le même matin), l'ordre des échanges X3DH peut créer des états incohérents transitoires. La résolution nécessite un protocole supplémentaire.
+- **Pas de standard formel** pour la configuration "Sender Key" de groupe : l'implémentation custom augmente la surface d'audit et le risque d'erreur de conception.
+- **Auditabilité moins simple** : un auditeur externe doit auditer notre design complet, pas seulement sa conformité à une RFC.
+
+**Risques** :
+- Risque d'erreur de conception dans la gestion des états concurrents qui n'est détectée qu'à l'usage ou à l'audit.
+- Risque de "protocol creep" : commencer simple et devoir ajouter des cas particuliers qui rendent le code crypto aussi complexe que MLS mais sans les garanties formelles.
+
+## Critères de décision
+
+1. **Forward Secrecy et Post-Compromise Security** — les deux propriétés sont requises pour la promesse E2EE zero-knowledge.
+2. **Révocation propre** — la révocation d'un aidant doit exclure toute possibilité de déchiffrement des messages futurs.
+3. **Auditabilité** — un auditeur crypto externe (Sprint 5-6) doit pouvoir valider l'implémentation sans lire 10 000 lignes de code crypto custom.
+4. **Maturité des bindings mobile** — doit fonctionner sur iOS + Android + Web dès Sprint 0.
+5. **Complexité d'implémentation pour un solo dev** — minimiser le risque d'erreur silencieuse.
+6. **Performance de révocation** — la révocation d'un aidant ne doit pas bloquer l'UI > 5 secondes.
+
+## Décision
+
+**Choix retenu : Option A — MLS (RFC 9420) via `openmls`/`mls-ts`, SOUS RÉSERVE de validation du PoC Sprint 0**
+
+MLS est le bon choix *sur le principe* pour toutes les raisons évoquées : standard IETF auditée, FS+PCS natifs, révocation efficace O(log N), auditabilité par référence à la RFC. Pour une application qui gère des données de santé d'enfants avec une promesse E2EE zero-knowledge, ne pas choisir le standard IETF de référence lorsqu'il est disponible serait difficile à défendre éthiquement et techniquement.
+
+Cependant, ce choix est conditionné à un PoC obligatoire en Sprint 0 : 3 devices (iOS + Android + Web) + 1 révocation, avec validation que les bindings disponibles (`openmls` via WASM ou JSI, ou `mls-ts`) compilent, passent les tests d'intégration, et ont des performances acceptables (temps de révocation < 5s pour un groupe de 5 membres).
+
+Ce qui ferait pencher vers le fallback : si le PoC échoue sur les bindings mobiles, si `mls-ts` est en trop mauvaise posture de maturité pour être fiable, ou si l'auditeur crypto externe (consulté en preview au Sprint 0) identifie un risque spécifique sur l'implémentation disponible.
+
+**Si le PoC Sprint 0 échoue** : basculer sur le Double Ratchet avec Sender Key, documenter le compromis dans cet ADR, et planifier la migration vers MLS pour la v1.1 dès que les bindings seront stables.
+
+## Conséquences
+
+**Positives :**
+- Forward Secrecy et Post-Compromise Security garantis formellement par le standard.
+- Révocation native en un seul Commit MLS — opération atomique du point de vue de l'Admin.
+- L'auditeur crypto externe peut travailler contre la RFC 9420, pas contre une implémentation custom.
+- Un `household_id` = un groupe MLS. Un device = un membre MLS avec son KeyPackage. La correspondance avec le modèle de données Kinhale est directe.
+- Chaque epoch MLS peut être corrélé à une version du document Automerge — le chiffrement des deltas CRDT avec le secret de l'epoch courant est une invariante forte.
+
+**Négatives / compromis acceptés :**
+- Le PoC Sprint 0 est critique path — si les bindings mobiles sont instables, le Sprint 0 prend 1-2 semaines supplémentaires.
+- La gestion de l'état MLS (KeyPackage, groupe, epoch) ajoute une couche de stockage chiffré (`packages/crypto/mls-state`) distincte du document Automerge.
+- L'onboarding d'un nouveau device (Welcome MLS) nécessite que l'Admin soit en ligne ou que son device soit accessible — une subtilité UX à gérer (message "En attente de confirmation de l'Admin du foyer").
+- Les utilisateurs qui perdent leur device perdent aussi leur état MLS local — la restauration via recovery seed doit régénérer un nouveau KeyPackage et passer par l'Admin pour un Commit Add. Ce flux est plus complexe que le double Ratchet.
+
+**Plan de fallback** : Double Ratchet X3DH par paires avec Sender Key pour le groupe. Implémenté sur `react-native-libsodium` uniquement. Coût de migration de MLS → Double Ratchet si le PoC échoue : 3-4 jours-homme. Coût de migration ultérieure Double Ratchet → MLS (v1.1) : 5-7 jours-homme + rotation de toutes les clés en production (opération critique à planifier avec les utilisateurs).
+
+## Plan de PoC Sprint 0
+
+Le PoC doit valider les points suivants avant verrouillage :
+1. Build `openmls` ou `mls-ts` sur iOS (Bare Workflow Expo) sans erreur de compilation.
+2. Build sur Android (Bare Workflow Expo) sans erreur Gradle.
+3. Build sur Web (Next.js 15 avec WASM) sans erreur.
+4. Création d'un groupe MLS avec 3 membres (devices simulés), chiffrement d'un message, déchiffrement sur les 3 devices.
+5. Add Proposal + Commit pour un 4e member. Validation que le 4e membre peut déchiffrer les messages post-commit.
+6. Remove Proposal + Commit pour le 4e membre. Validation que le 4e membre ne peut plus déchiffrer les messages post-commit (test négatif critique).
+7. Persistance de l'état MLS entre les redémarrages de l'app (state sérialisé en SQLite chiffré).
+8. Temps de révocation mesuré pour un groupe de 5 membres : cible < 5s sur device mid-range Android.
+
+Le PoC est considéré comme validé si tous ces points passent. Toute régression sur le point 6 (test négatif de révocation) est un bloquant absolu.
+
+## Révision prévue
+
+Après le PoC Sprint 0 (décision finale : MLS confirmé ou fallback Double Ratchet). Puis après l'audit crypto externe Sprint 5-6 (possibles recommandations de paramètres ou d'implémentation). À réévaluer en v1.1 si les bindings MLS pour React Native arrivent à maturité stable (si on a dû prendre le fallback Double Ratchet).

--- a/docs/architecture/adr/ADR-D4-relay-hosting.md
+++ b/docs/architecture/adr/ADR-D4-relay-hosting.md
@@ -1,0 +1,213 @@
+# ADR-D4 — Hébergement du relais : Hostinger + Coolify (v1.0) → migration progressive
+
+**Date** : 2026-04-20
+**Statut** : Accepté — révisé 2026-04-20
+**Décideurs** : Martial Kaljob (Kamez Conseils)
+
+## Contexte
+
+Le relais Kamez est le backbone opérationnel de Kinhale : il gère les comptes, les mailboxes de synchronisation chiffrée, le routage des blobs E2EE entre devices, les WebSockets temps réel, et les push notifications. Bien qu'il soit zero-knowledge pour les données santé, sa disponibilité et sa conformité sont critiques : une panne de 2 heures empêche la synchronisation entre aidants, une fuite de logs peut révéler des métadonnées sensibles.
+
+Deux contraintes structurantes pèsent sur ce choix :
+
+**Data residency Canada (Loi 25 + PIPEDA)** : les métadonnées de compte (email hashé, device_id, consentements) sont des données à caractère personnel. La Loi 25 du Québec et PIPEDA imposent que les données des résidents québécois soient hébergées au Canada ou dans une juridiction offrant une protection équivalente. Même si le relais est zero-knowledge pour les données santé, les métadonnées de compte restent des données personnelles soumises à cette exigence. L'hébergeur doit être capable de signer un DPA (Data Processing Agreement) couvrant explicitement la résidence Canada.
+
+**Scrubbing santé des logs** : une exigence non-négociable est qu'aucun champ santé ne doit apparaître dans les logs ou les métriques. La configuration des logs côté hébergeur doit être maîtrisée — pas de logging automatique des payloads qui pourrait capurer accidentellement des données en clair.
+
+Pour un solo dev, la complexité opérationnelle est un facteur de risque réel : une infrastructure complexe à maintenir = des erreurs de configuration, des incidents de production non diagnostiqués rapidement, et une charge mentale qui détourne du développement produit.
+
+## Options évaluées
+
+### Option A — AWS natif, région ca-central-1, CDK TypeScript
+
+**Description** : L'infrastructure complète est déployée sur AWS en région `ca-central-1` (Montréal), gérée via AWS CDK en TypeScript (cohérence avec le reste du monorepo). Les services utilisés sont : ECS Fargate (runtime Fastify), RDS PostgreSQL 16 Multi-AZ, ElastiCache Redis 7, S3 (blobs chiffrés), CloudFront (CDN web), ALB, Route 53, WAF, Secrets Manager, KMS, CloudWatch.
+
+**Avantages** :
+- **Data residency Canada garantie** : `ca-central-1` est physiquement à Montréal. AWS signe des DPA (Business Associate Agreements / Data Processing Addendums) couvrant explicitement la résidence des données. Aucun doute sur la conformité Loi 25/PIPEDA.
+- **Contrôle total des logs** : CloudWatch Logs est entièrement configurable. Le scrubbing des logs santé passe par des filtres CloudWatch + la configuration du logger Fastify. Aucun tier ne voit les logs bruts.
+- **Isolation réseau** : VPC, Security Groups, NACL permettent une isolation réseau stricte entre les composants. Aucun accès public direct aux RDS ou Redis.
+- **KMS pour le chiffrement at rest** : toutes les données at rest (RDS, S3, ElastiCache, Secrets Manager) sont chiffrées avec des clés KMS gérées par Kamez — pas par AWS.
+- **WAF inclus** : protection OWASP Top 10, rate limiting, règles custom (ex : bloquer les requêtes contenant des payloads JSON > 1Mo sur les endpoints non-blob).
+- **CDK TypeScript** : le code d'infrastructure est dans le même langage que le reste du projet, dans le même monorepo, avec le même pipeline CI/CD. Les PRs d'infra passent par la même review que le code applicatif.
+- **Scalabilité maîtrisée** : ECS Fargate scale automatiquement sur CPU > 70%. Pour la v1.0 (100-5000 foyers), 2 tasks 0.5 vCPU / 1 Gio RAM sont largement suffisantes.
+- **Crédibilité enterprise** : pour les futurs clients B2B (cliniques, CPE), "hébergé sur AWS Canada" est plus rassurant que "hébergé sur un service SaaS tiers".
+
+**Inconvénients** :
+- **Complexité de setup initiale** : déployer une stack AWS CDK complète (VPC, RDS Multi-AZ, ECS, ALB, CloudFront...) prend 3-5 jours-homme pour la première fois.
+- **Courbe d'apprentissage CDK** : CDK a ses propres abstractions et comportements (`Aspects`, `CfnOutput`, `CrossStack references`) qui surprennent même un dev TypeScript expérimenté.
+- **Coût mensuel plus élevé** qu'une solution SaaS managée.
+- **Pas de dashboard out-of-the-box** : CloudWatch n'a pas l'ergonomie de Supabase Studio ou Retool.
+
+**Estimation de coût mensuel (v1.0, ~100-500 foyers actifs)** :
+| Service | Config | Coût estimé/mois |
+|---|---|---|
+| ECS Fargate | 2 tasks × 0.5 vCPU × 1 Gio RAM | ~$15 |
+| RDS PostgreSQL | db.t4g.small Multi-AZ, 20 Gio gp3 | ~$55 |
+| ElastiCache Redis | cache.t4g.micro, 1 node | ~$15 |
+| S3 | ~10 Gio blobs + lifecycle | ~$2 |
+| ALB | 1 ALB | ~$20 |
+| CloudFront | CDN web | ~$5 |
+| Route 53 | 1 zone | ~$0.50 |
+| CloudWatch | Logs + métriques | ~$10 |
+| KMS | 3 CMK | ~$3 |
+| WAF | Règles managées | ~$10 |
+| **TOTAL estimé** | | **~$135/mois (~180 CAD)** |
+
+Croissance à ~5000 foyers actifs : ~$300-400/mois (RDS scale-up, trafic S3/CloudFront).
+
+**Risques** :
+- Risque opérationnel si Martial n'a pas d'expérience AWS CDK — mitigé par la documentation abondante et le fait que CDK TypeScript est dans la zone de confort du profil.
+- Risque de dérive des coûts si les tailles RDS ou ECS sont mal calibrées — mitigé par les alarmes CloudWatch.
+
+### Option B — Supabase (Postgres managé + Auth + Storage + Realtime)
+
+**Description** : Supabase est une plateforme BaaS (Backend-as-a-Service) qui fournit PostgreSQL managé, authentification, stockage de fichiers, et WebSockets temps réel (via son API Realtime basée sur Elixir/Phoenix). Le code Fastify serait simplifié ou remplacé par des API Supabase directes.
+
+**Avantages** :
+- **Setup ultra-rapide** : un projet Supabase est opérationnel en < 2h. La console web, les migrations, les logs sont accessibles sans configuration.
+- **Postgres managé** : pas de gestion de RDS Multi-AZ, de snapshots, de paramètres de connexion.
+- **Auth intégré** : le module Supabase Auth gère magic links, JWT, sessions — réduisant le code à écrire dans Fastify.
+- **Storage intégré** : Supabase Storage peut remplacer S3 pour les blobs chiffrés.
+- **Coût mensuel plus bas en démarrage** : plan Pro Supabase ~$25/mois pour les premiers foyers.
+- **Realtime intégré** : les WebSockets Supabase Realtime peuvent remplacer le duo Redis pub/sub + ws.
+
+**Inconvénients** :
+- **Data residency Canada incertaine** : Supabase propose des régions AWS us-east-1, eu-west-1, ap-southeast-1... mais **pas de région ca-central-1 en avril 2026**. Les données des utilisateurs québécois seraient hébergées aux US ou en Europe, en violation potentielle de la Loi 25/PIPEDA. Ce point est rédhibitoire.
+- **DPA Supabase insuffisant pour des données de santé** : le DPA de Supabase (GDPR DPA disponible, HIPAA BAA en cours) ne couvre pas explicitement la résidence Canada. Pour des données de santé d'enfants, ce vide est inacceptable.
+- **Contrôle des logs limité** : Supabase log les requêtes SQL et les appels API pour son propre monitoring. La garantie que des métadonnées sensibles ne soient jamais loggées côté Supabase est impossible à obtenir contractuellement.
+- **Vendor lock-in** : migrer de Supabase vers AWS natif post-v1.0 est coûteux (réécriture de la couche Auth, migration des données, remplacement du Storage).
+- **Opacité de la couche Realtime** : le Realtime Supabase est basé sur les triggers Postgres et Elixir Phoenix Channels — difficile à auditer pour garantir qu'aucune donnée chiffrée n'est exposée dans les canaux.
+- **Moins adapté aux WebSockets custom** : le protocole mailbox de Kinhale (envoi de blobs chiffrés dans des mailboxes, notification push des devices destinataires) ne correspond pas aux patterns Supabase Realtime (qui diffuse des events de DB).
+
+**Estimation de coût mensuel** :
+| Plan | Config | Coût |
+|---|---|---|
+| Supabase Pro | Postgres 8 Gio, 100k MAU | ~$25/mois |
+| (mais sans région Canada — non conforme) | | |
+
+**Risques** :
+- **Risque légal critique** : absence de région Canada = non-conformité Loi 25/PIPEDA dès le premier utilisateur québécois.
+- **Risque de migration forcée** si Supabase change sa politique de prix ou décide d'ouvrir/fermer une région.
+
+### Option C — PaaS intermédiaire (Railway, Render, Fly.io)
+
+Brièvement évaluée. Railway/Render/Fly.io offrent des Postgres managés et des runtimes Node.js avec des régions qui n'incluent pas `ca-central-1` de façon fiable. Les mêmes problèmes de data residency que Supabase s'appliquent. Non retenu.
+
+## Critères de décision
+
+1. **Data residency Canada (ca-central-1)** — exigence légale bloquante Loi 25/PIPEDA.
+2. **DPA signable couvrant les données de santé de mineurs** — requis avant mise en production.
+3. **Contrôle complet des logs** — aucun payload santé ne peut apparaître dans les logs d'un tiers.
+4. **Coût opérationnel acceptable pour la v1.0** — budget infra < $500 CAD/mois jusqu'à 5000 foyers.
+5. **Complexité opérationnelle acceptable pour un solo dev** — la configuration initiale doit être faisable en < 1 semaine.
+6. **Cohérence technologique avec le monorepo** — TypeScript CDK dans le même repo, même CI/CD.
+
+## Décision
+
+**Choix retenu : Hostinger existant + Coolify (v1.0) → migration progressive selon traction**
+
+### Contexte de la décision révisée (2026-04-20)
+
+La décision initiale ciblait AWS natif (`ca-central-1`). Après analyse, la contrainte opérationnelle est réelle : Martial dispose déjà d'un serveur Hostinger actif géré via Coolify. Créer une infrastructure AWS dédiée uniquement pour Kinhale v1.0 représente un coût fixe de ~$135-180 CAD/mois + 3-5 jours de setup pour un projet en phase de validation (0-500 foyers). Ce ratio coût/bénéfice n'est pas justifié à ce stade.
+
+**Hostinger ne dispose pas de data center au Canada.** Les régions disponibles sont USA, UK, Pays-Bas, Singapour, Inde, Brésil. La conformité stricte Loi 25 (`ca-central-1`) ne peut donc pas être garantie nativement.
+
+### Mitigation légale retenue : clause de protection équivalente (USA)
+
+La Loi 25 et PIPEDA autorisent le transfert de données personnelles hors Canada à condition de :
+
+1. **Documenter le transfert** dans la politique de confidentialité avec mention explicite de la juridiction de l'hébergeur (USA) et des mesures de protection en place.
+2. **Signer un contrat de traitement** avec Hostinger couvrant : finalité du traitement, mesures de sécurité, interdiction de sous-traitement non autorisé, notification de violation de données.
+3. **Appliquer des mesures techniques compensatoires** : chiffrement E2EE zero-knowledge (les données santé ne quittent jamais les devices en clair), chiffrement at rest de la base PostgreSQL, TLS 1.3 en transit.
+4. **Informer les utilisateurs** dès l'onboarding que les métadonnées de compte sont hébergées aux USA sur infrastructure sécurisée.
+
+> **Note importante** : cette mitigation est acceptable car le relais Kinhale est zero-knowledge. Les données de santé (prises, symptômes, plans) ne transitent jamais en clair sur le serveur — seules les métadonnées opaques (email hashé, device_id, blobs chiffrés) y résident. Le risque légal résiduel est faible mais documenté.
+
+### Stack complète retenue pour v1.0
+
+Hostinger + Coolify + Cloudflare (proxy + R2) couvrent l'ensemble des besoins infrastructure :
+
+| Brique | Équivalent AWS | Solution retenue |
+|---|---|---|
+| Runtime API Fastify | ECS Fargate | Container Docker via Coolify |
+| PostgreSQL | RDS | PostgreSQL via Coolify (volume persistant) |
+| Redis | ElastiCache | Redis via Coolify |
+| SSL / Reverse proxy | ALB + ACM | Caddy automatique via Coolify (Let's Encrypt) |
+| Stockage blobs chiffrés | S3 | **Cloudflare R2** |
+| CDN web statique | CloudFront | **Cloudflare CDN** (inclus dans le proxy) |
+| WAF / DDoS | AWS WAF | **Cloudflare WAF** (plan gratuit) |
+| Variables d'environnement | Secrets Manager | Coolify Env vars (chiffrées) |
+| Déploiement CD | CodePipeline | GitHub webhook → Coolify auto-deploy |
+| Backups PostgreSQL | RDS automated | `pg_dump` cron → **Cloudflare R2** |
+
+**Pourquoi Cloudflare R2 pour les blobs chiffrés :**
+
+- **API S3-compatible** : le code Fastify utilise le SDK AWS S3 (`@aws-sdk/client-s3`) avec l'endpoint R2 — zéro changement de code lors d'une migration future vers S3.
+- **Zéro frais d'egress** : S3 facture la sortie de données (~$0.09/Go). R2 = $0 d'egress. Pour des blobs Automerge téléchargés fréquemment par les devices, c'est un avantage significatif à l'échelle.
+- **Plan gratuit très généreux** : 10 Go de stockage/mois + 1 million d'opérations Class A + 10 millions Class B — couvre largement la v1.0.
+- **Déjà utilisé par Martial** : compte, facturation et DPA déjà en place. Zéro onboarding.
+- **Chiffrement at rest natif** : R2 chiffre toutes les données au repos (AES-256). Les blobs Kinhale sont déjà chiffrés côté client — double couche de chiffrement sans effort.
+
+**Configuration R2 pour Kinhale :**
+```
+Bucket : kinhale-relay-blobs
+Région : auto (Cloudflare distribue globalement)
+Lifecycle : purge des blobs après 90 jours (via R2 lifecycle rules)
+Accès : clé API R2 avec permission write-only depuis Fastify, read depuis les devices authentifiés
+```
+
+**Cloudflare CDN pour l'app web :**
+- Le proxy Cloudflare (déjà en place pour le WAF) sert également de CDN pour les assets statiques Next.js.
+- Cache automatique des assets immutables (`/_next/static/`).
+- Remplace CloudFront sans configuration supplémentaire.
+
+**Ce que Coolify + Cloudflare ne remplacent pas :**
+- Monitoring applicatif → Sentry (déjà prévu) + UptimeRobot
+
+**Estimation de coût mensuel v1.0 :**
+
+| Poste | Coût |
+|---|---|
+| Hostinger VPS (partagé avec autres projets) | ~$0 additionnel |
+| Cloudflare proxy + WAF + CDN | Gratuit |
+| Cloudflare R2 (≤ 10 Go + opérations v1.0) | **Gratuit** |
+| Resend (≤ 3 000 emails/mois) | **Gratuit** |
+| Sentry (plan gratuit ≤ 5k erreurs/mois) | Gratuit |
+| UptimeRobot | Gratuit |
+| **TOTAL v1.0** | **~$0 CAD/mois** |
+
+### Seuils de migration déclencheurs
+
+La migration est planifiée selon la traction réelle :
+
+| Seuil | Action |
+|---|---|
+| **> 200 foyers actifs** | Évaluer migration vers VPS canadien dédié (OVH Canada, ~$20-40 CAD/mois) — data residency Canada native, même stack Coolify |
+| **> 500 foyers actifs** | Migration vers AWS `ca-central-1` (stack CDK TypeScript documentée ci-dessus) — scalabilité, Multi-AZ, WAF managed |
+| **Premiers clients B2B (cliniques)** | Migration AWS obligatoire — les cliniques exigent contractuellement la résidence Canada et un BAA/DPA signé |
+
+Le code applicatif (Fastify, Drizzle, Redis) est identique dans les trois scénarios — seul le `docker-compose` de production change. La migration est une opération d'infrastructure, pas une réécriture.
+
+## Conséquences
+
+**Positives :**
+- Démarrage immédiat sans setup d'infrastructure — Sprint 0 raccourci de 3-4 jours.
+- Coût mensuel quasi nul pendant la phase de validation (0-200 foyers).
+- Coolify est open source et aligné avec les valeurs AGPL de Kinhale — cohérence de posture.
+- Le `docker-compose` local de dev est identique au `docker-compose` de prod Coolify — zéro friction dev/prod.
+- Migration progressive non-destructive : le code ne change pas, seule l'infra évolue.
+
+**Négatives / compromis acceptés :**
+- Data residency Canada non native en v1.0 — mitigée par E2EE zero-knowledge + clause contractuelle + information utilisateur.
+- Pas de Multi-AZ — disponibilité single-node. Acceptable pour une pré-alpha / beta publique.
+- Backups PostgreSQL manuels (`pg_dump` cron → R2) — risque opérationnel si le script échoue silencieusement. Mitigation : alerte UptimeRobot sur le timestamp du dernier backup R2.
+- Partage du serveur avec d'autres projets Wonupshop — isolation via Docker networks, pas de risque de fuite inter-projets, mais ressources CPU/RAM partagées.
+
+**Plan de fallback :**
+Si le serveur Hostinger est saturé avant d'atteindre le seuil de 200 foyers (pic de trafic, autre projet Wonupshop gourmand), provisionner un VPS OVH Canada (~$20 CAD/mois) avec la même stack Coolify en < 2 heures.
+
+## Révision prévue
+
+- **À 200 foyers actifs** : décision VPS Canada dédié vs maintien Hostinger.
+- **À 500 foyers actifs ou premier client B2B** : migration AWS `ca-central-1` obligatoire.
+- **Revue trimestrielle** : vérifier que Coolify et les containers sont à jour (sécurité).

--- a/docs/architecture/adr/ADR-D5-monorepo-tooling.md
+++ b/docs/architecture/adr/ADR-D5-monorepo-tooling.md
@@ -1,0 +1,102 @@
+# ADR-D5 — Monorepo Tooling : Turborepo vs Nx
+
+**Date** : 2026-04-20
+**Statut** : Accepté
+**Décideurs** : Martial Kaljob (Kamez Conseils)
+
+## Contexte
+
+Kinhale est organisé en monorepo avec une structure claire : `apps/` (mobile React Native, web Next.js, api Fastify) et `packages/` (crypto, sync, domain, ui, i18n, eslint-config, tsconfig, test-utils). Cette organisation permet de partager le code TypeScript, les types, les primitives crypto et les composants UI entre les applications, ce qui est essentiel pour maintenir la cohérence entre plateformes.
+
+Un outil de build monorepo est indispensable pour trois raisons :
+1. **Orchestration des tâches** : `pnpm test` dans le repo racine doit lancer les tests de tous les packages dans le bon ordre (les packages dont dépendent d'autres packages doivent être buildés en premier).
+2. **Cache des builds** : un changement dans `packages/i18n` ne doit pas rebuilder `apps/mobile` si l'API publique de `i18n` n'a pas changé. Sans cache intelligent, les temps de build en CI deviennent prohibitifs.
+3. **Pipeline CI/CD** : les GitHub Actions doivent savoir quels packages ont changé dans une PR pour lancer seulement les tests pertinents, pas la suite complète.
+
+Pour un solo dev, le choix de l'outil de build monorepo a un impact direct sur la vitesse de feedback (temps entre un changement de code et le résultat des tests), la complexité de configuration (temps perdu à déboguer l'outil de build plutôt que le produit), et le cache distant en CI (qui peut réduire le temps de CI de 10-15 min à 2-3 min sur les PRs courantes).
+
+## Options évaluées
+
+### Option A — Turborepo (par Vercel)
+
+**Description** : Turborepo est un outil d'orchestration de tâches de build pour monorepos JavaScript/TypeScript. Il s'occupe du graphe de dépendances entre packages, du cache local et distant des sorties de build, et de l'exécution parallèle des tâches. Il est configuré via un fichier `turbo.json` minimal.
+
+**Avantages** :
+- **Configuration minimale** : un `turbo.json` de ~30 lignes suffit pour démarrer. La convention par défaut (chaque package a ses scripts `build`, `test`, `lint` dans son `package.json`) est respectée sans configuration supplémentaire.
+- **Cache intelligent** : Turborepo hache les inputs (fichiers source, variables d'environnement, dépendances) et skipe les tâches dont le cache est valide. Sur un monorepo de taille moyenne, les gains sont de 60-80% sur les runs CI suivants.
+- **Cache distant** : Turborepo Remote Cache (via Vercel) ou un cache S3 custom (`turbo.json` `remoteCache`) permettent de partager le cache entre développeurs et CI. Pour un solo dev avec CI GitHub Actions, le Vercel Remote Cache est gratuit sur le plan Hobby.
+- **Parallelisme natif** : Turborepo exécute les tâches en parallèle en respectant le graphe de dépendances. Sur un CI avec 4 vCPUs, les builds parallèles divisent les temps par ~3.
+- **Intégration pnpm workspaces** : Turborepo s'intègre nativement avec pnpm, qui est le package manager choisi pour Kinhale. Pas de configuration d'intégration.
+- **Légèreté** : Turborepo est un binaire Go (< 20Mo). Il n'ajoute aucune surcouche conceptuelle au projet.
+- **Communauté active** : maintenu par Vercel, bien documenté, nombreux exemples avec Next.js + React Native.
+
+**Inconvénients** :
+- **Pas de générateurs de code intégrés** : créer un nouveau package implique de copier manuellement la structure d'un package existant. Turborepo n'a pas de générateur de scaffolding intégré comparable à `nx generate`.
+- **Pas d'analyse d'impact automatisée** : Turborepo ne génère pas de rapport "ces packages sont affectés par ce changement" aussi lisible que Nx. En CI, on peut déduire les packages affectés via `turbo run --filter=...[HEAD~1]` mais c'est moins intuitif.
+- **Pas de gestion de plugins** : Turborepo n'a pas d'écosystème de plugins au sens Nx. Tout ce qui n'est pas une tâche de build doit être scripté manuellement.
+
+**Risques** :
+- Faible. Turborepo est utilisé en production par Vercel eux-mêmes et par de nombreux projets open source de référence.
+
+### Option B — Nx (par Nrwl)
+
+**Description** : Nx est une plateforme complète de développement monorepo. Il combine la gestion des tâches de build (comme Turborepo), des générateurs de code (scaffolding de nouveaux apps/libs), des plugins pour les frameworks courants (React, Next.js, React Native, Node.js), une interface graphique (Nx Console VS Code), et une gestion fine de l'impact des changements.
+
+**Avantages** :
+- **Générateurs intégrés** : `nx generate @nx/react-native:library` crée automatiquement un nouveau package avec la bonne structure, le `tsconfig.json` hérité, les scripts `package.json`, et les references nécessaires. Pour un monorepo avec 8+ packages, cela fait gagner du temps à chaque nouveau package.
+- **Analyse d'impact précise** : `nx affected:test` lance exactement les tests des packages affectés par les changements (et leurs dépendants). Plus granulaire que `turbo run --filter=...[HEAD~1]`.
+- **Nx Console** : extension VS Code qui visualise le graphe de dépendances et permet de lancer des tâches ciblées depuis l'IDE.
+- **Cache distant Nx Cloud** : plus configurable que Turbo Remote Cache, avec des statistiques détaillées de hit rate.
+- **Plugins maturés** : `@nx/react-native`, `@nx/next`, `@nx/node` configurent automatiquement les outils (Jest, ESLint, TypeScript) pour chaque type de projet.
+
+**Inconvénients** :
+- **Surcouche conceptuelle importante** : Nx introduit ses propres concepts (Workspace, Project, Target, Executor, Generator) qui s'ajoutent à la complexité du projet. Un solo dev passe du temps à comprendre et configurer Nx plutôt qu'à développer le produit.
+- **`project.json` par package** : Nx remplace les scripts `package.json` par des fichiers `project.json` Nx-spécifiques. Cela crée une couche d'abstraction supplémentaire et rend le repo moins portable (un contributeur sans expérience Nx aura du mal à s'y retrouver).
+- **Configuration initiale lourde** : bootstrapper un monorepo Nx est significativement plus complexe que Turborepo. La compatibilité avec pnpm workspaces et la configuration de chaque plugin prend 1-2 jours.
+- **Taille des dépendances** : Nx et ses plugins ajoutent ~200-400Mo de dépendances de développement. Sur un CI où `pnpm install` est dans le critical path, cela rallonge les temps.
+- **Risque de sur-ingénierie** : un monorepo avec 3 apps et 8 packages est de taille moyenne. La valeur ajoutée des générateurs Nx ne justifie pas la complexité supplémentaire à ce stade.
+
+**Risques** :
+- Risque de frustration pour les contributeurs open source non familiers avec Nx — barrière à la contribution.
+- Risque de dépendance aux plugins Nx qui peuvent prendre du retard sur les nouvelles versions de React Native ou Next.js.
+
+## Critères de décision
+
+1. **Temps de configuration initial** — minimiser le temps perdu sur l'outillage en Sprint 0.
+2. **Cache distant fonctionnel en CI** — réduire les temps de CI sur les PRs récurrentes.
+3. **Compatibilité pnpm workspaces** — le package manager est fixé à pnpm.
+4. **Complexité pour les contributeurs open source** — le repo est AGPL v3 et vise des contributions externes.
+5. **Valeur ajoutée réelle pour un monorepo de cette taille** — 3 apps + 8 packages.
+6. **Maintenance à long terme** — l'outil doit être stable et bien maintenu.
+
+## Décision
+
+**Choix retenu : Option A — Turborepo**
+
+Pour un monorepo de taille moyenne (3 apps + 8 packages) géré par un solo dev, Turborepo est le bon choix. Il résout exactement le problème — cache de build, parallélisme, dépendances entre packages — sans introduire de concepts supplémentaires, sans remplacer les `package.json` scripts, et sans créer une barrière à la contribution pour les développeurs open source.
+
+La complexité de Nx est valorisée dans de grands monorepos (10+ apps, 50+ libs, 5+ développeurs) où les générateurs et l'analyse d'impact économisent des heures par semaine. Pour Kinhale v1.0, le retour sur investissement de la complexité Nx est négatif : on passe du temps à configurer des générateurs pour créer 2-3 nouveaux packages sur tout le projet.
+
+Le Vercel Remote Cache de Turborepo est gratuit pour un usage solo et s'intègre en 5 minutes avec GitHub Actions via `TURBO_TOKEN` en secret. Le gain attendu : les PRs qui ne touchent pas `packages/crypto` ou `packages/sync` skiperont ~70% des tâches de test/build grâce au cache.
+
+Ce qui invaliderait ce choix : si l'équipe passe à 5+ développeurs en v2.0 et que la création de nouveaux packages devient une tâche récurrente (> 1 par semaine), réévaluer Nx. La migration Turborepo → Nx est documentée et faisable en 1-2 jours.
+
+## Conséquences
+
+**Positives :**
+- `turbo.json` de ~30 lignes, compréhensible par tout contributeur TypeScript sans formation préalable.
+- Cache local et distant opérationnel dès le Sprint 0, sans configuration complexe.
+- Les scripts `package.json` standard (`build`, `test`, `lint`, `typecheck`) sont préservés — chaque package reste autonome et testable sans Turborepo.
+- `turbo run test --filter=packages/domain...` pour tester un package et ses dépendants : syntaxe simple à documenter dans le CONTRIBUTING.md.
+- Compatible avec le pipeline GitHub Actions existant via `TURBO_TOKEN` secret.
+
+**Négatives / compromis acceptés :**
+- Pas de générateurs de scaffolding : créer un nouveau package = copier un package existant et adapter. Documenté dans `docs/contributing/NEW_PACKAGE.md` (une page, 5 étapes).
+- `turbo run --filter=...[HEAD~1]` pour les pipelines "affected" est moins intuitif que `nx affected` — documenté dans le `CONTRIBUTING.md`.
+- Pas d'interface graphique pour le graphe de dépendances (Nx Console VS Code). Contourné par `turbo run build --graph` qui génère un DOT graph visualisable.
+
+**Plan de fallback** : Si Turborepo Remote Cache est indisponible ou trop lent (latence Vercel CDN depuis Montréal), le fallback est un cache S3 `ca-central-1` custom via l'option `remoteCache.apiUrl` de Turborepo. Coût : négligeable (quelques MB de cache dans S3).
+
+## Révision prévue
+
+À réévaluer si : (1) l'équipe dépasse 5 contributeurs actifs, (2) la création de nouveaux packages dépasse 1/semaine, ou (3) Nx sort une version avec une configuration pnpm-native aussi simple que Turborepo. Horizon probable : v2.0 (6-12 mois post-lancement).

--- a/docs/architecture/adr/ADR-D6-web-wrap.md
+++ b/docs/architecture/adr/ADR-D6-web-wrap.md
@@ -1,0 +1,104 @@
+# ADR-D6 — Wrap Web : Next.js 15 (App Router) + React Native Web vs Vite SPA + React Native Web
+
+**Date** : 2026-04-20
+**Statut** : Accepté
+**Décideurs** : Martial Kaljob (Kamez Conseils)
+
+## Contexte
+
+Kinhale cible trois plateformes : iOS, Android, et Web. La cible web remplit deux rôles distincts qui ont des exigences techniques différentes :
+
+1. **Landing page et pages statiques** : page d'accueil présentant le produit, pages légales (`/privacy`, `/terms`), page de téléchargement (`/download`), guide self-hosting. Ces pages doivent être indexées par les moteurs de recherche (SEO) pour que les familles cherchant "application asthme enfant gratuite" puissent trouver Kinhale. Elles sont majoritairement du contenu statique avec peu d'interactivité.
+
+2. **Application web PWA** : l'application Kinhale elle-même, accessible depuis un navigateur sans installation. Utilisée par des aidants qui n'ont pas de smartphone ou qui accèdent depuis un ordinateur. Doit être installable comme PWA. Cette partie est une SPA React Native Web à part entière, avec les mêmes composants que l'app mobile.
+
+Ces deux rôles peuvent théoriquement être servis par le même framework web ou par des solutions différentes. Le choix du framework impacte le SEO, la performance perçue (Time to First Byte), la complexité du build, la compatibilité avec React Native Web, et le niveau de configuration requis.
+
+La compatibilité entre React Native Web et le framework web choisi est un point de vigilance : React Native Web génère du CSS-in-JS et des composants qui s'attendent à un environnement DOM standard, mais les rendus serveur (SSR) de ces composants nécessitent une configuration spécifique pour éviter les erreurs d'hydratation.
+
+## Options évaluées
+
+### Option A — Next.js 15 (App Router) + React Native Web
+
+**Description** : Next.js 15 avec l'App Router est utilisé comme framework web. Les pages statiques (`/`, `/privacy`, `/download`) sont rendues en SSR/SSG côté serveur pour le SEO. L'application Kinhale elle-même est rendue comme une SPA React Native Web imbriquée dans le layout Next.js, avec `'use client'` pour tous les composants React Native Web (qui ne peuvent pas être rendus côté serveur sans configuration spécifique).
+
+**Avantages** :
+- **SEO natif pour les pages publiques** : la landing page, les pages légales, et la page de téléchargement sont rendues côté serveur (SSR/SSG), indexées immédiatement par les moteurs de recherche. Pour un produit open source en quête d'adoption organique, c'est un avantage non négligeable.
+- **PWA installable** : Next.js + `next-pwa` permet de configurer le Service Worker pour l'installation PWA et le cache offline de l'app shell.
+- **Routing unifié** : un seul système de routing (Next.js App Router) gère à la fois les pages marketing et l'app. Pas de proxy, pas de domaine séparé.
+- **Cohérence TypeScript** : Next.js 15 est entièrement TypeScript, avec les Server Components et les Server Actions qui permettent des patterns stricts.
+- **Déploiement simplifié** : la même app Next.js est déployée sur CloudFront + S3 (export statique) ou sur ECS Fargate si du SSR dynamique est requis. Le pipeline CI/CD est unique.
+- **Middleware Next.js** : utile pour la gestion des redirections, les headers de sécurité (CSP, HSTS, X-Frame-Options), et la géolocalisation des utilisateurs (redirection `/fr` vs `/en`).
+
+**Inconvénients** :
+- **Friction React Native Web + App Router** : React Native Web crée des composants `View`, `Text`, `TouchableOpacity` qui ne peuvent pas être rendus côté serveur sans une configuration d'alias (`react-native` → `react-native-web`) dans le build Next.js. Cette configuration est documentée mais demande 0.5-1 jour de setup. Les erreurs d'hydratation ("Hydration mismatch") sont un risque si un composant React Native Web a un comportement différent entre SSR et CSR.
+- **Bundle size plus lourd** : Next.js ajoute son propre runtime (~75Ko gzippé) en plus de React Native Web (~50Ko gzippé). Pour l'app shell, cela reste dans les limites acceptables mais est à surveiller.
+- **App Router est encore en maturité** : l'App Router de Next.js 15 est stable mais certains patterns avancés (notamment les Server Components imbriqués avec des Client Components React Native Web) ont des cas limites documentés dans les issues GitHub. Il faut être prêt à contourner certains bugs.
+- **Complexité de la configuration Tamagui** : Tamagui doit être configuré pour fonctionner à la fois côté serveur (SSR) et côté client, avec des CSS variables et des style sheets générés différemment. La documentation Tamagui + Next.js App Router est disponible mais dense.
+
+**Risques** :
+- Risque de blocage sur la compatibilité React Native Web + App Router SSR. Mitigé par le fait que ce problème est connu et documenté (solution : `'use client'` sur tous les composants RNW + configuration des alias de module).
+- Risque d'overhead de maintenance si Next.js évolue rapidement (App Router a eu 3 versions majeures en 18 mois).
+
+### Option B — Vite SPA + React Native Web
+
+**Description** : Vite est utilisé comme bundler pour produire une Single Page Application (SPA) React Native Web. Pas de SSR. La landing page et les pages légales sont soit des routes SPA (rendues côté client), soit un site statique séparé (simple HTML/CSS) servi via CloudFront.
+
+**Avantages** :
+- **Configuration la plus simple pour React Native Web** : Vite avec le plugin `vite-plugin-react` + les alias `react-native` → `react-native-web` est la configuration la plus documentée et la plus testée pour React Native Web. Pas de friction SSR.
+- **Build ultra-rapide** : Vite HMR est quasi-instantané (< 100ms de feedback en développement). Next.js App Router a un temps de compilation plus long (~2-5s pour les changements).
+- **Moins de dépendances** : Vite seul ajoute peu de poids. Pas de runtime Next.js, pas de Node.js serveur requis (deploy purement statique sur CloudFront/S3).
+- **Pas d'erreurs d'hydratation** : une SPA pure est entièrement rendue côté client — aucun risque d'écart SSR/CSR.
+- **Compatible avec toutes les librairies React** sans se préoccuper de la distinction Server/Client Component.
+
+**Inconvénients** :
+- **SEO inexistant pour les pages publiques** : une SPA rendue côté client n'est pas indexée par les moteurs de recherche (les crawlers Google comprennent le JS mais avec un délai et une couverture incomplète). La landing page, les pages légales, et la page de téléchargement ne seraient pas indexées correctement.
+- **PWA possible mais plus complexe** : Vite PWA via `vite-plugin-pwa` fonctionne mais demande plus de configuration manuelle pour les Service Workers qu'avec `next-pwa`.
+- **Deux systèmes de déploiement** : si on veut une landing page avec SEO, il faut un site statique séparé (un simple HTML/CSS ou un autre framework léger). On se retrouve à gérer deux projets web au lieu d'un.
+- **Routing SPA moins puissant** : sans SSR, les deep links (`kinhale.health/foyer/abc123`) ne fonctionnent que si le serveur est configuré pour rediriger toutes les routes vers `index.html`. Gérable avec CloudFront, mais à configurer.
+- **Pas de middleware** : sans couche serveur, les redirections de langue, les headers de sécurité custom, et la détection de géolocalisation doivent être gérés via CloudFront Functions ou Lambda@Edge — une complexité supplémentaire côté infra.
+
+**Risques** :
+- Risque de perte d'adoption organique si le SEO de la landing page est insuffisant. Pour un produit open source gratuit qui cherche à être découvert par des familles, le SEO est un canal d'acquisition non-négligeable.
+
+## Critères de décision
+
+1. **SEO des pages publiques** — la landing page et les pages légales doivent être indexées correctement.
+2. **Compatibilité React Native Web** — l'app Kinhale utilise des composants RNW partagés avec le mobile.
+3. **PWA installable** — l'application web doit être installable comme PWA.
+4. **Complexité de build acceptable** — le setup initial doit être réalisable en < 2 jours.
+5. **Déploiement unifié** — un seul projet web à déployer et maintenir.
+6. **Performance perçue** — TTFB des pages publiques < 200ms.
+
+## Décision
+
+**Choix retenu : Option A — Next.js 15 (App Router) + React Native Web**
+
+Le SEO de la landing page est un critère déterminant. Kinhale est un produit open source gratuit dont l'acquisition repose principalement sur la découverte organique (recherches Google, partage entre parents, recommandations de pneumo-pédiatres). Sans SEO, une famille cherchant "application suivi asthme enfant gratuite open source" ne trouvera pas Kinhale. Avec Next.js SSR/SSG sur les pages publiques, les pages sont indexées dès J1.
+
+La friction React Native Web + App Router est réelle mais connue et documentée. La stratégie est claire : tous les composants qui utilisent des primitives React Native Web portent `'use client'` et sont rendus uniquement côté client. Les pages marketing (`/`, `/privacy`) sont des Server Components purs avec du HTML/CSS standard, sans React Native Web. L'app elle-même (`/app/**`) est un Client Component React Native Web intégral.
+
+Cette séparation claire entre pages marketing (SSR pur) et app (CSR React Native Web) évite les problèmes d'hydratation tout en préservant les bénéfices SEO des pages publiques.
+
+Ce qui invaliderait ce choix : si le PoC Sprint 0 révèle des incompatibilités bloquantes entre Tamagui + React Native Web + App Router que les contournements documentés ne résolvent pas. Dans ce cas, le fallback est Vite SPA + un site statique HTML minimal pour la landing page.
+
+## Conséquences
+
+**Positives :**
+- SEO immédiat sur la landing page, `/privacy`, `/terms`, `/download` — pages générées en SSG au build time.
+- PWA installable via `next-pwa` avec Service Worker configuré pour le cache offline de l'app shell.
+- Un seul projet web, un seul déploiement, un seul pipeline CI/CD.
+- Middleware Next.js pour les headers de sécurité (CSP, HSTS) et les redirections de langue.
+- Les pages légales et de conformité sont des Server Components avec du Markdown rendu côté serveur — accessibles aux crawlers d'accessibilité et de conformité.
+
+**Négatives / compromis acceptés :**
+- Configuration d'alias module (`react-native` → `react-native-web`) dans `next.config.ts` — 0.5 jour de setup.
+- Tous les composants React Native Web portent `'use client'` — pattern verbeux mais explicite et compréhensible.
+- La configuration Tamagui SSR (CSS variables, style sheets serveur) ajoute de la complexité au `next.config.ts`.
+- Build time légèrement plus long qu'une Vite SPA pure (Next.js compile les Server Components séparément).
+
+**Plan de fallback** : Si la compatibilité React Native Web + App Router crée des blocages au Sprint 0, le fallback est : pages marketing en HTML statique pur (simple et rapide, ~1 jour), app Kinhale en Vite SPA React Native Web. Un proxy CloudFront route `/` et les pages statiques vers le bucket S3 marketing, et `/app` vers le bucket S3 Vite SPA. Coût de cette séparation : ~1 jour supplémentaire de configuration CloudFront.
+
+## Révision prévue
+
+Après le Sprint 0 (validation de la compatibilité React Native Web + App Router). À réévaluer si React Native Web atteint une compatibilité native avec les Server Components (hypothèse : horizon 2027+).

--- a/docs/architecture/adr/ADR-D7-design-system.md
+++ b/docs/architecture/adr/ADR-D7-design-system.md
@@ -1,0 +1,105 @@
+# ADR-D7 — Design System : Tamagui vs StyleSheet natif + tokens custom (@kinhale/ui)
+
+**Date** : 2026-04-20
+**Statut** : Accepté (avec point de contrôle Sprint 0)
+**Décideurs** : Martial Kaljob (Kamez Conseils)
+
+## Contexte
+
+Kinhale est une application cross-platform (iOS + Android + Web PWA) qui partage ses composants UI entre les trois plateformes via React Native Web. Le design system est la couche qui traduit les décisions de design (couleurs, typographie, espacement, composants) en code réutilisable sur toutes les plateformes.
+
+Deux exigences structurantes pèsent sur ce choix :
+
+**WCAG 2.1 AA dès la v1.0** : les contrastes de texte doivent être ≥ 4:5:1, les composants interactifs ≥ 3:1. Les touch targets doivent être ≥ 44×44pt. La navigation clavier doit être complète sur web. Ces exigences d'accessibilité doivent être vérifiées automatiquement en CI (axe-core sur Playwright, Lighthouse a11y ≥ 95). Un design system qui facilite la vérification automatique des contrastes et des rôles ARIA est un avantage concret.
+
+**Cross-platform via React Native Web** : un `<Button>` Kinhale doit s'afficher correctement sur iOS (native), Android (native), et web (React Native Web → HTML/CSS). Les primitives de style doivent fonctionner sur les trois plateformes sans code conditionnel.
+
+Pour un solo dev, le design system est aussi un investissement en temps : une configuration complexe qui ralentit les builds ou génère des erreurs cryptiques est un multiplicateur de friction quotidien sur 13+ semaines de développement.
+
+## Options évaluées
+
+### Option A — Tamagui
+
+**Description** : Tamagui est un design system et un compilateur de styles pour React Native et React Native Web. Son point différenciant est un compilateur qui évalue statiquement les props de style (couleurs, tailles, espacements) et génère du CSS natif ou des StyleSheets optimisés au moment du build, plutôt qu'au runtime. Cela élimine le coût de calcul de style au render.
+
+**Avantages** :
+- **Performance compile-time** : le compilateur Tamagui transforme les composants `<Stack>`, `<Text>`, `<Button>` en styles statiques. Sur mobile, plus de StyleSheet.create au runtime. Sur web, le CSS généré est un fichier statique. Les benchmarks publiés montrent 2-3× d'amélioration sur les renders lourds de listes.
+- **Tokens partagés** : les tokens de couleur, de typographie, et d'espacement sont définis une seule fois dans `packages/ui/src/tokens.ts` et utilisés de façon identique sur iOS, Android, et Web. Pas de mapping manuel entre plateformes.
+- **Support WCAG natif** : Tamagui expose des helpers de contraste (`$color.contrast`, variants sémantiques `intent: 'primary' | 'destructive' | 'neutral'`) qui facilitent la validation des ratios de contraste.
+- **Dark mode natif** : `useTheme()` de Tamagui gère automatiquement les tokens de couleur en dark mode via des CSS variables sur web et des variables Tamagui sur mobile. Pas de code conditionnel.
+- **React Native Web compatible** : Tamagui est conçu pour fonctionner identiquement sur React Native et React Native Web. Les composants Tamagui compilent en `View`/`Text` React Native sur mobile et en `div`/`span` sur web via React Native Web.
+- **Communauté active** : Tamagui est maintenu par une équipe dédiée (Nate Wienert), utilisé par des apps React Native à grande audience, et documenté activement.
+
+**Inconvénients** :
+- **Courbe d'apprentissage** : le modèle mental Tamagui (tokens, variants, themes, compiler) est différent du StyleSheet React Native standard. Un dev React Native habitué aux StyleSheets aura besoin de 1-2 jours d'adaptation.
+- **Impact sur le temps de build** : le compilateur Tamagui est un plugin Babel/Metro qui analyse chaque composant. Sur un projet de taille moyenne (100+ composants), cela peut ajouter 30-60s au build initial. Les builds incrémentiels sont mis en cache.
+- **Risque de friction avec Next.js App Router** : la configuration Tamagui pour SSR (CSS variables, style sheets serveur via `@tamagui/next-plugin`) ajoute de la complexité. Des erreurs d'hydratation sont possibles si la configuration est incomplète.
+- **Version locking** : Tamagui évolue rapidement. Les mises à jour majeures peuvent nécessiter des ajustements dans `packages/ui`. Risque de breaking changes à surveiller.
+
+**Risques** :
+- **Risque principal** : le benchmark de build Sprint 0 révèle un temps de build iOS/Android > 5 min avec Tamagui, ce qui impacte la productivité quotidienne. Si ce seuil est dépassé, le fallback s'impose.
+- **Risque secondaire** : une mise à jour Tamagui majeure en cours de développement crée une régression sur un composant critique.
+
+### Option B — StyleSheet React Native + tokens custom (@kinhale/ui)
+
+**Description** : Le design system est implémenté "from scratch" avec les primitives natives React Native (`StyleSheet.create`, `View`, `Text`, `TouchableOpacity`) + un package `@kinhale/ui` qui exporte des tokens (couleurs, typographie, espacement) et des composants de base. Pas de compilateur externe.
+
+**Avantages** :
+- **Aucune dépendance externe critique** : le design system ne dépend que de React Native lui-même. Pas de risque de breaking change d'un tiers.
+- **Compréhensible par tout dev React Native** : `StyleSheet.create` est la primitive universelle. Tout contributeur open source peut contribuer sans apprendre Tamagui.
+- **Build time inchangé** : pas de compilateur Babel/Metro supplémentaire. Les temps de build iOS/Android ne sont pas affectés.
+- **Contrôle total** : chaque décision de style est explicite et lisible dans le code. Pas de magie de compilation.
+- **Configuration SSR triviale** : sur Next.js, React Native Web + StyleSheet fonctionne nativement sans plugin supplémentaire.
+
+**Inconvénients** :
+- **Tokens manuels sur chaque plateforme** : les tokens de couleur, typographie, et espacement doivent être adaptés manuellement pour chaque plateforme si leurs représentations diffèrent. Par exemple, les `rem` n'existent pas en React Native — tout est en `px` ou en pourcentage.
+- **Dark mode coûteux à implémenter** : sans système de tokens dynamiques, le dark mode nécessite un `useColorScheme()` partout où une couleur est définie, ou une solution custom de theming. Cela représente 2-4 jours-homme supplémentaires.
+- **Pas d'optimisation compile-time** : chaque render recalcule les styles (mitigé par `StyleSheet.create` qui fait du caching, mais moins efficace que le compile-time de Tamagui).
+- **Couche d'accessibilité manuelle** : les helpers de contraste, les rôles ARIA, et les états d'accessibilité doivent être implémentés manuellement sur chaque composant, sans l'aide d'un système de design.
+- **Temps de développement initial plus long** : construire un composant `Button` cross-platform avec variants (primary/secondary/destructive), dark mode, états disabled/pressed, et accessibilité WCAG prend 2-3× plus de temps qu'avec Tamagui.
+
+**Risques** :
+- Risque de dette technique si les tokens ne sont pas bien centralisés dès le départ — des couleurs hardcodées apparaissent dans les composants, rendant les changements de theme coûteux.
+- Risque de sous-investissement en accessibilité : sans helpers WCAG, il est facile d'oublier un ratio de contraste ou un `accessibilityLabel` sur un composant secondaire.
+
+## Critères de décision
+
+1. **WCAG 2.1 AA dès la v1.0** — helpers de contraste et composants accessibles par défaut.
+2. **Cross-platform iOS/Android/Web** — tokens partagés, pas de code conditionnel.
+3. **Dark mode natif** — requis dès la v1.0 (exigence produit).
+4. **Temps de build iOS/Android < 5 min** — seuil de productivité pour un solo dev.
+5. **Courbe d'apprentissage raisonnable** — < 2 jours pour un dev React Native senior.
+6. **Maintenance acceptable** — pas de breaking change Tamagui bloquant sur la durée du projet.
+
+## Décision
+
+**Choix retenu : Option A — Tamagui, avec benchmark obligatoire en Sprint 0**
+
+Tamagui résout trois problèmes simultanément que le StyleSheet custom résout moins bien : le cross-platform tokens, le dark mode natif, et les helpers d'accessibilité WCAG. Pour un solo dev qui doit livrer une app WCAG 2.1 AA sur trois plateformes avec dark mode en 13 semaines, Tamagui est un multiplicateur de productivité réel, pas un gadget.
+
+Le risque principal — l'impact sur le temps de build — est mesuré en Sprint 0 avec un projet de test représentatif (5-10 composants Tamagui compilés, build iOS simulateur). Si le seuil de 5 minutes est dépassé, le fallback StyleSheet est activé. La décision est conditionnée par ce benchmark.
+
+Ce qui a fait pencher la balance : le dark mode seul représente 2-4 jours-homme en StyleSheet custom. Les composants WCAG (avec contrastes vérifiables, rôles ARIA, états d'accessibilité) représentent 30-50% du temps de développement UI en StyleSheet custom. Tamagui amortit ces coûts sur l'ensemble des composants.
+
+Ce choix serait invalidé si : le benchmark Sprint 0 révèle > 5 min de build, ou si une incompatibilité bloquante avec Next.js App Router SSR n'est pas résoluble avec le `@tamagui/next-plugin`.
+
+## Conséquences
+
+**Positives :**
+- Tokens de couleur, typographie, et espacement définis une seule fois dans `packages/ui/src/tamagui.config.ts` et utilisés identiquement sur iOS, Android, et Web.
+- Dark mode sans code conditionnel : `<Text color="$text">` s'adapte automatiquement selon le thème actif.
+- Composants accessibles par défaut : `<Button>` Tamagui expose `role`, `aria-label`, `aria-disabled` nativement sur web.
+- Benchmark de contraste : les tokens de couleur sont validés contre le ratio WCAG 4.5:1 dès leur définition, pas après coup.
+- Styles compile-time sur web : le CSS généré par Tamagui est un fichier statique servi par CloudFront — pas de FOUC (Flash of Unstyled Content).
+
+**Négatives / compromis acceptés :**
+- 1-2 jours d'adaptation pour comprendre le modèle Tamagui (variants, themes, compiler).
+- Configuration `@tamagui/next-plugin` dans `next.config.ts` — documentation disponible mais dense.
+- Mises à jour Tamagui majeures à gérer activement (veille sur le changelog).
+- Le compilateur Tamagui analyse tous les composants du projet — les builds from scratch sont plus lents (mitigé par le cache Turborepo).
+
+**Plan de fallback** : Si le benchmark Sprint 0 dépasse 5 min de build iOS, ou si la compatibilité Next.js App Router SSR est bloquante : basculer sur StyleSheet React Native + `@kinhale/ui` custom. Coût de migration estimé : 3-5 jours-homme (les composants sont refactorisés avec des StyleSheets standards). La couche de tokens reste identique (`packages/ui/src/tokens.ts`), seul le mécanisme de consommation change. Le dark mode est alors implémenté via un `ThemeContext` custom (~1 jour).
+
+## Révision prévue
+
+Après le benchmark Sprint 0 (décision définitive : Tamagui confirmé ou fallback). À revisiter si Tamagui sort une v2.0 avec une API significativement différente qui impose une migration coûteuse. Horizon : fin Sprint 2 (validation sur les composants de base produits).

--- a/docs/architecture/adr/ADR-D8-email-transactionnel.md
+++ b/docs/architecture/adr/ADR-D8-email-transactionnel.md
@@ -1,0 +1,154 @@
+# ADR-D8 — Email Transactionnel : Resend (retenu) vs Postmark vs AWS SES
+
+**Date** : 2026-04-20
+**Statut** : Accepté — révisé 2026-04-20
+**Décideurs** : Martial Kaljob (Kamez Conseils)
+
+## Contexte
+
+Kinhale utilise l'email transactionnel pour deux cas d'usage distincts, et seulement deux :
+
+1. **Magic link d'authentification** : l'utilisateur saisit son email, reçoit un lien à usage unique (valable 15 minutes) qui l'authentifie sans mot de passe. C'est le seul mécanisme d'authentification obligatoire de la v1.0. La délivrabilité de cet email est critique : si le magic link n'arrive pas en boîte de réception dans les 30 secondes, l'utilisateur abandonne.
+
+2. **Alerte dose manquée en fallback email** : si une dose planifiée n'est pas confirmée et que le push notification a échoué (device hors-ligne, notifications désactivées), un email de fallback est envoyé au Parent référent. Cet email porte un contenu générique ("Une prise de médicament n'a pas été confirmée dans votre application Kinhale") — jamais de contenu santé en clair (pas de nom de pompe, pas de symptôme, pas de prénom de l'enfant).
+
+Ces deux usages partagent des exigences communes :
+- **Délivrabilité élevée** : le magic link doit arriver dans < 30s, en boîte principale (pas en spam).
+- **Aucune donnée santé dans les payloads** : le prestataire email ne doit jamais voir de données de santé. Les templates sont purement génériques.
+- **Data residency Canada** : idéalement, le prestataire traite les emails depuis des serveurs situés au Canada, ou au moins signe un DPA couvrant la Loi 25/PIPEDA.
+- **DPA signable** : un accord de traitement des données est nécessaire avant la mise en production.
+- **Volume faible** : la v1.0 cible 100-5000 foyers actifs. Le volume d'emails est estimé à 500-10 000 emails/mois, très loin des seuils de tarification des solutions enterprise.
+
+Un détail important : contrairement à ce que l'on pourrait croire, l'email transactionnel d'authentification est soumis à la réglementation anti-spam (CASL au Canada, CAN-SPAM aux US, RGPD en Europe) même pour les emails déclenchés par l'utilisateur lui-même. Le prestataire doit avoir une bonne réputation d'expéditeur pour garantir la délivrabilité.
+
+## Options évaluées
+
+### Option A — Postmark
+
+**Description** : Postmark est un prestataire d'email transactionnel spécialisé (fondé en 2009, acquis par ActiveCampaign en 2022) dont le positionnement est explicitement orienté vers la délivrabilité des emails transactionnels critiques (magic links, notifications de sécurité, confirmations de commande). Postmark utilise des serveurs SMTP en Europe (Amsterdam, Dublin) et aux US (Ashburn).
+
+**Avantages** :
+- **Délivrabilité de référence** : Postmark est reconnu dans l'industrie comme l'un des prestataires avec les meilleurs taux de délivrabilité pour les emails transactionnels. Leur infrastructure de serveurs d'envoi est dédiée aux transactions (ils n'envoient pas d'emails marketing, ce qui préserve la réputation de leurs IPs).
+- **API simple** : l'API REST Postmark est la plus simple à intégrer — un POST avec le template ID, les variables, et l'email destinataire. Le SDK TypeScript officiel (`@postmark/postmark`) est maintenu et typé.
+- **Templates serveur** : Postmark gère les templates d'email côté serveur (MJML ou HTML). Le magic link template est stocké dans la console Postmark et référencé par ID dans le code — les modifications de template ne nécessitent pas de redéploiement.
+- **Dashboard de monitoring** : le dashboard Postmark expose en temps réel les bounces, les opens (optionnel), les délais de livraison. Utile pour diagnostiquer les problèmes de délivrabilité sans fouiller les logs CloudWatch.
+- **DPA disponible** : Postmark propose un DPA RGPD standard signable. Depuis l'acquisition par ActiveCampaign, un DPA couvrant les exigences de la Loi 25 québécoise est disponible sur demande. Postmark ne voit jamais le contenu santé (les emails ne contiennent pas de données de santé).
+- **Coût prévisible** : tarification à l'email ($1.25/1000 emails + $1.25/mois pour 100 messages/mois minimum). Pour 5000 emails/mois : ~$7/mois.
+- **CASL-compliant** : Postmark intègre les unsubscribe links et la gestion des bounces requise par CASL pour les emails transactionnels au Canada.
+
+**Inconvénients** :
+- **Pas de région Canada** : Postmark traite et route les emails depuis des serveurs en US/Europe. L'email du magic link transite par des serveurs américains ou européens avant d'arriver dans la boîte du destinataire canadien.
+- **Dépendance à un tiers** : si Postmark subit une panne, les magic links ne sont plus délivrés. Mitigé par le fait que Postmark a un SLA de 99.99% de disponibilité et par une file de retry côté Fastify.
+- **Acquisition ActiveCampaign** : le rachat de Postmark par ActiveCampaign en 2022 a créé des interrogations sur l'évolution du service. En pratique, Postmark opère toujours de façon indépendante en 2026, mais le risque de changement de politique existe.
+
+**Estimation de coût mensuel** :
+- 500 emails/mois (démarrage) : ~$1.50
+- 10 000 emails/mois (5000 foyers actifs) : ~$12.50
+- Très largement dans le budget.
+
+**Risques** :
+- Risque de blocage temporaire des emails Kinhale si un autre client Postmark abuse de leur infrastructure partagée — Postmark isole les expéditeurs sur des IPs dédiées à partir de certains volumes, non pertinent pour la v1.0.
+
+### Option B — AWS SES (Simple Email Service), région ca-central-1
+
+**Description** : AWS SES est le service d'email d'Amazon, disponible depuis 2011. Il est directement intégré à l'infrastructure AWS ca-central-1 déjà choisie pour le relais (ADR-D4). SES ca-central-1 est disponible depuis 2021. Les emails sont envoyés depuis des serveurs AWS physiquement situés à Montréal.
+
+**Avantages** :
+- **Data residency Canada garantie** : les emails de magic link sont traités et envoyés depuis les serveurs AWS ca-central-1 à Montréal. Aucune donnée ne quitte le Canada pour le traitement email.
+- **DPA AWS unifié** : le même DPA AWS signé pour le relais (ADR-D4) couvre également SES. Pas de DPA supplémentaire à négocier.
+- **Intégration native AWS** : SES est dans le même compte AWS que le reste de l'infrastructure. Les logs d'envoi vont directement dans CloudWatch. Le billing est unifié. La configuration IAM (rôle Fargate → SES) est simple.
+- **Coût extrêmement bas** : $0.10/1000 emails (10× moins cher que Postmark). Pour 10 000 emails/mois : $1.
+- **Sandbox → Production** : le processus de sortie de sandbox SES (pour envoyer à des adresses non-vérifiées) est maintenant rapide (~24h de review) en 2026.
+
+**Inconvénients** :
+- **Délivrabilité inférieure à Postmark** : les IPs SES sont partagées entre tous les clients AWS (dont beaucoup envoient du spam ou des emails marketing). La réputation des IPs SES ca-central-1 est historiquement inférieure à celle de Postmark. Pour un magic link critique, un taux de deliverabilité de 95% vs 99.5% fait une différence mesurable en UX.
+- **Pas de templates gérés en self-service** : SES Templates sont gérés via l'API AWS CLI ou la console — moins ergonomique que la console Postmark pour un solo dev qui veut modifier rapidement un template email.
+- **Pas de dashboard de monitoring intuitif** : le monitoring SES se fait via CloudWatch Metrics (bounces, complaints, delivery rate) — fonctionnel mais moins lisible qu'un dashboard Postmark dédié.
+- **Configuration plus complexe** : sender identity, DKIM, DMARC, SPF doivent être configurés manuellement. Postmark configure automatiquement ces éléments lors de l'ajout d'un domaine d'expéditeur.
+- **Configuration IP dédiée possible mais coûteuse** : pour améliorer la délivrabilité, SES propose des IPs dédiées à $24.95/mois/IP — ce qui annule l'avantage de coût et dépasse Postmark.
+
+**Estimation de coût mensuel** :
+- 10 000 emails/mois : $1
+- Avec IP dédiée : $25.95/mois
+
+**Risques** :
+- **Risque principal** : la délivrabilité des magic links est insuffisante (emails en spam), créant une frustration utilisateur et un taux d'abandon à l'onboarding. Ce risque est difficile à quantifier avant la mise en production mais documenté par de nombreux témoignages dans l'industrie.
+- Risque de sur-configuration : DKIM + DMARC + SPF + warming up des IPs SES représente 1-2 jours de configuration et de test que Postmark élimine.
+
+### Option C — Resend ⭐ Retenu
+
+**Description** : Resend est un service d'email transactionnel fondé en 2023, conçu explicitement pour les développeurs TypeScript/React. Il est bâti sur une infrastructure AWS multi-région et se distingue par son intégration native avec **React Email** — les templates d'email sont des composants React écrits directement dans le monorepo, versionnés avec le code, reviewés en PR.
+
+**Avantages** :
+
+- **React Email intégré** : les templates d'email sont des composants `.tsx` dans `packages/i18n/emails/` — même langage, même pipeline CI, même review que le reste du code. Modifier le template du magic link = une PR, pas un aller-retour dans une console externe.
+- **TypeScript SDK de référence** : le package `resend` est le SDK le plus ergonomique du marché en 2026. `resend.emails.send({ from, to, react: <MagicLinkEmail token={...} /> })` — c'est littéralement tout.
+- **Plan gratuit généreux** : 3 000 emails/mois gratuits, 100/jour. La v1.0 (0-500 foyers) ne paiera probablement rien pendant les 6 premiers mois.
+- **Délivrabilité solide** : Resend gère sa propre réputation d'IPs sur infrastructure AWS, comparable à Postmark pour les volumes transactionnels faibles à moyens.
+- **Déjà en production chez Martial** : intégration et DPA déjà en place sur d'autres projets Wonupshop — zéro setup, zéro nouvelle négociation contractuelle, courbe d'apprentissage nulle.
+- **DKIM/SPF/DMARC automatiques** : comme Postmark, Resend configure automatiquement les enregistrements DNS à l'ajout du domaine `kinhale.health`.
+- **Dashboard moderne** : monitoring des envois, bounces, taux d'ouverture, logs par email — interface développeur très lisible.
+- **Pricing prévisible** : après le tier gratuit, $20/mois pour 50 000 emails (vs ~$65/mois Postmark à ce volume).
+
+**Inconvénients** :
+
+- **Service plus récent** (2023) : moins d'historique de fiabilité que Postmark (2009) ou SES. Mitigé par la croissance rapide et la confiance de l'écosystème.
+- **Pas de région Canada** : même situation que Postmark — serveurs US/EU. Même mitigation applicable (emails génériques, aucune donnée santé).
+- **DPA** : disponible et RGPD-compliant. Couverture Loi 25 à vérifier formellement, mais même posture que Postmark — emails ne contiennent pas de données de santé.
+
+**Estimation de coût mensuel** :
+
+| Volume | Coût |
+|---|---|
+| 0-3 000 emails/mois | **Gratuit** |
+| 3 000-50 000 emails/mois | $20/mois |
+| > 50 000 emails/mois | Sur devis |
+
+**Avantage décisif sur Postmark pour ce projet** : React Email dans le monorepo TypeScript. Les templates sont des composants React versionnés, testables (snapshots), traduisibles via `i18next` — cohérence totale avec l'architecture du projet.
+
+## Critères de décision
+
+1. **Délivrabilité du magic link** — arriver en boîte principale en < 30s, critère UX critique.
+2. **Data residency Canada** — idéal, mais non-bloquant si le contenu email ne contient pas de données de santé.
+3. **DPA signable couvrant Loi 25/PIPEDA** — obligatoire avant mise en production.
+4. **Facilité de configuration et maintenance** — un solo dev ne doit pas passer > 1 jour sur la configuration email.
+5. **Coût mensuel** — marginal pour le budget de ce projet.
+6. **Aucune donnée santé dans les payloads** — quelle que soit l'option choisie.
+
+## Décision
+
+**Choix retenu : Option C — Resend**
+
+Resend réunit tous les critères et élimine le principal friction point des autres options :
+
+**Pourquoi pas Postmark** : Postmark a une délivrabilité excellente mais impose des templates gérés dans sa console externe — une friction supplémentaire pour un solo dev qui veut itérer vite sur les emails. Surtout, Martial utilise déjà Resend en production sur Wonupshop. Migrer vers Postmark = nouvel onboarding, nouveau DPA, nouveau monitoring à apprendre. Zéro gain justifiant ce switch.
+
+**Pourquoi pas SES** : la délivrabilité des IPs partagées SES reste inférieure pour les magic links. Le gain de data residency Canada est annulé par le fait que les emails Kinhale ne contiennent aucune donnée de santé. La complexité de setup (DKIM, SPF, DMARC, sandbox approval) coûte 1-2 jours qu'on économise avec Resend.
+
+**L'argument décisif** : React Email. Les templates d'email sont des composants React dans `packages/emails/` — versionnés, testés, traduits via `i18next`, reviewés en PR comme n'importe quel autre composant. C'est la cohérence architecturale parfaite avec un monorepo TypeScript/React.
+
+**Posture conformité** : identique à Postmark. Les emails Kinhale sont génériques (magic link = token opaque, alerte = message sans donnée santé). Le prestataire ne voit que l'adresse email du destinataire. DPA Resend RGPD-compliant. Même mitigation Loi 25 que pour l'hébergement Hostinger.
+
+Ce qui invaliderait ce choix : si un client B2B (clinique) exige contractuellement que les emails transitent depuis des serveurs canadiens. Dans ce cas, migration SES ca-central-1.
+
+## Conséquences
+
+**Positives :**
+- **Zéro setup** — déjà intégré et opérationnel sur Wonupshop. Réutilisation du compte, des DNS, du DPA.
+- **Plan gratuit couvre la v1.0** — 3 000 emails/mois gratuits, probablement suffisant jusqu'à ~300 foyers actifs.
+- **React Email dans le monorepo** — templates `.tsx` dans `packages/emails/`, traduits FR/EN, testés par snapshots Jest, reviewés en PR.
+- **SDK TypeScript minimal** — `resend.emails.send({ react: <MagicLinkEmail /> })` en 3 lignes.
+- **Dashboard développeur** — monitoring des bounces et délais de livraison sans CloudWatch.
+
+**Négatives / compromis acceptés :**
+- Service plus récent que Postmark — historique de fiabilité plus court. Acceptable au vu de la traction et de l'usage existant.
+- Emails transitent par serveurs US/EU — même posture que Postmark, acceptable car contenu générique.
+- Dépendance à un tiers pour l'authentification magic link — mitigée par une file de retry Fastify (3 tentatives, backoff exponentiel) et passkeys WebAuthn comme alternative future.
+
+**Plan de fallback** : variable d'environnement `EMAIL_PROVIDER=resend|ses` côté Fastify. Si Resend subit une panne, bascule vers SES ca-central-1 sans redéploiement. Configuration SES pré-documentée dans `docs/ops/EMAIL_FALLBACK.md`.
+
+## Révision prévue
+
+- **À 3 000 emails/mois** : passage au plan payant Resend ($20/mois) — décision triviale.
+- **Premier client B2B clinique** : évaluer si le contrat exige data residency Canada pour les emails → migration SES ca-central-1.
+- **À 50 000 emails/mois** (horizon v2.0) : comparer coût Resend ($20/mois) vs SES + IP dédiée (~$26/mois). Delta marginal, migration justifiée uniquement si exigence contractuelle B2B.

--- a/docs/superpowers/plans/2026-04-20-sprint0-plan1-foundation.md
+++ b/docs/superpowers/plans/2026-04-20-sprint0-plan1-foundation.md
@@ -1,0 +1,1030 @@
+# Sprint 0 — Plan 1 : Foundation (crypto + docker + test-utils)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Étendre `packages/crypto` avec les primitives libsodium (Ed25519, X25519, XChaCha20-Poly1305, Argon2id), créer `infra/docker/docker-compose.yml` pour le dev local, et créer `packages/test-utils` avec les helpers partagés.
+
+**Architecture:** `packages/crypto` wrap libsodium-wrappers (API Web Crypto-compatible, zéro import direct de libsodium dans les autres packages). `infra/docker` fournit Postgres 16, Redis 7, Mailpit et MinIO (compatible R2). `packages/test-utils` expose des factories de données de test et des helpers crypto pour les tests des autres packages.
+
+**Tech Stack:** libsodium-wrappers 0.7+, libsodium-wrappers-sumo (pour Argon2id), Docker Compose v2, Vitest, pnpm workspaces, TypeScript 5.7 strict.
+
+---
+
+## Fichiers créés ou modifiés
+
+```
+packages/crypto/
+  package.json                          ← ajouter libsodium-wrappers + types
+  src/index.ts                          ← exporter toutes les primitives
+  src/sign/                             ← Ed25519 sign/verify/keygen
+    ed25519.ts
+    ed25519.test.ts
+  src/box/                              ← X25519 + XChaCha20-Poly1305
+    xchacha20.ts
+    xchacha20.test.ts
+  src/kdf/                              ← Argon2id key derivation
+    argon2id.ts
+    argon2id.test.ts
+  src/random/                           ← randombytes sécurisé
+    random.ts
+    random.test.ts
+  src/sodium.ts                         ← init singleton libsodium
+
+packages/test-utils/
+  package.json
+  tsconfig.json
+  vitest.config.ts
+  eslint.config.js
+  src/index.ts
+  src/factories/
+    household.ts                        ← createTestHousehold()
+    caregiver.ts                        ← createTestCaregiver()
+    dose.ts                             ← createTestDose()
+    pump.ts                             ← createTestPump()
+  src/crypto/
+    test-keys.ts                        ← paires de clés déterministes pour tests
+
+infra/docker/
+  docker-compose.yml                    ← postgres, redis, mailpit, minio
+  .env.docker                           ← variables d'environnement docker
+  README.md                             ← guide démarrage dev local
+
+.env.example                            ← créer à la racine
+```
+
+---
+
+## Task 1 : Initialiser libsodium dans packages/crypto
+
+**Files:**
+- Modify: `packages/crypto/package.json`
+- Create: `packages/crypto/src/sodium.ts`
+
+- [ ] **Step 1 : Ajouter libsodium-wrappers aux dépendances**
+
+```bash
+cd packages/crypto
+pnpm add libsodium-wrappers libsodium-wrappers-sumo
+pnpm add -D @types/libsodium-wrappers @types/libsodium-wrappers-sumo
+```
+
+- [ ] **Step 2 : Vérifier que les types sont présents**
+
+```bash
+ls node_modules/@types/libsodium-wrappers/index.d.ts
+```
+
+Expected : le fichier existe.
+
+- [ ] **Step 3 : Créer le singleton d'initialisation**
+
+Créer `packages/crypto/src/sodium.ts` :
+
+```typescript
+import _sodium from 'libsodium-wrappers-sumo'
+
+let _ready = false
+
+export async function getSodium(): Promise<typeof _sodium> {
+  if (!_ready) {
+    await _sodium.ready
+    _ready = true
+  }
+  return _sodium
+}
+```
+
+> libsodium-wrappers-sumo inclut Argon2id (absent de la version de base). On utilise sumo partout pour cohérence.
+
+- [ ] **Step 4 : Écrire le test de smoke**
+
+Créer `packages/crypto/src/sodium.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { getSodium } from './sodium.js'
+
+describe('getSodium', () => {
+  it('retourne une instance libsodium initialisée', async () => {
+    const sodium = await getSodium()
+    expect(sodium.SODIUM_VERSION_STRING).toMatch(/^\d+\.\d+\.\d+$/)
+  })
+
+  it('retourne la même instance au second appel', async () => {
+    const a = await getSodium()
+    const b = await getSodium()
+    expect(a).toBe(b)
+  })
+})
+```
+
+- [ ] **Step 5 : Lancer le test et vérifier qu'il passe**
+
+```bash
+cd packages/crypto
+pnpm test
+```
+
+Expected : 2 tests passent.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add packages/crypto/
+git commit -m "feat(crypto): initialise libsodium-wrappers-sumo singleton"
+```
+
+---
+
+## Task 2 : Ed25519 — signature et vérification
+
+**Files:**
+- Create: `packages/crypto/src/sign/ed25519.ts`
+- Create: `packages/crypto/src/sign/ed25519.test.ts`
+
+- [ ] **Step 1 : Écrire les tests Ed25519 (rouge)**
+
+Créer `packages/crypto/src/sign/ed25519.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import {
+  generateSigningKeypair,
+  sign,
+  verify,
+} from './ed25519.js'
+
+describe('Ed25519', () => {
+  it('génère une paire de clés valide (32 + 64 octets)', async () => {
+    const kp = await generateSigningKeypair()
+    expect(kp.publicKey).toHaveLength(32)
+    expect(kp.secretKey).toHaveLength(64)
+  })
+
+  it('signe un message et le vérifie correctement', async () => {
+    const kp = await generateSigningKeypair()
+    const message = new TextEncoder().encode('événement:dose_administered')
+    const sig = await sign(message, kp.secretKey)
+    expect(sig).toHaveLength(64)
+    const ok = await verify(message, sig, kp.publicKey)
+    expect(ok).toBe(true)
+  })
+
+  it('rejette une signature modifiée', async () => {
+    const kp = await generateSigningKeypair()
+    const message = new TextEncoder().encode('événement:dose_administered')
+    const sig = await sign(message, kp.secretKey)
+    sig[0] ^= 0xff // corrompt le premier octet
+    const ok = await verify(message, sig, kp.publicKey)
+    expect(ok).toBe(false)
+  })
+
+  it('rejette une signature avec la mauvaise clé publique', async () => {
+    const kp1 = await generateSigningKeypair()
+    const kp2 = await generateSigningKeypair()
+    const message = new TextEncoder().encode('événement:dose_administered')
+    const sig = await sign(message, kp1.secretKey)
+    const ok = await verify(message, sig, kp2.publicKey)
+    expect(ok).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2 : Vérifier que les tests échouent**
+
+```bash
+cd packages/crypto && pnpm test src/sign/ed25519.test.ts
+```
+
+Expected : FAIL — module non trouvé.
+
+- [ ] **Step 3 : Implémenter ed25519.ts**
+
+Créer `packages/crypto/src/sign/ed25519.ts` :
+
+```typescript
+import { getSodium } from '../sodium.js'
+
+export interface SigningKeypair {
+  publicKey: Uint8Array
+  secretKey: Uint8Array
+}
+
+export async function generateSigningKeypair(): Promise<SigningKeypair> {
+  const sodium = await getSodium()
+  const kp = sodium.crypto_sign_keypair()
+  return { publicKey: kp.publicKey, secretKey: kp.privateKey }
+}
+
+export async function sign(
+  message: Uint8Array,
+  secretKey: Uint8Array,
+): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.crypto_sign_detached(message, secretKey)
+}
+
+export async function verify(
+  message: Uint8Array,
+  signature: Uint8Array,
+  publicKey: Uint8Array,
+): Promise<boolean> {
+  const sodium = await getSodium()
+  try {
+    return sodium.crypto_sign_verify_detached(signature, message, publicKey)
+  } catch {
+    return false
+  }
+}
+```
+
+- [ ] **Step 4 : Vérifier que les tests passent**
+
+```bash
+cd packages/crypto && pnpm test src/sign/ed25519.test.ts
+```
+
+Expected : 4 tests PASS.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/crypto/src/sign/
+git commit -m "feat(crypto): Ed25519 sign/verify/keygen via libsodium"
+```
+
+---
+
+## Task 3 : XChaCha20-Poly1305 — chiffrement symétrique authentifié
+
+**Files:**
+- Create: `packages/crypto/src/box/xchacha20.ts`
+- Create: `packages/crypto/src/box/xchacha20.test.ts`
+
+- [ ] **Step 1 : Écrire les tests (rouge)**
+
+Créer `packages/crypto/src/box/xchacha20.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import {
+  secretboxKeygen,
+  secretboxNonce,
+  secretbox,
+  secretboxOpen,
+} from './xchacha20.js'
+
+describe('XChaCha20-Poly1305', () => {
+  it('génère une clé de 32 octets', async () => {
+    const key = await secretboxKeygen()
+    expect(key).toHaveLength(32)
+  })
+
+  it('génère un nonce de 24 octets', async () => {
+    const nonce = await secretboxNonce()
+    expect(nonce).toHaveLength(24)
+  })
+
+  it('chiffre et déchiffre un blob', async () => {
+    const key = await secretboxKeygen()
+    const nonce = await secretboxNonce()
+    const plaintext = new TextEncoder().encode('données santé chiffrées')
+    const ciphertext = await secretbox(plaintext, nonce, key)
+    expect(ciphertext.length).toBeGreaterThan(plaintext.length)
+    const decrypted = await secretboxOpen(ciphertext, nonce, key)
+    expect(new TextDecoder().decode(decrypted)).toBe('données santé chiffrées')
+  })
+
+  it('rejette un ciphertext altéré', async () => {
+    const key = await secretboxKeygen()
+    const nonce = await secretboxNonce()
+    const plaintext = new TextEncoder().encode('données santé chiffrées')
+    const ciphertext = await secretbox(plaintext, nonce, key)
+    ciphertext[0] ^= 0xff
+    await expect(secretboxOpen(ciphertext, nonce, key)).rejects.toThrow()
+  })
+
+  it('deux nonces différents produisent deux ciphertexts différents', async () => {
+    const key = await secretboxKeygen()
+    const n1 = await secretboxNonce()
+    const n2 = await secretboxNonce()
+    const msg = new TextEncoder().encode('test')
+    const c1 = await secretbox(msg, n1, key)
+    const c2 = await secretbox(msg, n2, key)
+    expect(Buffer.from(c1).toString('hex')).not.toBe(Buffer.from(c2).toString('hex'))
+  })
+})
+```
+
+- [ ] **Step 2 : Vérifier que les tests échouent**
+
+```bash
+cd packages/crypto && pnpm test src/box/xchacha20.test.ts
+```
+
+Expected : FAIL.
+
+- [ ] **Step 3 : Implémenter xchacha20.ts**
+
+Créer `packages/crypto/src/box/xchacha20.ts` :
+
+```typescript
+import { getSodium } from '../sodium.js'
+
+export async function secretboxKeygen(): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.crypto_secretbox_keygen()
+}
+
+export async function secretboxNonce(): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES)
+}
+
+export async function secretbox(
+  plaintext: Uint8Array,
+  nonce: Uint8Array,
+  key: Uint8Array,
+): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.crypto_secretbox_easy(plaintext, nonce, key)
+}
+
+export async function secretboxOpen(
+  ciphertext: Uint8Array,
+  nonce: Uint8Array,
+  key: Uint8Array,
+): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  const result = sodium.crypto_secretbox_open_easy(ciphertext, nonce, key)
+  if (!result) throw new Error('crypto: déchiffrement échoué — MAC invalide')
+  return result
+}
+```
+
+- [ ] **Step 4 : Vérifier que les tests passent**
+
+```bash
+cd packages/crypto && pnpm test src/box/xchacha20.test.ts
+```
+
+Expected : 5 tests PASS.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/crypto/src/box/
+git commit -m "feat(crypto): XChaCha20-Poly1305 secretbox via libsodium"
+```
+
+---
+
+## Task 4 : Argon2id — dérivation de clé depuis la recovery seed
+
+**Files:**
+- Create: `packages/crypto/src/kdf/argon2id.ts`
+- Create: `packages/crypto/src/kdf/argon2id.test.ts`
+
+- [ ] **Step 1 : Écrire les tests (rouge)**
+
+Créer `packages/crypto/src/kdf/argon2id.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { deriveKey, generateSalt, ARGON2ID_PARAMS } from './argon2id.js'
+
+describe('Argon2id', () => {
+  it('dérive une clé de longueur demandée', async () => {
+    const salt = await generateSalt()
+    const key = await deriveKey('recovery seed mnemonic 24 words', salt, 32)
+    expect(key).toHaveLength(32)
+  }, 15_000) // Argon2id est intentionnellement lent
+
+  it('deux appels identiques produisent la même clé', async () => {
+    const salt = await generateSalt()
+    const password = 'correct horse battery staple'
+    const k1 = await deriveKey(password, salt, 32)
+    const k2 = await deriveKey(password, salt, 32)
+    expect(Buffer.from(k1).toString('hex')).toBe(Buffer.from(k2).toString('hex'))
+  }, 30_000)
+
+  it('un salt différent produit une clé différente', async () => {
+    const s1 = await generateSalt()
+    const s2 = await generateSalt()
+    const password = 'correct horse battery staple'
+    const k1 = await deriveKey(password, s1, 32)
+    const k2 = await deriveKey(password, s2, 32)
+    expect(Buffer.from(k1).toString('hex')).not.toBe(Buffer.from(k2).toString('hex'))
+  }, 30_000)
+
+  it('expose les paramètres Argon2id conformes OWASP 2024', () => {
+    // OWASP recommande m>=64MB, t>=3, p=1 minimum
+    expect(ARGON2ID_PARAMS.memoryCost).toBeGreaterThanOrEqual(65536) // 64 Mio en KiB
+    expect(ARGON2ID_PARAMS.timeCost).toBeGreaterThanOrEqual(3)
+  })
+})
+```
+
+- [ ] **Step 2 : Vérifier que les tests échouent**
+
+```bash
+cd packages/crypto && pnpm test src/kdf/argon2id.test.ts
+```
+
+Expected : FAIL.
+
+- [ ] **Step 3 : Implémenter argon2id.ts**
+
+Créer `packages/crypto/src/kdf/argon2id.ts` :
+
+```typescript
+import { getSodium } from '../sodium.js'
+
+// Paramètres OWASP 2024 — intentionnellement lents pour résister aux attaques bruteforce
+export const ARGON2ID_PARAMS = {
+  memoryCost: 65536, // 64 Mio en KiB
+  timeCost: 3,       // 3 passes
+  parallelism: 1,    // 1 thread (mobile single-core compatible)
+} as const
+
+export async function generateSalt(): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.randombytes_buf(sodium.crypto_pwhash_SALTBYTES)
+}
+
+export async function deriveKey(
+  password: string,
+  salt: Uint8Array,
+  outputLen: number,
+): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.crypto_pwhash(
+    outputLen,
+    password,
+    salt,
+    ARGON2ID_PARAMS.timeCost,
+    ARGON2ID_PARAMS.memoryCost * 1024, // libsodium attend des octets
+    sodium.crypto_pwhash_ALG_ARGON2ID13,
+  )
+}
+```
+
+- [ ] **Step 4 : Vérifier que les tests passent**
+
+```bash
+cd packages/crypto && pnpm test src/kdf/argon2id.test.ts
+```
+
+Expected : 4 tests PASS. Les tests Argon2id sont lents (5-10s) — c'est normal et attendu.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git add packages/crypto/src/kdf/
+git commit -m "feat(crypto): Argon2id KDF (OWASP 2024) via libsodium-sumo"
+```
+
+---
+
+## Task 5 : randomBytes + mise à jour de l'index
+
+**Files:**
+- Create: `packages/crypto/src/random/random.ts`
+- Create: `packages/crypto/src/random/random.test.ts`
+- Modify: `packages/crypto/src/index.ts`
+
+- [ ] **Step 1 : Écrire le test random (rouge)**
+
+Créer `packages/crypto/src/random/random.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { randomBytes } from './random.js'
+
+describe('randomBytes', () => {
+  it('génère N octets aléatoires', async () => {
+    const bytes = await randomBytes(32)
+    expect(bytes).toHaveLength(32)
+  })
+
+  it('deux appels produisent des valeurs différentes', async () => {
+    const a = await randomBytes(32)
+    const b = await randomBytes(32)
+    expect(Buffer.from(a).toString('hex')).not.toBe(Buffer.from(b).toString('hex'))
+  })
+})
+```
+
+- [ ] **Step 2 : Implémenter random.ts**
+
+Créer `packages/crypto/src/random/random.ts` :
+
+```typescript
+import { getSodium } from '../sodium.js'
+
+export async function randomBytes(n: number): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.randombytes_buf(n)
+}
+```
+
+- [ ] **Step 3 : Mettre à jour l'index principal**
+
+Modifier `packages/crypto/src/index.ts` :
+
+```typescript
+// Existant
+export { sha256Hex, sha256HexFromString } from './hash/sha256.js'
+
+// Nouveau — libsodium primitives
+export { getSodium } from './sodium.js'
+export { generateSigningKeypair, sign, verify } from './sign/ed25519.js'
+export type { SigningKeypair } from './sign/ed25519.js'
+export { secretboxKeygen, secretboxNonce, secretbox, secretboxOpen } from './box/xchacha20.js'
+export { deriveKey, generateSalt, ARGON2ID_PARAMS } from './kdf/argon2id.js'
+export { randomBytes } from './random/random.js'
+```
+
+- [ ] **Step 4 : Lancer tous les tests crypto**
+
+```bash
+cd packages/crypto && pnpm test
+```
+
+Expected : tous les tests passent (y compris les anciens SHA-256).
+
+- [ ] **Step 5 : Lancer typecheck**
+
+```bash
+cd packages/crypto && pnpm typecheck
+```
+
+Expected : 0 erreurs.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git add packages/crypto/src/random/ packages/crypto/src/index.ts
+git commit -m "feat(crypto): randomBytes + exporte toutes les primitives libsodium"
+```
+
+---
+
+## Task 6 : packages/test-utils — factories partagées
+
+**Files:**
+- Create: `packages/test-utils/package.json`
+- Create: `packages/test-utils/tsconfig.json`
+- Create: `packages/test-utils/vitest.config.ts`
+- Create: `packages/test-utils/eslint.config.js`
+- Create: `packages/test-utils/src/index.ts`
+- Create: `packages/test-utils/src/factories/household.ts`
+- Create: `packages/test-utils/src/factories/caregiver.ts`
+- Create: `packages/test-utils/src/factories/dose.ts`
+- Create: `packages/test-utils/src/crypto/test-keys.ts`
+
+- [ ] **Step 1 : Créer package.json**
+
+Créer `packages/test-utils/package.json` :
+
+```json
+{
+  "name": "@kinhale/test-utils",
+  "version": "0.1.0",
+  "description": "Helpers de test partagés pour Kinhale (factories, fixtures, crypto deterministe)",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@kinhale/crypto": "workspace:*",
+    "@kinhale/domain": "workspace:*"
+  },
+  "devDependencies": {
+    "@kinhale/eslint-config": "workspace:*",
+    "@kinhale/tsconfig": "workspace:*",
+    "typescript": "^5.7.3",
+    "vitest": "^2.0.0"
+  }
+}
+```
+
+- [ ] **Step 2 : Créer tsconfig.json**
+
+Créer `packages/test-utils/tsconfig.json` :
+
+```json
+{
+  "extends": "@kinhale/tsconfig/library.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}
+```
+
+- [ ] **Step 3 : Créer eslint.config.js**
+
+Créer `packages/test-utils/eslint.config.js` :
+
+```js
+import config from '@kinhale/eslint-config'
+export default config
+```
+
+- [ ] **Step 4 : Créer les clés de test déterministes**
+
+Créer `packages/test-utils/src/crypto/test-keys.ts` :
+
+```typescript
+import { generateSigningKeypair } from '@kinhale/crypto'
+
+// Clés déterministes pour les tests — NE JAMAIS utiliser en production
+// Générées une fois et réutilisées via le cache Vitest
+
+let _adminKeypair: Awaited<ReturnType<typeof generateSigningKeypair>> | null = null
+let _caregiverKeypair: Awaited<ReturnType<typeof generateSigningKeypair>> | null = null
+
+export async function getAdminTestKeypair() {
+  if (!_adminKeypair) _adminKeypair = await generateSigningKeypair()
+  return _adminKeypair
+}
+
+export async function getCaregiverTestKeypair() {
+  if (!_caregiverKeypair) _caregiverKeypair = await generateSigningKeypair()
+  return _caregiverKeypair
+}
+```
+
+- [ ] **Step 5 : Créer les factories**
+
+Créer `packages/test-utils/src/factories/household.ts` :
+
+```typescript
+import type { Household } from '@kinhale/domain'
+
+let _counter = 0
+
+export function createTestHousehold(overrides: Partial<Household> = {}): Household {
+  const id = `household-test-${++_counter}`
+  return {
+    id,
+    name: `Foyer Test ${_counter}`,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  }
+}
+```
+
+Créer `packages/test-utils/src/factories/caregiver.ts` :
+
+```typescript
+import type { Caregiver } from '@kinhale/domain'
+import { Role } from '@kinhale/domain'
+
+let _counter = 0
+
+export function createTestCaregiver(overrides: Partial<Caregiver> = {}): Caregiver {
+  const id = `caregiver-test-${++_counter}`
+  return {
+    id,
+    householdId: 'household-test-1',
+    role: Role.Admin,
+    deviceId: `device-test-${_counter}`,
+    joinedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  }
+}
+```
+
+Créer `packages/test-utils/src/factories/dose.ts` :
+
+```typescript
+import type { Dose } from '@kinhale/domain'
+import { PumpType } from '@kinhale/domain'
+
+let _counter = 0
+
+export function createTestDose(overrides: Partial<Dose> = {}): Dose {
+  const id = `dose-test-${++_counter}`
+  return {
+    id,
+    householdId: 'household-test-1',
+    pumpId: 'pump-test-1',
+    pumpType: PumpType.Controller,
+    administeredAt: new Date('2026-01-01T08:00:00Z'),
+    recordedAt: new Date('2026-01-01T08:00:05Z'),
+    caregiverId: 'caregiver-test-1',
+    voided: false,
+    ...overrides,
+  }
+}
+```
+
+- [ ] **Step 6 : Créer l'index**
+
+Créer `packages/test-utils/src/index.ts` :
+
+```typescript
+export { createTestHousehold } from './factories/household.js'
+export { createTestCaregiver } from './factories/caregiver.js'
+export { createTestDose } from './factories/dose.js'
+export { getAdminTestKeypair, getCaregiverTestKeypair } from './crypto/test-keys.js'
+```
+
+- [ ] **Step 7 : Installer les dépendances et vérifier**
+
+```bash
+pnpm install
+cd packages/test-utils && pnpm typecheck
+```
+
+Expected : 0 erreurs TypeScript.
+
+> **Note** : si les types `Household`, `Caregiver`, `Dose`, `PumpType`, `Role` ne sont pas encore exportés depuis `@kinhale/domain`, ajuster les imports ou les ajouter à `packages/domain/src/index.ts` avant de continuer.
+
+- [ ] **Step 8 : Commit**
+
+```bash
+git add packages/test-utils/
+git commit -m "feat(test-utils): factories partagées household/caregiver/dose + clés crypto test"
+```
+
+---
+
+## Task 7 : infra/docker — environnement de développement local
+
+**Files:**
+- Create: `infra/docker/docker-compose.yml`
+- Create: `infra/docker/.env.docker`
+- Create: `infra/docker/README.md`
+- Create: `.env.example` (racine)
+
+- [ ] **Step 1 : Créer docker-compose.yml**
+
+Créer `infra/docker/docker-compose.yml` :
+
+```yaml
+# Environnement de développement local Kinhale
+# Usage : docker compose -f infra/docker/docker-compose.yml up -d
+# Compatible Coolify (production)
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: kinhale_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: kinhale_dev
+      POSTGRES_USER: kinhale
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-kinhale_dev_secret}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U kinhale -d kinhale_dev"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: kinhale_redis
+    restart: unless-stopped
+    command: redis-server --requirepass ${REDIS_PASSWORD:-kinhale_redis_dev}
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "--pass", "${REDIS_PASSWORD:-kinhale_redis_dev}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: kinhale_mailpit
+    restart: unless-stopped
+    ports:
+      - "1025:1025"   # SMTP
+      - "8025:8025"   # UI web (http://localhost:8025)
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+
+  minio:
+    image: minio/minio:latest
+    container_name: kinhale_minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-kinhale}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-kinhale_minio_dev}
+    ports:
+      - "9000:9000"   # API S3-compatible (équivalent R2)
+      - "9001:9001"   # Console web (http://localhost:9001)
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+volumes:
+  postgres_data:
+  redis_data:
+  minio_data:
+
+networks:
+  default:
+    name: kinhale_dev
+```
+
+- [ ] **Step 2 : Créer .env.docker**
+
+Créer `infra/docker/.env.docker` :
+
+```bash
+# Variables docker-compose développement local
+# NE PAS COMMITTER de vraies valeurs de production ici
+POSTGRES_PASSWORD=kinhale_dev_secret
+REDIS_PASSWORD=kinhale_redis_dev
+MINIO_ROOT_USER=kinhale
+MINIO_ROOT_PASSWORD=kinhale_minio_dev
+```
+
+- [ ] **Step 3 : Créer .env.example à la racine**
+
+Créer `.env.example` :
+
+```bash
+# Copier vers .env et remplir les valeurs
+# cp .env.example .env
+
+# Base de données
+DATABASE_URL=postgresql://kinhale:kinhale_dev_secret@localhost:5432/kinhale_dev
+
+# Redis
+REDIS_URL=redis://:kinhale_redis_dev@localhost:6379
+
+# Stockage blobs (MinIO local = équivalent Cloudflare R2)
+STORAGE_ENDPOINT=http://localhost:9000
+STORAGE_BUCKET=kinhale-relay-blobs
+STORAGE_ACCESS_KEY_ID=kinhale
+STORAGE_SECRET_ACCESS_KEY=kinhale_minio_dev
+STORAGE_REGION=us-east-1
+
+# Email (Mailpit local = équivalent Resend)
+EMAIL_PROVIDER=smtp
+SMTP_HOST=localhost
+SMTP_PORT=1025
+EMAIL_FROM=noreply@kinhale.health
+
+# JWT
+JWT_SECRET=dev_jwt_secret_change_in_production_minimum_32_chars
+
+# App
+NODE_ENV=development
+PORT=3000
+```
+
+- [ ] **Step 4 : Créer infra/docker/README.md**
+
+Créer `infra/docker/README.md` :
+
+```markdown
+# Environnement de développement local Kinhale
+
+## Démarrage
+
+```bash
+# Depuis la racine du projet
+docker compose -f infra/docker/docker-compose.yml up -d
+
+# Vérifier que tout est healthy
+docker compose -f infra/docker/docker-compose.yml ps
+```
+
+## Services disponibles
+
+| Service | Port | UI |
+|---|---|---|
+| PostgreSQL 16 | 5432 | — |
+| Redis 7 | 6379 | — |
+| Mailpit (SMTP + UI) | 1025 / 8025 | http://localhost:8025 |
+| MinIO (S3-compatible / R2) | 9000 / 9001 | http://localhost:9001 |
+
+## Initialiser MinIO (premier démarrage)
+
+```bash
+# Créer le bucket kinhale-relay-blobs
+docker exec kinhale_minio mc alias set local http://localhost:9000 kinhale kinhale_minio_dev
+docker exec kinhale_minio mc mb local/kinhale-relay-blobs
+```
+
+## Arrêt
+
+```bash
+docker compose -f infra/docker/docker-compose.yml down
+# Pour supprimer les volumes (reset complet) :
+docker compose -f infra/docker/docker-compose.yml down -v
+```
+```
+
+- [ ] **Step 5 : Vérifier que docker-compose démarre correctement**
+
+```bash
+docker compose -f infra/docker/docker-compose.yml up -d
+docker compose -f infra/docker/docker-compose.yml ps
+```
+
+Expected : 4 services en état `healthy` ou `running`.
+
+- [ ] **Step 6 : Vérifier la connexion PostgreSQL**
+
+```bash
+docker exec kinhale_postgres psql -U kinhale -d kinhale_dev -c "SELECT version();"
+```
+
+Expected : affiche la version PostgreSQL 16.x.
+
+- [ ] **Step 7 : Vérifier MinIO**
+
+```bash
+docker exec kinhale_minio mc alias set local http://localhost:9000 kinhale kinhale_minio_dev
+docker exec kinhale_minio mc mb local/kinhale-relay-blobs
+docker exec kinhale_minio mc ls local/
+```
+
+Expected : `[DATE] kinhale-relay-blobs/`
+
+- [ ] **Step 8 : Ajouter .env.example et docker au .gitignore si nécessaire**
+
+Vérifier que `.env` (pas `.env.example`) est bien dans `.gitignore` :
+
+```bash
+grep "^\.env$" .gitignore || echo ".env" >> .gitignore
+```
+
+- [ ] **Step 9 : Commit**
+
+```bash
+git add infra/docker/ .env.example .gitignore
+git commit -m "feat(infra): docker-compose dev local (postgres, redis, mailpit, minio)"
+```
+
+---
+
+## Task 8 : Vérification finale et CI
+
+- [ ] **Step 1 : Lancer la suite complète depuis la racine**
+
+```bash
+pnpm install
+pnpm lint && pnpm typecheck && pnpm test
+```
+
+Expected : 0 erreurs lint, 0 erreurs TypeScript, tous les tests passent.
+
+- [ ] **Step 2 : Vérifier la couverture crypto**
+
+```bash
+cd packages/crypto && pnpm test --coverage
+```
+
+Expected : couverture > 80% sur toutes les métriques.
+
+- [ ] **Step 3 : Vérifier que la CI passe**
+
+```bash
+git push origin feature/KIN-017-rm23-geolocation-opt-in
+```
+
+Vérifier que le workflow `.github/workflows/ci.yml` passe sur GitHub Actions.
+
+- [ ] **Step 4 : Commit de synthèse si nécessaire**
+
+```bash
+git add .
+git commit -m "chore(sprint0): Plan 1 Foundation — crypto libsodium + docker + test-utils"
+```
+
+---
+
+## Notes importantes
+
+**Argon2id en tests :** les tests Argon2id sont volontairement lents (5-10s chacun). Ne pas réduire les paramètres dans les tests — cela invaliderait la validation des paramètres OWASP. Si le timeout Vitest est trop court, augmenter dans `vitest.config.ts` : `testTimeout: 30_000`.
+
+**libsodium-wrappers-sumo vs standard :** on utilise `-sumo` qui inclut Argon2id. La version standard ne l'a pas. Ne pas substituer par `libsodium-wrappers` sans sumo.
+
+**Types domain dans test-utils :** les factories dépendent des types exportés par `@kinhale/domain`. Si un type (`Household`, `Caregiver`, etc.) n'est pas encore exporté, l'ajouter à `packages/domain/src/index.ts` plutôt que de contourner dans test-utils.
+
+**MinIO ↔ Cloudflare R2 :** MinIO expose une API S3-compatible. Le code applicatif utilise `@aws-sdk/client-s3` avec l'endpoint configuré via `STORAGE_ENDPOINT`. En production, changer `STORAGE_ENDPOINT` vers l'endpoint R2 de Cloudflare. Zéro changement de code.

--- a/docs/superpowers/plans/2026-04-20-sprint0-plan2-sync.md
+++ b/docs/superpowers/plans/2026-04-20-sprint0-plan2-sync.md
@@ -1,0 +1,1336 @@
+# Sprint 0 — Plan 2 : packages/sync (Automerge 2 + E2EE)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Créer `packages/sync` — le moteur local-first de Kinhale : document CRDT Automerge 2 par foyer, événements domaine signés Ed25519, chiffrement des deltas pour le relais opaque.
+
+**Architecture:** Un document Automerge par foyer contient une liste append-only d'événements domaine signés Ed25519. Les deltas (Automerge `getChanges`) sont chiffrés XChaCha20-Poly1305 avec la clé de groupe avant d'être envoyés au relais — qui ne voit que des blobs opaques. Le relais ne détient jamais la clé de groupe (MLS le gèrera dans un sprint futur ; pour l'instant la clé de groupe est un `Uint8Array` passé explicitement).
+
+**Tech Stack:** `@automerge/automerge` 2.2+, `@kinhale/crypto` (Ed25519 + XChaCha20-Poly1305 + randomBytes), TypeScript strict, Vitest.
+
+---
+
+## Fichiers créés
+
+```
+packages/sync/
+  package.json
+  tsconfig.json
+  vitest.config.ts
+  eslint.config.js
+  src/
+    index.ts                        ← exporte tout
+    doc/
+      schema.ts                     ← KinhaleDoc + SignedEventRecord (types Automerge)
+      schema.test.ts
+      lifecycle.ts                  ← createDoc, loadDoc, saveDoc, getDocChanges, mergeChanges
+      lifecycle.test.ts
+    events/
+      types.ts                      ← DomainEventType + payload union
+      sign.ts                       ← signEvent(), verifySignedEvent()
+      sign.test.ts
+      append.ts                     ← appendEvent()
+      append.test.ts
+    mailbox/
+      encrypt.ts                    ← encryptChanges(), decryptChanges(), EncryptedBlob
+      encrypt.test.ts
+      message.ts                    ← SyncMessage + encodeSyncMessage(), decodeSyncMessage()
+      message.test.ts
+```
+
+---
+
+## Task 1 : Package scaffold
+
+**Files:**
+- Create: `packages/sync/package.json`
+- Create: `packages/sync/tsconfig.json`
+- Create: `packages/sync/vitest.config.ts`
+- Create: `packages/sync/eslint.config.js`
+
+- [ ] **Step 1 : Créer package.json**
+
+Créer `packages/sync/package.json` :
+
+```json
+{
+  "name": "@kinhale/sync",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "description": "Moteur de synchronisation local-first Kinhale (Automerge 2 + E2EE mailbox)",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint --max-warnings=0 .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@automerge/automerge": "^2.2.0",
+    "@kinhale/crypto": "workspace:*"
+  },
+  "devDependencies": {
+    "@kinhale/eslint-config": "workspace:*",
+    "@kinhale/tsconfig": "workspace:*",
+    "@kinhale/test-utils": "workspace:*",
+    "@types/node": "^22.10.5",
+    "@vitest/coverage-v8": "^3.0.0",
+    "eslint": "^9.18.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.2"
+  }
+}
+```
+
+- [ ] **Step 2 : Créer tsconfig.json**
+
+Créer `packages/sync/tsconfig.json` :
+
+```json
+{
+  "extends": "@kinhale/tsconfig/library.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}
+```
+
+- [ ] **Step 3 : Créer vitest.config.ts**
+
+Créer `packages/sync/vitest.config.ts` :
+
+```typescript
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/**/index.ts'],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+})
+```
+
+- [ ] **Step 4 : Créer eslint.config.js**
+
+Créer `packages/sync/eslint.config.js` :
+
+```js
+import kinhale from '@kinhale/eslint-config'
+
+export default [
+  ...kinhale,
+  {
+    files: ['src/**/*.ts'],
+    rules: {
+      'no-console': 'error',
+    },
+  },
+  {
+    files: ['src/**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+]
+```
+
+- [ ] **Step 5 : Installer les dépendances**
+
+```bash
+cd /Users/martial/development/asthma-tracker && pnpm install
+```
+
+Expected : `@automerge/automerge` installé dans `packages/sync/node_modules`.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add packages/sync/
+git -C /Users/martial/development/asthma-tracker commit -m "chore(sync): scaffold package @kinhale/sync
+
+Package vide : package.json, tsconfig, vitest.config, eslint.config.
+Dépendances : @automerge/automerge ^2.2.0 + @kinhale/crypto.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2 : KinhaleDoc — schéma Automerge
+
+**Files:**
+- Create: `packages/sync/src/doc/schema.ts`
+- Create: `packages/sync/src/doc/schema.test.ts`
+
+Le document Automerge d'un foyer. Les `Uint8Array` (clés, signatures) sont stockés en hex dans le CRDT car Automerge gère les strings nativement. La couche sign/verify ré-encode en `Uint8Array` à la demande.
+
+- [ ] **Step 1 : Écrire les tests (rouge)**
+
+Créer `packages/sync/src/doc/schema.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import type { KinhaleDoc, SignedEventRecord } from './schema.js'
+
+describe('KinhaleDoc schema', () => {
+  it('SignedEventRecord a toutes les propriétés requises', () => {
+    const record: SignedEventRecord = {
+      id: 'evt-001',
+      type: 'DoseAdministered',
+      payloadJson: JSON.stringify({ doseId: 'd1' }),
+      signerPublicKeyHex: 'aabbcc',
+      signatureHex: 'ddeeff',
+      deviceId: 'device-001',
+      occurredAtMs: 1_700_000_000_000,
+    }
+    expect(record.id).toBe('evt-001')
+    expect(record.type).toBe('DoseAdministered')
+    expect(record.occurredAtMs).toBeGreaterThan(0)
+  })
+
+  it('KinhaleDoc a householdId et events', () => {
+    const doc: KinhaleDoc = {
+      householdId: 'hh-001',
+      events: [],
+    }
+    expect(doc.householdId).toBe('hh-001')
+    expect(doc.events).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 2 : Vérifier que les tests échouent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/doc/schema.test.ts
+```
+
+Expected : FAIL (module not found).
+
+- [ ] **Step 3 : Créer schema.ts**
+
+Créer `packages/sync/src/doc/schema.ts` :
+
+```typescript
+/**
+ * Événement domaine stocké dans le document Automerge.
+ * Les Uint8Array (clé publique, signature) sont encodés en hex pour
+ * compatibilité native avec le CRDT Automerge.
+ */
+export interface SignedEventRecord {
+  readonly id: string
+  readonly type: string
+  /** JSON.stringify du payload domaine (DoseAdministeredPayload, etc.) */
+  readonly payloadJson: string
+  /** Clé publique Ed25519 du device émetteur (hex 64 chars) */
+  readonly signerPublicKeyHex: string
+  /** Signature Ed25519 du canonical bytes (hex 128 chars) */
+  readonly signatureHex: string
+  readonly deviceId: string
+  /** Timestamp UTC en millisecondes */
+  readonly occurredAtMs: number
+}
+
+/**
+ * Document Automerge d'un foyer Kinhale.
+ * Un foyer = un document. Les entités (pompes, plans, historique)
+ * sont des projections calculées à la lecture depuis la liste d'événements.
+ */
+export interface KinhaleDoc {
+  householdId: string
+  events: SignedEventRecord[]
+}
+```
+
+- [ ] **Step 4 : Vérifier que les tests passent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/doc/schema.test.ts
+```
+
+Expected : 2 tests PASS.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add packages/sync/src/doc/schema.ts packages/sync/src/doc/schema.test.ts
+git -C /Users/martial/development/asthma-tracker commit -m "feat(sync): KinhaleDoc schema — document Automerge du foyer
+
+SignedEventRecord : id, type, payloadJson, signerPublicKeyHex (hex),
+signatureHex (hex), deviceId, occurredAtMs.
+KinhaleDoc : householdId + events append-only.
+Hex encoding des Uint8Array pour compatibilité native Automerge.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3 : Cycle de vie du document
+
+**Files:**
+- Create: `packages/sync/src/doc/lifecycle.ts`
+- Create: `packages/sync/src/doc/lifecycle.test.ts`
+
+- [ ] **Step 1 : Écrire les tests (rouge)**
+
+Créer `packages/sync/src/doc/lifecycle.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import {
+  createDoc,
+  loadDoc,
+  saveDoc,
+  getDocChanges,
+  getAllDocChanges,
+  mergeChanges,
+} from './lifecycle.js'
+
+describe('Document lifecycle', () => {
+  it('createDoc initialise un document avec householdId', () => {
+    const doc = createDoc('hh-test-1')
+    expect(doc.householdId).toBe('hh-test-1')
+    expect(doc.events).toHaveLength(0)
+  })
+
+  it('saveDoc + loadDoc : aller-retour binaire', () => {
+    const doc = createDoc('hh-test-2')
+    const bytes = saveDoc(doc)
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    expect(bytes.length).toBeGreaterThan(0)
+    const loaded = loadDoc(bytes)
+    expect(loaded.householdId).toBe('hh-test-2')
+    expect(loaded.events).toHaveLength(0)
+  })
+
+  it('getAllDocChanges retourne des Uint8Array[]', () => {
+    const doc = createDoc('hh-test-3')
+    const changes = getAllDocChanges(doc)
+    expect(Array.isArray(changes)).toBe(true)
+    expect(changes.length).toBeGreaterThan(0)
+    expect(changes[0]).toBeInstanceOf(Uint8Array)
+  })
+
+  it('getDocChanges retourne 0 changements si doc identique', () => {
+    const doc = createDoc('hh-test-4')
+    const changes = getDocChanges(doc, doc)
+    expect(changes).toHaveLength(0)
+  })
+
+  it('mergeChanges applique des changements et préserve les données', () => {
+    import * as A from '@automerge/automerge'
+    const doc = createDoc('hh-test-5')
+    const doc2 = A.change(doc, (d) => {
+      d.events.push({
+        id: 'evt-merge-1',
+        type: 'DoseAdministered',
+        payloadJson: '{}',
+        signerPublicKeyHex: 'aa',
+        signatureHex: 'bb',
+        deviceId: 'dev-1',
+        occurredAtMs: 1_700_000_000_000,
+      })
+    })
+    const changes = getDocChanges(doc, doc2)
+    const fresh = createDoc('hh-test-5')
+    const merged = mergeChanges(fresh, changes)
+    expect(merged.events).toHaveLength(0) // fresh n'a pas l'historique de doc
+    // Correct behavior: mergeChanges applique les changements delta
+    // entre doc et doc2 sur fresh — ce delta contient l'ajout de l'événement
+    // seulement si fresh est déjà à l'état de doc (même base).
+    // Test réaliste : même base, même foyer
+    const base = createDoc('hh-test-5b')
+    const copy = loadDoc(saveDoc(base))
+    const updated = A.change(base, (d) => {
+      d.events.push({
+        id: 'evt-merge-2',
+        type: 'PumpReplaced',
+        payloadJson: '{}',
+        signerPublicKeyHex: 'cc',
+        signatureHex: 'dd',
+        deviceId: 'dev-2',
+        occurredAtMs: 1_700_000_000_001,
+      })
+    })
+    const delta = getDocChanges(base, updated)
+    const mergedCopy = mergeChanges(copy, delta)
+    expect(mergedCopy.events).toHaveLength(1)
+    expect(mergedCopy.events[0]!.id).toBe('evt-merge-2')
+  })
+})
+```
+
+- [ ] **Step 2 : Vérifier que les tests échouent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/doc/lifecycle.test.ts
+```
+
+Expected : FAIL (module not found).
+
+- [ ] **Step 3 : Implémenter lifecycle.ts**
+
+Créer `packages/sync/src/doc/lifecycle.ts` :
+
+```typescript
+import * as A from '@automerge/automerge'
+import type { KinhaleDoc } from './schema.js'
+
+export function createDoc(householdId: string): A.Doc<KinhaleDoc> {
+  return A.change(A.init<KinhaleDoc>(), (d) => {
+    d.householdId = householdId
+    d.events = []
+  })
+}
+
+export function saveDoc(doc: A.Doc<KinhaleDoc>): Uint8Array {
+  return A.save(doc)
+}
+
+export function loadDoc(bytes: Uint8Array): A.Doc<KinhaleDoc> {
+  return A.load<KinhaleDoc>(bytes)
+}
+
+/**
+ * Retourne les changements delta entre before et after.
+ * Pré-condition : before est un ancêtre de after (même acteur).
+ * Utilisation : calculer le delta à envoyer au relais après une mutation locale.
+ */
+export function getDocChanges(
+  before: A.Doc<KinhaleDoc>,
+  after: A.Doc<KinhaleDoc>,
+): Uint8Array[] {
+  return A.getChanges(before, after).map((c) => new Uint8Array(c))
+}
+
+/**
+ * Retourne tous les changements du document depuis sa création.
+ * Utilisation : synchronisation initiale avec un nouveau device.
+ */
+export function getAllDocChanges(doc: A.Doc<KinhaleDoc>): Uint8Array[] {
+  return A.getAllChanges(doc).map((c) => new Uint8Array(c))
+}
+
+/**
+ * Applique des changements reçus du relais sur un document local.
+ * Automerge garantit la convergence CRDT : l'ordre d'application n'importe pas.
+ */
+export function mergeChanges(
+  doc: A.Doc<KinhaleDoc>,
+  changes: Uint8Array[],
+): A.Doc<KinhaleDoc> {
+  const [newDoc] = A.applyChanges(doc, changes as unknown as A.Change[])
+  return newDoc
+}
+```
+
+- [ ] **Step 4 : Corriger le test (import inline invalide)**
+
+Le test contient un `import * as A from '@automerge/automerge'` inline dans un `it()` — c'est invalide. Remplacer le contenu de `lifecycle.test.ts` par :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import * as A from '@automerge/automerge'
+import {
+  createDoc,
+  loadDoc,
+  saveDoc,
+  getDocChanges,
+  getAllDocChanges,
+  mergeChanges,
+} from './lifecycle.js'
+import type { SignedEventRecord } from './schema.js'
+
+const makeRecord = (id: string): SignedEventRecord => ({
+  id,
+  type: 'DoseAdministered',
+  payloadJson: '{}',
+  signerPublicKeyHex: 'aa',
+  signatureHex: 'bb',
+  deviceId: 'dev-1',
+  occurredAtMs: 1_700_000_000_000,
+})
+
+describe('Document lifecycle', () => {
+  it('createDoc initialise un document avec householdId', () => {
+    const doc = createDoc('hh-test-1')
+    expect(doc.householdId).toBe('hh-test-1')
+    expect(doc.events).toHaveLength(0)
+  })
+
+  it('saveDoc + loadDoc : aller-retour binaire', () => {
+    const doc = createDoc('hh-test-2')
+    const bytes = saveDoc(doc)
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    expect(bytes.length).toBeGreaterThan(0)
+    const loaded = loadDoc(bytes)
+    expect(loaded.householdId).toBe('hh-test-2')
+    expect(loaded.events).toHaveLength(0)
+  })
+
+  it('getAllDocChanges retourne des Uint8Array non vides', () => {
+    const doc = createDoc('hh-test-3')
+    const changes = getAllDocChanges(doc)
+    expect(Array.isArray(changes)).toBe(true)
+    expect(changes.length).toBeGreaterThan(0)
+    expect(changes[0]).toBeInstanceOf(Uint8Array)
+  })
+
+  it('getDocChanges retourne 0 changements si doc identique', () => {
+    const doc = createDoc('hh-test-4')
+    const changes = getDocChanges(doc, doc)
+    expect(changes).toHaveLength(0)
+  })
+
+  it('mergeChanges applique un delta sur une copie du document', () => {
+    const base = createDoc('hh-merge-1')
+    const copy = loadDoc(saveDoc(base))
+    const updated = A.change(base, (d) => {
+      d.events.push(makeRecord('evt-1'))
+    })
+    const delta = getDocChanges(base, updated)
+    const merged = mergeChanges(copy, delta)
+    expect(merged.events).toHaveLength(1)
+    expect(merged.events[0]!.id).toBe('evt-1')
+  })
+
+  it('mergeChanges est idempotent (double application)', () => {
+    const base = createDoc('hh-merge-2')
+    const copy = loadDoc(saveDoc(base))
+    const updated = A.change(base, (d) => {
+      d.events.push(makeRecord('evt-2'))
+    })
+    const delta = getDocChanges(base, updated)
+    const merged1 = mergeChanges(copy, delta)
+    const merged2 = mergeChanges(merged1, delta)
+    expect(merged2.events).toHaveLength(1)
+  })
+})
+```
+
+- [ ] **Step 5 : Vérifier que les tests passent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/doc/lifecycle.test.ts
+```
+
+Expected : 6 tests PASS.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add packages/sync/src/doc/
+git -C /Users/martial/development/asthma-tracker commit -m "feat(sync): cycle de vie du document Automerge (create/save/load/merge)
+
+createDoc, saveDoc, loadDoc, getDocChanges, getAllDocChanges, mergeChanges.
+getDocChanges : delta entre before et after (même acteur).
+getAllDocChanges : tous les changements depuis la création (sync initiale).
+mergeChanges : applique changes reçus du relais, idempotent (CRDT).
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4 : Types d'événements domaine
+
+**Files:**
+- Create: `packages/sync/src/events/types.ts`
+
+Types uniquement — pas de tests (file de types purs, validée par typecheck).
+
+- [ ] **Step 1 : Créer types.ts**
+
+Créer `packages/sync/src/events/types.ts` :
+
+```typescript
+/** Types d'événements domaine persistés dans le document Automerge. */
+export type DomainEventType =
+  | 'DoseAdministered'
+  | 'PumpReplaced'
+  | 'PlanUpdated'
+  | 'CaregiverInvited'
+  | 'CaregiverRevoked'
+
+/** Payload pour DoseAdministered */
+export interface DoseAdministeredPayload {
+  doseId: string
+  pumpId: string
+  childId: string
+  caregiverId: string
+  /** UTC ms */
+  administeredAtMs: number
+  /** 'maintenance' | 'rescue' */
+  doseType: string
+  dosesAdministered: number
+  symptoms: string[]
+  circumstances: string[]
+  freeFormTag: string | null
+}
+
+/** Payload pour PumpReplaced */
+export interface PumpReplacedPayload {
+  pumpId: string
+  name: string
+  /** 'maintenance' | 'rescue' */
+  pumpType: string
+  totalDoses: number
+  /** UTC ms, null si pas de date d'expiration connue */
+  expiresAtMs: number | null
+}
+
+/** Payload pour PlanUpdated */
+export interface PlanUpdatedPayload {
+  planId: string
+  pumpId: string
+  /** Heures cibles en UTC (ex : [8, 20]) */
+  scheduledHoursUtc: number[]
+  /** UTC ms */
+  startAtMs: number
+  /** UTC ms, null si durée indéfinie */
+  endAtMs: number | null
+}
+
+/** Payload pour CaregiverInvited */
+export interface CaregiverInvitedPayload {
+  caregiverId: string
+  /** 'admin' | 'contributor' | 'restricted_contributor' */
+  role: string
+  displayName: string
+}
+
+/** Payload pour CaregiverRevoked */
+export interface CaregiverRevokedPayload {
+  caregiverId: string
+}
+
+/** Union discriminée des payloads */
+export type DomainEventPayload =
+  | { type: 'DoseAdministered'; payload: DoseAdministeredPayload }
+  | { type: 'PumpReplaced'; payload: PumpReplacedPayload }
+  | { type: 'PlanUpdated'; payload: PlanUpdatedPayload }
+  | { type: 'CaregiverInvited'; payload: CaregiverInvitedPayload }
+  | { type: 'CaregiverRevoked'; payload: CaregiverRevokedPayload }
+
+/**
+ * Événement non signé : données à signer avant insertion dans le document.
+ * L'id et l'occurredAtMs sont générés par l'appelant.
+ */
+export interface UnsignedEvent {
+  id: string
+  deviceId: string
+  occurredAtMs: number
+  event: DomainEventPayload
+}
+```
+
+- [ ] **Step 2 : Vérifier typecheck**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm typecheck
+```
+
+Expected : 0 erreurs.
+
+- [ ] **Step 3 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add packages/sync/src/events/types.ts
+git -C /Users/martial/development/asthma-tracker commit -m "feat(sync): types d'événements domaine (DoseAdministered, PumpReplaced, etc.)
+
+Union discriminée DomainEventPayload + UnsignedEvent.
+5 types : DoseAdministered, PumpReplaced, PlanUpdated, CaregiverInvited,
+CaregiverRevoked. Payloads sans Uint8Array (compatibilité JSON/CRDT).
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5 : Signature des événements (Ed25519)
+
+**Files:**
+- Create: `packages/sync/src/events/sign.ts`
+- Create: `packages/sync/src/events/sign.test.ts`
+
+- [ ] **Step 1 : Écrire les tests (rouge)**
+
+Créer `packages/sync/src/events/sign.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { generateSigningKeypair } from '@kinhale/crypto'
+import { signEvent, verifySignedEvent, canonicalBytes } from './sign.js'
+import type { UnsignedEvent } from './types.js'
+
+const makeUnsigned = (): UnsignedEvent => ({
+  id: 'evt-sign-1',
+  deviceId: 'device-001',
+  occurredAtMs: 1_700_000_000_000,
+  event: {
+    type: 'DoseAdministered',
+    payload: {
+      doseId: 'd1',
+      pumpId: 'p1',
+      childId: 'c1',
+      caregiverId: 'cg1',
+      administeredAtMs: 1_700_000_000_000,
+      doseType: 'maintenance',
+      dosesAdministered: 1,
+      symptoms: [],
+      circumstances: [],
+      freeFormTag: null,
+    },
+  },
+})
+
+describe('Event signing', () => {
+  it('signEvent produit un SignedEventRecord avec signatureHex non vide', async () => {
+    const kp = await generateSigningKeypair()
+    const record = await signEvent(makeUnsigned(), kp.secretKey)
+    expect(record.id).toBe('evt-sign-1')
+    expect(record.type).toBe('DoseAdministered')
+    expect(record.signatureHex).toHaveLength(128) // 64 bytes Ed25519 → 128 hex chars
+    expect(record.signerPublicKeyHex).toHaveLength(64) // 32 bytes → 64 hex chars
+    expect(record.deviceId).toBe('device-001')
+  })
+
+  it('verifySignedEvent retourne true pour une signature valide', async () => {
+    const kp = await generateSigningKeypair()
+    const record = await signEvent(makeUnsigned(), kp.secretKey)
+    const valid = await verifySignedEvent(record)
+    expect(valid).toBe(true)
+  })
+
+  it('verifySignedEvent retourne false si le payload est altéré', async () => {
+    const kp = await generateSigningKeypair()
+    const record = await signEvent(makeUnsigned(), kp.secretKey)
+    const tampered = { ...record, payloadJson: JSON.stringify({ doseId: 'HACKED' }) }
+    const valid = await verifySignedEvent(tampered)
+    expect(valid).toBe(false)
+  })
+
+  it('verifySignedEvent retourne false si la signature est corrompue', async () => {
+    const kp = await generateSigningKeypair()
+    const record = await signEvent(makeUnsigned(), kp.secretKey)
+    const corrupted = { ...record, signatureHex: 'a'.repeat(128) }
+    const valid = await verifySignedEvent(corrupted)
+    expect(valid).toBe(false)
+  })
+
+  it('deux signEvent sur le même UnsignedEvent produisent la même signature', async () => {
+    const kp = await generateSigningKeypair()
+    const unsigned = makeUnsigned()
+    const r1 = await signEvent(unsigned, kp.secretKey)
+    const r2 = await signEvent(unsigned, kp.secretKey)
+    expect(r1.signatureHex).toBe(r2.signatureHex)
+  })
+
+  it('canonicalBytes est déterministe', () => {
+    const unsigned = makeUnsigned()
+    const b1 = canonicalBytes(unsigned)
+    const b2 = canonicalBytes(unsigned)
+    expect(Buffer.from(b1).toString('hex')).toBe(Buffer.from(b2).toString('hex'))
+  })
+})
+```
+
+- [ ] **Step 2 : Vérifier que les tests échouent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/events/sign.test.ts
+```
+
+Expected : FAIL (module not found).
+
+- [ ] **Step 3 : Créer sign.ts**
+
+Créer `packages/sync/src/events/sign.ts` :
+
+```typescript
+import { sign, verify } from '@kinhale/crypto'
+import type { SignedEventRecord } from '../doc/schema.js'
+import type { UnsignedEvent } from './types.js'
+
+/**
+ * Retourne les bytes canoniques à signer pour un UnsignedEvent.
+ * Le payload est inclus via payloadJson pour éviter les ambiguités de
+ * sérialisation (order des clés JSON).
+ */
+export function canonicalBytes(unsigned: UnsignedEvent): Uint8Array {
+  const canonical = JSON.stringify({
+    id: unsigned.id,
+    type: unsigned.event.type,
+    payloadJson: JSON.stringify(unsigned.event.payload),
+    deviceId: unsigned.deviceId,
+    occurredAtMs: unsigned.occurredAtMs,
+  })
+  return new TextEncoder().encode(canonical)
+}
+
+/**
+ * Signe un événement domaine avec la clé Ed25519 du device.
+ * Retourne un SignedEventRecord prêt à être inséré dans le document Automerge.
+ */
+export async function signEvent(
+  unsigned: UnsignedEvent,
+  secretKey: Uint8Array,
+): Promise<SignedEventRecord> {
+  // Dériver la clé publique depuis secretKey (libsodium : secretKey = privateKey || publicKey)
+  // La clé secrète libsodium Ed25519 fait 64 bytes : [32 bytes seed][32 bytes publicKey]
+  const signerPublicKey = secretKey.slice(32, 64)
+  const payloadJson = JSON.stringify(unsigned.event.payload)
+  const bytes = canonicalBytes(unsigned)
+  const signature = await sign(bytes, secretKey)
+
+  return {
+    id: unsigned.id,
+    type: unsigned.event.type,
+    payloadJson,
+    signerPublicKeyHex: Buffer.from(signerPublicKey).toString('hex'),
+    signatureHex: Buffer.from(signature).toString('hex'),
+    deviceId: unsigned.deviceId,
+    occurredAtMs: unsigned.occurredAtMs,
+  }
+}
+
+/**
+ * Vérifie la signature Ed25519 d'un SignedEventRecord.
+ * Retourne false (jamais throw) si la signature est invalide ou corrompue.
+ */
+export async function verifySignedEvent(record: SignedEventRecord): Promise<boolean> {
+  try {
+    const unsigned: UnsignedEvent = {
+      id: record.id,
+      deviceId: record.deviceId,
+      occurredAtMs: record.occurredAtMs,
+      event: {
+        type: record.type as UnsignedEvent['event']['type'],
+        payload: JSON.parse(record.payloadJson) as UnsignedEvent['event']['payload'],
+      },
+    }
+    const bytes = canonicalBytes(unsigned)
+    const signature = Buffer.from(record.signatureHex, 'hex')
+    const publicKey = Buffer.from(record.signerPublicKeyHex, 'hex')
+    return await verify(bytes, signature, publicKey)
+  } catch {
+    return false
+  }
+}
+```
+
+- [ ] **Step 4 : Vérifier que les tests passent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/events/sign.test.ts
+```
+
+Expected : 6 tests PASS.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add packages/sync/src/events/sign.ts packages/sync/src/events/sign.test.ts
+git -C /Users/martial/development/asthma-tracker commit -m "feat(sync): signature Ed25519 des événements domaine
+
+signEvent() : signe les canonical bytes (id+type+payloadJson+deviceId+ms).
+verifySignedEvent() : vérifie sans throw (retourne false si invalide).
+canonicalBytes() : sérialisation déterministe JSON.stringify ordonnée.
+Clé publique extraite des 32 derniers bytes de la secretKey libsodium.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6 : appendEvent — mutation du document CRDT
+
+**Files:**
+- Create: `packages/sync/src/events/append.ts`
+- Create: `packages/sync/src/events/append.test.ts`
+
+- [ ] **Step 1 : Écrire les tests (rouge)**
+
+Créer `packages/sync/src/events/append.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { generateSigningKeypair } from '@kinhale/crypto'
+import { createDoc } from '../doc/lifecycle.js'
+import { signEvent } from './sign.js'
+import { appendEvent } from './append.js'
+import type { UnsignedEvent } from './types.js'
+
+const makeUnsigned = (id: string): UnsignedEvent => ({
+  id,
+  deviceId: 'device-001',
+  occurredAtMs: 1_700_000_000_000 + parseInt(id.slice(-1), 10),
+  event: {
+    type: 'DoseAdministered',
+    payload: {
+      doseId: id,
+      pumpId: 'p1',
+      childId: 'c1',
+      caregiverId: 'cg1',
+      administeredAtMs: 1_700_000_000_000,
+      doseType: 'maintenance',
+      dosesAdministered: 1,
+      symptoms: [],
+      circumstances: [],
+      freeFormTag: null,
+    },
+  },
+})
+
+describe('appendEvent', () => {
+  it('ajoute un SignedEventRecord au document', async () => {
+    const kp = await generateSigningKeypair()
+    const doc = createDoc('hh-append-1')
+    const record = await signEvent(makeUnsigned('evt-1'), kp.secretKey)
+    const doc2 = appendEvent(doc, record)
+    expect(doc2.events).toHaveLength(1)
+    expect(doc2.events[0]!.id).toBe('evt-1')
+  })
+
+  it('ne modifie pas le document original (immutabilité Automerge)', async () => {
+    const kp = await generateSigningKeypair()
+    const doc = createDoc('hh-append-2')
+    const record = await signEvent(makeUnsigned('evt-2'), kp.secretKey)
+    const doc2 = appendEvent(doc, record)
+    expect(doc.events).toHaveLength(0)
+    expect(doc2.events).toHaveLength(1)
+  })
+
+  it('plusieurs appendEvent préservent l\'ordre d\'insertion', async () => {
+    const kp = await generateSigningKeypair()
+    let doc = createDoc('hh-append-3')
+    for (let i = 1; i <= 3; i++) {
+      const record = await signEvent(makeUnsigned(`evt-${i}`), kp.secretKey)
+      doc = appendEvent(doc, record)
+    }
+    expect(doc.events).toHaveLength(3)
+    expect(doc.events[0]!.id).toBe('evt-1')
+    expect(doc.events[2]!.id).toBe('evt-3')
+  })
+})
+```
+
+- [ ] **Step 2 : Vérifier que les tests échouent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/events/append.test.ts
+```
+
+Expected : FAIL (module not found).
+
+- [ ] **Step 3 : Créer append.ts**
+
+Créer `packages/sync/src/events/append.ts` :
+
+```typescript
+import * as A from '@automerge/automerge'
+import type { KinhaleDoc } from '../doc/schema.js'
+import type { SignedEventRecord } from '../doc/schema.js'
+
+/**
+ * Ajoute un SignedEventRecord au document Automerge du foyer.
+ * Retourne un nouveau document (Automerge est immutable).
+ * L'appelant doit vérifier la signature avant d'appeler appendEvent.
+ */
+export function appendEvent(
+  doc: A.Doc<KinhaleDoc>,
+  record: SignedEventRecord,
+): A.Doc<KinhaleDoc> {
+  return A.change(doc, (d) => {
+    d.events.push(record)
+  })
+}
+```
+
+- [ ] **Step 4 : Vérifier que les tests passent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/events/append.test.ts
+```
+
+Expected : 3 tests PASS.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add packages/sync/src/events/append.ts packages/sync/src/events/append.test.ts
+git -C /Users/martial/development/asthma-tracker commit -m "feat(sync): appendEvent — insertion signée dans le document CRDT
+
+Wrapper Automerge.change() : append-only, immutable, ordre préservé.
+L'appelant doit vérifier la signature avant l'appel (séparation claire).
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7 : Chiffrement des changes pour la mailbox
+
+**Files:**
+- Create: `packages/sync/src/mailbox/encrypt.ts`
+- Create: `packages/sync/src/mailbox/encrypt.test.ts`
+
+Les deltas Automerge (tableaux de `Uint8Array`) sont sérialisés en JSON de hex, puis chiffrés XChaCha20-Poly1305 avec la clé de groupe du foyer. Le relais ne voit que le blob chiffré.
+
+- [ ] **Step 1 : Écrire les tests (rouge)**
+
+Créer `packages/sync/src/mailbox/encrypt.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { secretboxKeygen } from '@kinhale/crypto'
+import { encryptChanges, decryptChanges } from './encrypt.js'
+import type { EncryptedBlob } from './encrypt.js'
+
+describe('encryptChanges / decryptChanges', () => {
+  it('encryptChanges retourne un EncryptedBlob avec nonce et ciphertext hex', async () => {
+    const key = await secretboxKeygen()
+    const changes = [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])]
+    const blob = await encryptChanges(changes, key)
+    expect(typeof blob.nonce).toBe('string')
+    expect(typeof blob.ciphertext).toBe('string')
+    expect(blob.nonce).toHaveLength(48) // 24 bytes × 2 hex chars
+    expect(blob.ciphertext.length).toBeGreaterThan(0)
+  })
+
+  it('decryptChanges restitue les Uint8Array originaux', async () => {
+    const key = await secretboxKeygen()
+    const original = [new Uint8Array([10, 20, 30]), new Uint8Array([40, 50])]
+    const blob = await encryptChanges(original, key)
+    const restored = await decryptChanges(blob, key)
+    expect(restored).toHaveLength(2)
+    expect(Array.from(restored[0]!)).toEqual([10, 20, 30])
+    expect(Array.from(restored[1]!)).toEqual([40, 50])
+  })
+
+  it('deux encryptChanges du même plaintext → nonces différents', async () => {
+    const key = await secretboxKeygen()
+    const changes = [new Uint8Array([1, 2, 3])]
+    const b1 = await encryptChanges(changes, key)
+    const b2 = await encryptChanges(changes, key)
+    expect(b1.nonce).not.toBe(b2.nonce)
+    expect(b1.ciphertext).not.toBe(b2.ciphertext)
+  })
+
+  it('decryptChanges throw si la clé est incorrecte', async () => {
+    const key1 = await secretboxKeygen()
+    const key2 = await secretboxKeygen()
+    const blob = await encryptChanges([new Uint8Array([1, 2, 3])], key1)
+    await expect(decryptChanges(blob, key2)).rejects.toThrow()
+  })
+
+  it('decryptChanges fonctionne sur liste vide', async () => {
+    const key = await secretboxKeygen()
+    const blob = await encryptChanges([], key)
+    const restored = await decryptChanges(blob, key)
+    expect(restored).toHaveLength(0)
+  })
+})
+```
+
+- [ ] **Step 2 : Vérifier que les tests échouent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/mailbox/encrypt.test.ts
+```
+
+Expected : FAIL (module not found).
+
+- [ ] **Step 3 : Créer encrypt.ts**
+
+Créer `packages/sync/src/mailbox/encrypt.ts` :
+
+```typescript
+import { secretbox, secretboxOpen, secretboxNonce } from '@kinhale/crypto'
+
+/**
+ * Blob chiffré à envoyer au relais.
+ * Nonce et ciphertext sont encodés en hex pour sérialisation JSON.
+ */
+export interface EncryptedBlob {
+  /** Hex, 24 bytes XChaCha20 nonce (48 chars) */
+  readonly nonce: string
+  /** Hex, plaintext chiffré + MAC Poly1305 */
+  readonly ciphertext: string
+}
+
+/**
+ * Chiffre un tableau de Uint8Array (changes Automerge) avec la clé de groupe.
+ * Sérialisation : JSON d'un tableau de hex strings, puis XChaCha20-Poly1305.
+ */
+export async function encryptChanges(
+  changes: Uint8Array[],
+  groupKey: Uint8Array,
+): Promise<EncryptedBlob> {
+  const serialized = JSON.stringify(
+    changes.map((c) => Buffer.from(c).toString('hex')),
+  )
+  const plaintext = new TextEncoder().encode(serialized)
+  const nonce = await secretboxNonce()
+  const ciphertext = await secretbox(plaintext, nonce, groupKey)
+  return {
+    nonce: Buffer.from(nonce).toString('hex'),
+    ciphertext: Buffer.from(ciphertext).toString('hex'),
+  }
+}
+
+/**
+ * Déchiffre un EncryptedBlob et restitue le tableau de Uint8Array d'origine.
+ * Throws si le MAC est invalide (clé incorrecte ou blob corrompu).
+ */
+export async function decryptChanges(
+  blob: EncryptedBlob,
+  groupKey: Uint8Array,
+): Promise<Uint8Array[]> {
+  const nonce = Buffer.from(blob.nonce, 'hex')
+  const ciphertext = Buffer.from(blob.ciphertext, 'hex')
+  const plaintext = await secretboxOpen(ciphertext, nonce, groupKey)
+  const hexArray = JSON.parse(new TextDecoder().decode(plaintext)) as string[]
+  return hexArray.map((h) => Buffer.from(h, 'hex'))
+}
+```
+
+- [ ] **Step 4 : Vérifier que les tests passent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/mailbox/encrypt.test.ts
+```
+
+Expected : 5 tests PASS.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add packages/sync/src/mailbox/encrypt.ts packages/sync/src/mailbox/encrypt.test.ts
+git -C /Users/martial/development/asthma-tracker commit -m "feat(sync): chiffrement XChaCha20 des changes Automerge pour la mailbox
+
+encryptChanges : JSON(hex[]) → XChaCha20-Poly1305 → EncryptedBlob.
+decryptChanges : EncryptedBlob → JSON(hex[]) → Uint8Array[].
+Nonce aléatoire par appel (secretboxNonce). Throw si MAC invalide.
+Le relais reçoit uniquement l'EncryptedBlob opaque.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8 : SyncMessage + index + CI
+
+**Files:**
+- Create: `packages/sync/src/mailbox/message.ts`
+- Create: `packages/sync/src/mailbox/message.test.ts`
+- Create: `packages/sync/src/index.ts`
+
+- [ ] **Step 1 : Écrire les tests pour SyncMessage (rouge)**
+
+Créer `packages/sync/src/mailbox/message.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { encodeSyncMessage, decodeSyncMessage } from './message.js'
+import type { SyncMessage } from './message.js'
+
+const makeMsg = (): SyncMessage => ({
+  mailboxId: 'mailbox-opaque-001',
+  deviceId: 'device-001',
+  blob: { nonce: 'a'.repeat(48), ciphertext: 'b'.repeat(64) },
+  seq: 1,
+  sentAtMs: 1_700_000_000_000,
+})
+
+describe('SyncMessage encode/decode', () => {
+  it('encodeSyncMessage retourne une string JSON valide', () => {
+    const json = encodeSyncMessage(makeMsg())
+    expect(typeof json).toBe('string')
+    const parsed = JSON.parse(json)
+    expect(parsed.mailboxId).toBe('mailbox-opaque-001')
+    expect(parsed.seq).toBe(1)
+  })
+
+  it('decodeSyncMessage restitue le message original', () => {
+    const original = makeMsg()
+    const json = encodeSyncMessage(original)
+    const decoded = decodeSyncMessage(json)
+    expect(decoded.mailboxId).toBe(original.mailboxId)
+    expect(decoded.deviceId).toBe(original.deviceId)
+    expect(decoded.seq).toBe(original.seq)
+    expect(decoded.blob.nonce).toBe(original.blob.nonce)
+  })
+
+  it('decodeSyncMessage throw sur JSON invalide', () => {
+    expect(() => decodeSyncMessage('not json')).toThrow()
+  })
+
+  it('decodeSyncMessage throw si champ obligatoire manquant', () => {
+    const incomplete = JSON.stringify({ mailboxId: 'x', deviceId: 'y' })
+    expect(() => decodeSyncMessage(incomplete)).toThrow('sync: message invalide')
+  })
+})
+```
+
+- [ ] **Step 2 : Vérifier que les tests échouent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/mailbox/message.test.ts
+```
+
+Expected : FAIL (module not found).
+
+- [ ] **Step 3 : Créer message.ts**
+
+Créer `packages/sync/src/mailbox/message.ts` :
+
+```typescript
+import type { EncryptedBlob } from './encrypt.js'
+
+/**
+ * Enveloppe de synchronisation envoyée au relais (WebSocket ou HTTP).
+ * Le relais indexe par mailboxId + seq mais ne peut jamais lire blob.
+ */
+export interface SyncMessage {
+  /** Identifiant opaque du groupe/foyer (ne doit pas révéler l'householdId) */
+  readonly mailboxId: string
+  /** Device émetteur */
+  readonly deviceId: string
+  /** Contenu chiffré : changes Automerge chiffrés XChaCha20 */
+  readonly blob: EncryptedBlob
+  /** Numéro de séquence monotone côté émetteur (pour déduplication relais) */
+  readonly seq: number
+  /** Timestamp d'émission UTC ms */
+  readonly sentAtMs: number
+}
+
+export function encodeSyncMessage(msg: SyncMessage): string {
+  return JSON.stringify(msg)
+}
+
+export function decodeSyncMessage(json: string): SyncMessage {
+  const parsed: unknown = JSON.parse(json)
+  if (!isSyncMessage(parsed)) {
+    throw new Error('sync: message invalide')
+  }
+  return parsed
+}
+
+function isSyncMessage(v: unknown): v is SyncMessage {
+  if (typeof v !== 'object' || v === null) return false
+  const m = v as Record<string, unknown>
+  return (
+    typeof m['mailboxId'] === 'string' &&
+    typeof m['deviceId'] === 'string' &&
+    typeof m['seq'] === 'number' &&
+    typeof m['sentAtMs'] === 'number' &&
+    isEncryptedBlob(m['blob'])
+  )
+}
+
+function isEncryptedBlob(v: unknown): v is EncryptedBlob {
+  if (typeof v !== 'object' || v === null) return false
+  const b = v as Record<string, unknown>
+  return typeof b['nonce'] === 'string' && typeof b['ciphertext'] === 'string'
+}
+```
+
+- [ ] **Step 4 : Vérifier que les tests passent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test src/mailbox/message.test.ts
+```
+
+Expected : 4 tests PASS.
+
+- [ ] **Step 5 : Créer index.ts**
+
+Créer `packages/sync/src/index.ts` :
+
+```typescript
+// Document Automerge
+export type { KinhaleDoc, SignedEventRecord } from './doc/schema.js'
+export { createDoc, loadDoc, saveDoc, getDocChanges, getAllDocChanges, mergeChanges } from './doc/lifecycle.js'
+
+// Événements domaine
+export type {
+  DomainEventType,
+  DomainEventPayload,
+  UnsignedEvent,
+  DoseAdministeredPayload,
+  PumpReplacedPayload,
+  PlanUpdatedPayload,
+  CaregiverInvitedPayload,
+  CaregiverRevokedPayload,
+} from './events/types.js'
+export { canonicalBytes, signEvent, verifySignedEvent } from './events/sign.js'
+export { appendEvent } from './events/append.js'
+
+// Mailbox E2EE
+export type { EncryptedBlob } from './mailbox/encrypt.js'
+export { encryptChanges, decryptChanges } from './mailbox/encrypt.js'
+export type { SyncMessage } from './mailbox/message.js'
+export { encodeSyncMessage, decodeSyncMessage } from './mailbox/message.js'
+```
+
+- [ ] **Step 6 : Lancer la suite complète**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm test
+```
+
+Expected : tous les tests passent (schema + lifecycle + sign + append + encrypt + message).
+
+- [ ] **Step 7 : Typecheck**
+
+```bash
+cd /Users/martial/development/asthma-tracker/packages/sync && pnpm typecheck
+```
+
+Expected : 0 erreurs.
+
+- [ ] **Step 8 : CI racine**
+
+```bash
+cd /Users/martial/development/asthma-tracker && pnpm lint && pnpm typecheck && pnpm test
+```
+
+Expected : 0 erreurs lint, 0 erreurs TypeScript, tous les tests passent.
+
+- [ ] **Step 9 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add packages/sync/src/mailbox/message.ts packages/sync/src/mailbox/message.test.ts packages/sync/src/index.ts
+git -C /Users/martial/development/asthma-tracker commit -m "feat(sync): SyncMessage + index — Plan 2 complet
+
+SyncMessage : enveloppe mailbox (mailboxId, deviceId, blob, seq, sentAtMs).
+encodeSyncMessage / decodeSyncMessage avec validation de structure.
+src/index.ts : exporte tout le package @kinhale/sync.
+CI racine verte : lint + typecheck + tests.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```

--- a/docs/superpowers/plans/2026-04-20-sprint0-plan3-api.md
+++ b/docs/superpowers/plans/2026-04-20-sprint0-plan3-api.md
@@ -1,0 +1,1193 @@
+# Sprint 0 — Plan 3 : apps/api (Fastify 5 skeleton)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Créer `apps/api` — le relais Fastify 5 de Kinhale avec health check, authentification magic link (JWT), schéma Drizzle, et WebSocket relay E2EE.
+
+**Architecture:** `buildApp(env, overrides?)` retourne un `FastifyInstance` testable sans démarrer un vrai serveur. Les plugins (db, jwt) sont enregistrés via `fastify-plugin` pour que leurs décorations soient accessibles globalement. Les tests utilisent `app.inject()` de Fastify et un db mocké injecté via `overrides`. L'email est loggé en console (Resend branché en Sprint 1). Le WebSocket relay stocke les blobs en mémoire pour Sprint 0 (Redis pub/sub en Sprint 1).
+
+**Tech Stack:** Fastify 5, `@fastify/jwt` v9, `@fastify/websocket` v11, `@fastify/cors` v10, `fastify-plugin` v5, Drizzle ORM + `pg`, Zod, `tsx` (dev), Vitest, `@kinhale/crypto` (sha256, randomBytes).
+
+---
+
+## Fichiers créés
+
+```
+apps/api/
+  package.json
+  tsconfig.json
+  vitest.config.ts
+  eslint.config.js
+  src/
+    index.ts                    ← entry point (parseEnv + buildApp + listen)
+    app.ts                      ← buildApp(env, overrides?) factory testable
+    env.ts                      ← Zod schema de validation des variables d'environnement
+    plugins/
+      db.ts                     ← Drizzle + pg plugin (fastify-plugin)
+      jwt.ts                    ← @fastify/jwt plugin (fastify-plugin)
+    routes/
+      health.ts                 ← GET /health
+      health.test.ts
+      auth.ts                   ← POST /auth/magic-link + GET /auth/verify
+      auth.test.ts
+      relay.ts                  ← WebSocket GET /relay
+      relay.test.ts
+    db/
+      schema.ts                 ← pgTable: accounts, devices, magic_links, mailbox_messages
+```
+
+---
+
+## Task 1 : Package scaffold
+
+**Files:**
+- Create: `apps/api/package.json`
+- Create: `apps/api/tsconfig.json`
+- Create: `apps/api/vitest.config.ts`
+- Create: `apps/api/eslint.config.js`
+
+- [ ] **Step 1 : Créer package.json**
+
+Créer `apps/api/package.json` :
+
+```json
+{
+  "name": "@kinhale/api",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "description": "Relais Kinhale — Fastify 5, zero-knowledge, E2EE WebSocket",
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "lint": "eslint --max-warnings=0 .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@fastify/cors": "^10.0.0",
+    "@fastify/jwt": "^9.0.0",
+    "@fastify/websocket": "^11.0.0",
+    "@kinhale/crypto": "workspace:*",
+    "drizzle-orm": "^0.38.0",
+    "fastify": "^5.0.0",
+    "fastify-plugin": "^5.0.0",
+    "pg": "^8.13.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@kinhale/eslint-config": "workspace:*",
+    "@kinhale/tsconfig": "workspace:*",
+    "@types/node": "^22.10.5",
+    "@types/pg": "^8.11.0",
+    "@types/ws": "^8.5.0",
+    "drizzle-kit": "^0.30.0",
+    "eslint": "^9.18.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.2",
+    "ws": "^8.18.0"
+  }
+}
+```
+
+- [ ] **Step 2 : Créer tsconfig.json**
+
+Créer `apps/api/tsconfig.json` :
+
+```json
+{
+  "extends": "@kinhale/tsconfig/library.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}
+```
+
+- [ ] **Step 3 : Créer vitest.config.ts**
+
+Créer `apps/api/vitest.config.ts` :
+
+```typescript
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+})
+```
+
+- [ ] **Step 4 : Créer eslint.config.js**
+
+Créer `apps/api/eslint.config.js` :
+
+```js
+import kinhale from '@kinhale/eslint-config'
+
+export default [
+  ...kinhale,
+  {
+    files: ['src/**/*.ts'],
+    rules: {
+      'no-console': 'off', // le logger Fastify remplace console
+    },
+  },
+  {
+    files: ['src/**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+]
+```
+
+- [ ] **Step 5 : Installer les dépendances**
+
+```bash
+cd /Users/martial/development/asthma-tracker && pnpm install
+```
+
+Expected : `fastify`, `@fastify/jwt`, `@fastify/websocket`, `drizzle-orm`, `pg` installés dans `apps/api/node_modules`.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add apps/api/ pnpm-lock.yaml
+git -C /Users/martial/development/asthma-tracker commit -m "chore(api): scaffold apps/api — Fastify 5 skeleton
+
+package.json, tsconfig, vitest.config, eslint.config.
+Stack : Fastify 5, @fastify/jwt v9, @fastify/websocket v11,
+Drizzle ORM, pg, Zod, tsx (dev runner).
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2 : env.ts + app.ts + index.ts
+
+**Files:**
+- Create: `apps/api/src/env.ts`
+- Create: `apps/api/src/app.ts`
+- Create: `apps/api/src/index.ts`
+
+- [ ] **Step 1 : Créer env.ts**
+
+Créer `apps/api/src/env.ts` :
+
+```typescript
+import { z } from 'zod'
+
+export const EnvSchema = z.object({
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+  PORT: z.coerce.number().int().min(1).max(65535).default(3000),
+  DATABASE_URL: z.string().min(1),
+  JWT_SECRET: z.string().min(32),
+  JWT_ACCESS_TTL: z.string().default('15m'),
+  JWT_REFRESH_TTL: z.string().default('14d'),
+})
+
+export type Env = z.infer<typeof EnvSchema>
+
+export function parseEnv(raw: NodeJS.ProcessEnv = process.env): Env {
+  return EnvSchema.parse(raw)
+}
+
+/** Env de test — toutes les valeurs minimales valides */
+export function testEnv(overrides: Partial<Env> = {}): Env {
+  return {
+    NODE_ENV: 'test',
+    PORT: 3000,
+    DATABASE_URL: 'postgresql://kinhale:kinhale_dev_secret@localhost:5434/kinhale_dev',
+    JWT_SECRET: 'test-jwt-secret-minimum-32-characters-long',
+    JWT_ACCESS_TTL: '15m',
+    JWT_REFRESH_TTL: '14d',
+    ...overrides,
+  }
+}
+```
+
+- [ ] **Step 2 : Créer app.ts**
+
+Créer `apps/api/src/app.ts` :
+
+```typescript
+import Fastify, { type FastifyInstance } from 'fastify'
+import fastifyCors from '@fastify/cors'
+import fastifyWebsocket from '@fastify/websocket'
+import type { Env } from './env.js'
+import dbPlugin, { type DrizzleDb } from './plugins/db.js'
+import jwtPlugin from './plugins/jwt.js'
+import healthRoute from './routes/health.js'
+import authRoute from './routes/auth.js'
+import relayRoute from './routes/relay.js'
+
+declare module 'fastify' {
+  interface FastifyInstance {
+    env: Env
+    db: DrizzleDb
+  }
+}
+
+export interface BuildAppOverrides {
+  /** Injecter un db mocké pour les tests (évite une vraie connexion Postgres) */
+  db?: DrizzleDb
+}
+
+export function buildApp(env: Env, overrides: BuildAppOverrides = {}): FastifyInstance {
+  const app = Fastify({
+    logger: env.NODE_ENV !== 'test',
+  })
+
+  // Env accessible via app.env dans toute l'application
+  app.decorate('env', env)
+
+  // Plugins transversaux
+  void app.register(fastifyCors, { origin: true })
+  void app.register(fastifyWebsocket)
+
+  // DB : injecter le mock si fourni, sinon le vrai plugin
+  if (overrides.db !== undefined) {
+    app.decorate('db', overrides.db)
+  } else {
+    void app.register(dbPlugin)
+  }
+
+  // JWT
+  void app.register(jwtPlugin)
+
+  // Routes
+  void app.register(healthRoute)
+  void app.register(authRoute, { prefix: '/auth' })
+  void app.register(relayRoute, { prefix: '/relay' })
+
+  return app
+}
+```
+
+- [ ] **Step 3 : Créer les plugins stubs (pour que app.ts compile)**
+
+Créer `apps/api/src/plugins/db.ts` (stub — sera complété en Task 4) :
+
+```typescript
+import fp from 'fastify-plugin'
+import { type NodePgDatabase } from 'drizzle-orm/node-postgres'
+import type * as schema from '../db/schema.js'
+
+export type DrizzleDb = NodePgDatabase<typeof schema>
+
+export default fp(async function dbPlugin(_app) {
+  // Implémenté en Task 4
+})
+```
+
+Créer `apps/api/src/plugins/jwt.ts` (stub — sera complété en Task 5) :
+
+```typescript
+import fp from 'fastify-plugin'
+
+export default fp(async function jwtPlugin(_app) {
+  // Implémenté en Task 5
+})
+```
+
+Créer `apps/api/src/db/schema.ts` (stub — sera complété en Task 4) :
+
+```typescript
+// Schéma Drizzle — implémenté en Task 4
+```
+
+Créer `apps/api/src/routes/health.ts` (stub) :
+
+```typescript
+import type { FastifyPluginAsync } from 'fastify'
+
+const healthRoute: FastifyPluginAsync = async (app) => {
+  app.get('/health', async () => ({ status: 'ok' }))
+}
+export default healthRoute
+```
+
+Créer `apps/api/src/routes/auth.ts` (stub) :
+
+```typescript
+import type { FastifyPluginAsync } from 'fastify'
+
+const authRoute: FastifyPluginAsync = async (_app) => {
+  // Implémenté en Task 5
+}
+export default authRoute
+```
+
+Créer `apps/api/src/routes/relay.ts` (stub) :
+
+```typescript
+import type { FastifyPluginAsync } from 'fastify'
+
+const relayRoute: FastifyPluginAsync = async (_app) => {
+  // Implémenté en Task 6
+}
+export default relayRoute
+```
+
+- [ ] **Step 4 : Créer index.ts**
+
+Créer `apps/api/src/index.ts` :
+
+```typescript
+import { parseEnv } from './env.js'
+import { buildApp } from './app.js'
+
+const env = parseEnv()
+const app = buildApp(env)
+
+try {
+  await app.listen({ port: env.PORT, host: '0.0.0.0' })
+} catch (err) {
+  app.log.error(err)
+  process.exit(1)
+}
+```
+
+- [ ] **Step 5 : Typecheck**
+
+```bash
+cd /Users/martial/development/asthma-tracker/apps/api && pnpm typecheck
+```
+
+Expected : 0 erreurs TypeScript.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add apps/api/src/
+git -C /Users/martial/development/asthma-tracker commit -m "feat(api): buildApp factory + env Zod + stubs routes/plugins
+
+buildApp(env, overrides?) : Fastify 5 testable sans serveur réel.
+env.ts : Zod schema (NODE_ENV, PORT, DATABASE_URL, JWT_SECRET).
+testEnv() : helper de test avec valeurs par défaut.
+Stubs : db.ts, jwt.ts, health.ts, auth.ts, relay.ts.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3 : GET /health + tests
+
+**Files:**
+- Modify: `apps/api/src/routes/health.ts`
+- Create: `apps/api/src/routes/health.test.ts`
+
+- [ ] **Step 1 : Écrire les tests (rouge)**
+
+Créer `apps/api/src/routes/health.test.ts` :
+
+```typescript
+import { describe, it, expect } from 'vitest'
+import { buildApp } from '../app.js'
+import { testEnv } from '../env.js'
+import type { BuildAppOverrides } from '../app.js'
+
+// Mock db pour les tests (pas de vraie connexion Postgres)
+const mockDb = {} as BuildAppOverrides['db']
+
+describe('GET /health', () => {
+  it('retourne 200 avec status ok', async () => {
+    const app = buildApp(testEnv(), { db: mockDb })
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/health' })
+    expect(res.statusCode).toBe(200)
+    expect(res.json<{ status: string }>().status).toBe('ok')
+    await app.close()
+  })
+
+  it('retourne version et timestamp', async () => {
+    const app = buildApp(testEnv(), { db: mockDb })
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/health' })
+    const body = res.json<{ status: string; version: string; timestamp: string }>()
+    expect(body.version).toBe('0.1.0')
+    expect(new Date(body.timestamp).getTime()).toBeGreaterThan(0)
+    await app.close()
+  })
+
+  it('retourne 404 sur une route inconnue', async () => {
+    const app = buildApp(testEnv(), { db: mockDb })
+    await app.ready()
+    const res = await app.inject({ method: 'GET', url: '/not-found' })
+    expect(res.statusCode).toBe(404)
+    await app.close()
+  })
+})
+```
+
+- [ ] **Step 2 : Vérifier que les tests échouent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/apps/api && pnpm test src/routes/health.test.ts
+```
+
+Expected : FAIL (version et timestamp manquants dans la réponse actuelle).
+
+- [ ] **Step 3 : Implémenter health.ts**
+
+Remplacer le contenu de `apps/api/src/routes/health.ts` :
+
+```typescript
+import type { FastifyPluginAsync } from 'fastify'
+
+interface HealthResponse {
+  status: 'ok'
+  version: string
+  timestamp: string
+}
+
+const healthRoute: FastifyPluginAsync = async (app) => {
+  app.get<{ Reply: HealthResponse }>('/health', async () => ({
+    status: 'ok',
+    version: '0.1.0',
+    timestamp: new Date().toISOString(),
+  }))
+}
+
+export default healthRoute
+```
+
+- [ ] **Step 4 : Vérifier que les tests passent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/apps/api && pnpm test src/routes/health.test.ts
+```
+
+Expected : 3 tests PASS.
+
+- [ ] **Step 5 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add apps/api/src/routes/health.ts apps/api/src/routes/health.test.ts
+git -C /Users/martial/development/asthma-tracker commit -m "feat(api): GET /health — status ok + version + timestamp
+
+Route de santé testable via Fastify inject (pas de serveur réel).
+Retourne { status: 'ok', version: '0.1.0', timestamp: ISO string }.
+Tests : 200 ok, version + timestamp présents, 404 sur route inconnue.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4 : Drizzle schema + DB plugin
+
+**Files:**
+- Modify: `apps/api/src/db/schema.ts`
+- Modify: `apps/api/src/plugins/db.ts`
+
+**Note importante :** cette tâche ne nécessite pas de tests unitaires (connexion DB réelle). Le typecheck valide la cohérence du schéma.
+
+- [ ] **Step 1 : Implémenter schema.ts**
+
+Remplacer `apps/api/src/db/schema.ts` :
+
+```typescript
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  bigint,
+  boolean,
+} from 'drizzle-orm/pg-core'
+
+/**
+ * Comptes utilisateurs. L'email n'est jamais stocké en clair —
+ * uniquement son SHA-256 (pseudonymisation Loi 25 / RGPD).
+ */
+export const accounts = pgTable('accounts', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  emailHash: text('email_hash').notNull().unique(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})
+
+/**
+ * Devices enregistrés. Chaque device porte une clé publique Ed25519
+ * qui authentifie ses messages. Le householdId lie le device à un foyer.
+ * Aucune donnée santé ici.
+ */
+export const devices = pgTable('devices', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  accountId: uuid('account_id')
+    .notNull()
+    .references(() => accounts.id, { onDelete: 'cascade' }),
+  publicKeyHex: text('public_key_hex').notNull(),
+  householdId: uuid('household_id').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})
+
+/**
+ * Magic links d'authentification. Le token n'est stocké que sous forme
+ * de hash SHA-256 pour éviter toute réutilisation en cas de fuite DB.
+ * TTL : 10 minutes (RM conformité).
+ */
+export const magicLinks = pgTable('magic_links', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  emailHash: text('email_hash').notNull(),
+  tokenHash: text('token_hash').notNull().unique(),
+  expiresAt: timestamp('expires_at').notNull(),
+  usedAt: timestamp('used_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+})
+
+/**
+ * Messages de la mailbox E2EE. Le blob est le JSON de EncryptedBlob
+ * (@kinhale/sync) — le relais ne peut pas déchiffrer son contenu.
+ * TTL : 90 jours, purgé après ack du device destinataire.
+ */
+export const mailboxMessages = pgTable('mailbox_messages', {
+  id: uuid('id').defaultRandom().primaryKey(),
+  householdId: uuid('household_id').notNull(),
+  senderDeviceId: uuid('sender_device_id').notNull(),
+  /** JSON.stringify(EncryptedBlob) — opaque pour le relais */
+  blobJson: text('blob_json').notNull(),
+  seq: bigint('seq', { mode: 'number' }).notNull(),
+  sentAtMs: bigint('sent_at_ms', { mode: 'number' }).notNull(),
+  expiresAt: timestamp('expires_at').notNull(),
+  ackedAt: timestamp('acked_at'),
+})
+```
+
+- [ ] **Step 2 : Implémenter plugins/db.ts**
+
+Remplacer `apps/api/src/plugins/db.ts` :
+
+```typescript
+import fp from 'fastify-plugin'
+import { drizzle, type NodePgDatabase } from 'drizzle-orm/node-postgres'
+import { Pool } from 'pg'
+import * as schema from '../db/schema.js'
+
+export type DrizzleDb = NodePgDatabase<typeof schema>
+
+export default fp(async function dbPlugin(app) {
+  const pool = new Pool({ connectionString: app.env.DATABASE_URL })
+
+  // Vérification de la connexion au démarrage
+  const client = await pool.connect()
+  client.release()
+
+  const db = drizzle(pool, { schema })
+  app.decorate('db', db)
+
+  app.addHook('onClose', async () => {
+    await pool.end()
+  })
+})
+```
+
+- [ ] **Step 3 : Typecheck**
+
+```bash
+cd /Users/martial/development/asthma-tracker/apps/api && pnpm typecheck
+```
+
+Expected : 0 erreurs TypeScript. Vérifier en particulier que `app.db` est correctement typé.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add apps/api/src/db/schema.ts apps/api/src/plugins/db.ts
+git -C /Users/martial/development/asthma-tracker commit -m "feat(api): Drizzle schema + DB plugin (Postgres)
+
+Tables : accounts (email_hash SHA-256), devices (publicKeyHex Ed25519),
+magic_links (tokenHash SHA-256, TTL 10 min), mailbox_messages (blobJson opaque).
+Plugin db.ts : Pool pg + drizzle + onClose cleanup.
+Aucune donnée santé dans le schéma (conforme zero-knowledge).
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5 : JWT plugin + Auth routes
+
+**Files:**
+- Modify: `apps/api/src/plugins/jwt.ts`
+- Modify: `apps/api/src/routes/auth.ts`
+
+- [ ] **Step 1 : Implémenter plugins/jwt.ts**
+
+Remplacer `apps/api/src/plugins/jwt.ts` :
+
+```typescript
+import fp from 'fastify-plugin'
+import fastifyJwt from '@fastify/jwt'
+
+export interface JwtPayload {
+  sub: string       // accountId
+  deviceId: string
+  householdId: string
+  type: 'access' | 'refresh'
+}
+
+declare module '@fastify/jwt' {
+  interface FastifyJWT {
+    payload: JwtPayload
+    user: JwtPayload
+  }
+}
+
+export default fp(async function jwtPlugin(app) {
+  await app.register(fastifyJwt, {
+    secret: app.env.JWT_SECRET,
+  })
+})
+```
+
+- [ ] **Step 2 : Écrire les tests auth (rouge)**
+
+Créer `apps/api/src/routes/auth.test.ts` :
+
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { buildApp } from '../app.js'
+import { testEnv } from '../env.js'
+import type { BuildAppOverrides } from '../app.js'
+import type { DrizzleDb } from '../plugins/db.js'
+
+// Mock partiel du db — on override uniquement les méthodes utilisées
+function makeMockDb(): DrizzleDb {
+  return {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{
+          id: 'account-001',
+          emailHash: 'hash-of-test@example.com',
+          createdAt: new Date(),
+        }]),
+      }),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+  } as unknown as DrizzleDb
+}
+
+describe('POST /auth/magic-link', () => {
+  it('retourne 200 avec message de confirmation', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/magic-link',
+      payload: { email: 'test@example.com' },
+    })
+    expect(res.statusCode).toBe(200)
+    expect(res.json<{ message: string }>().message).toBe('Magic link envoyé')
+    await app.close()
+  })
+
+  it('retourne 400 si email manquant', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/magic-link',
+      payload: {},
+    })
+    expect(res.statusCode).toBe(400)
+    await app.close()
+  })
+
+  it('retourne 400 si email invalide', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+    const res = await app.inject({
+      method: 'POST',
+      url: '/auth/magic-link',
+      payload: { email: 'not-an-email' },
+    })
+    expect(res.statusCode).toBe(400)
+    await app.close()
+  })
+})
+
+describe('GET /auth/verify', () => {
+  it('retourne 400 si token absent', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/auth/verify',
+    })
+    expect(res.statusCode).toBe(400)
+    await app.close()
+  })
+
+  it('retourne 401 si token inconnu (hash non trouvé en DB)', async () => {
+    const db = makeMockDb()
+    // select retourne [] = token non trouvé
+    vi.mocked(db.select).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    } as ReturnType<typeof db.select>)
+
+    const app = buildApp(testEnv(), { db })
+    await app.ready()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/auth/verify?token=unknown-token-64-chars-padding-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    })
+    expect(res.statusCode).toBe(401)
+    await app.close()
+  })
+})
+```
+
+- [ ] **Step 3 : Vérifier que les tests échouent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/apps/api && pnpm test src/routes/auth.test.ts
+```
+
+Expected : FAIL.
+
+- [ ] **Step 4 : Implémenter auth.ts**
+
+Remplacer `apps/api/src/routes/auth.ts` :
+
+```typescript
+import type { FastifyPluginAsync } from 'fastify'
+import { z } from 'zod'
+import { sha256HexFromString, sha256Hex, randomBytes } from '@kinhale/crypto'
+import { magicLinks, accounts, devices } from '../db/schema.js'
+import { eq, and, gt } from 'drizzle-orm'
+
+const MagicLinkBodySchema = z.object({
+  email: z.string().email(),
+})
+
+const VerifyQuerySchema = z.object({
+  token: z.string().min(64),
+})
+
+const authRoute: FastifyPluginAsync = async (app) => {
+  /**
+   * POST /auth/magic-link
+   * Corps : { email: string }
+   * Crée un magic link (TTL 10 min) et le logue en console (Resend en Sprint 1).
+   * Répond toujours 200 pour ne pas exposer si l'email existe ou non (RM conformité).
+   */
+  app.post<{ Body: z.infer<typeof MagicLinkBodySchema> }>(
+    '/magic-link',
+    async (request, reply) => {
+      const result = MagicLinkBodySchema.safeParse(request.body)
+      if (!result.success) {
+        return reply.status(400).send({ error: 'Email invalide' })
+      }
+
+      const { email } = result.data
+      const emailHash = await sha256HexFromString(email.toLowerCase().trim())
+
+      // Génère un token aléatoire 32 bytes → 64 hex chars
+      const tokenBytes = await randomBytes(32)
+      const token = Buffer.from(tokenBytes).toString('hex')
+      const tokenHashBytes = await sha256HexFromString(token)
+
+      const expiresAt = new Date(Date.now() + 10 * 60 * 1000) // 10 minutes
+
+      await app.db.insert(magicLinks).values({
+        emailHash,
+        tokenHash: tokenHashBytes,
+        expiresAt,
+      })
+
+      // Sprint 0 : log du lien (Resend branché en Sprint 1)
+      const magicUrl = `http://localhost:${app.env.PORT}/auth/verify?token=${token}`
+      app.log.info({ magicUrl }, 'Magic link généré (dev only)')
+
+      return reply.status(200).send({ message: 'Magic link envoyé' })
+    },
+  )
+
+  /**
+   * GET /auth/verify?token=xxx
+   * Vérifie le magic link, émet un access JWT 15 min.
+   * Le device doit être déjà enregistré (ou en cours d'onboarding).
+   * Sprint 0 : retourne le token sans device check (simplifié).
+   */
+  app.get<{ Querystring: z.infer<typeof VerifyQuerySchema> }>(
+    '/verify',
+    async (request, reply) => {
+      const result = VerifyQuerySchema.safeParse(request.query)
+      if (!result.success) {
+        return reply.status(400).send({ error: 'Token manquant ou invalide' })
+      }
+
+      const { token } = result.data
+      const tokenHash = await sha256HexFromString(token)
+
+      // Cherche le magic link valide (non utilisé, non expiré)
+      const rows = await app.db
+        .select()
+        .from(magicLinks)
+        .where(
+          and(
+            eq(magicLinks.tokenHash, tokenHash),
+            gt(magicLinks.expiresAt, new Date()),
+          ),
+        )
+
+      if (rows.length === 0) {
+        return reply.status(401).send({ error: 'Token invalide ou expiré' })
+      }
+
+      const link = rows[0]!
+      if (link.usedAt !== null) {
+        return reply.status(401).send({ error: 'Token déjà utilisé' })
+      }
+
+      // Marque le token comme utilisé
+      await app.db
+        .update(magicLinks)
+        .set({ usedAt: new Date() })
+        .where(eq(magicLinks.id, link.id))
+
+      // Cherche ou crée le compte
+      const accountRows = await app.db
+        .select()
+        .from(accounts)
+        .where(eq(accounts.emailHash, link.emailHash))
+
+      let accountId: string
+      if (accountRows.length > 0) {
+        accountId = accountRows[0]!.id
+      } else {
+        const newAccount = await app.db
+          .insert(accounts)
+          .values({ emailHash: link.emailHash })
+          .returning()
+        accountId = newAccount[0]!.id
+      }
+
+      // Sprint 0 : household_id fictif (sera lié au device en Sprint 1)
+      const householdId = accountId
+      const deviceId = accountId
+
+      const accessToken = app.jwt.sign(
+        { sub: accountId, deviceId, householdId, type: 'access' },
+        { expiresIn: app.env.JWT_ACCESS_TTL },
+      )
+
+      return reply.status(200).send({ accessToken })
+    },
+  )
+}
+
+export default authRoute
+```
+
+- [ ] **Step 5 : Vérifier que les tests passent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/apps/api && pnpm test src/routes/auth.test.ts
+```
+
+Expected : 5 tests PASS.
+
+Si un test de mock db échoue à cause du chaînage `.select().from().where()`, ajuster le mock en conséquence — le pattern de mock du Step 2 doit correspondre exactement au chaînage utilisé dans auth.ts.
+
+- [ ] **Step 6 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add apps/api/src/plugins/jwt.ts apps/api/src/routes/auth.ts apps/api/src/routes/auth.test.ts
+git -C /Users/martial/development/asthma-tracker commit -m "feat(api): auth magic link + JWT plugin
+
+POST /auth/magic-link : génère token 32 bytes, hash SHA-256 en DB, TTL 10 min.
+GET /auth/verify : vérifie hash, marque usedAt, émet access JWT 15 min.
+Sprint 0 : magic link loggé en console (Resend branché Sprint 1).
+Email stocké uniquement comme SHA-256 (pseudonymisation Loi 25).
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6 : WebSocket relay
+
+**Files:**
+- Modify: `apps/api/src/routes/relay.ts`
+- Create: `apps/api/src/routes/relay.test.ts`
+
+Le relay WebSocket accepte des `SyncMessage` JSON, les stocke en DB (mailbox_messages) et les diffuse aux autres devices connectés du même foyer. Sprint 0 : routing in-memory (pas de Redis).
+
+- [ ] **Step 1 : Écrire les tests relay (rouge)**
+
+Créer `apps/api/src/routes/relay.test.ts` :
+
+```typescript
+import { describe, it, expect, vi } from 'vitest'
+import { buildApp } from '../app.js'
+import { testEnv } from '../env.js'
+import type { BuildAppOverrides } from '../app.js'
+import type { DrizzleDb } from '../plugins/db.js'
+
+function makeMockDb(): DrizzleDb {
+  return {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue([]),
+    }),
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+  } as unknown as DrizzleDb
+}
+
+describe('GET /relay (WebSocket upgrade)', () => {
+  it('retourne 101 Switching Protocols sur connexion WS valide', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+
+    // Fastify inject ne supporte pas les vraies connexions WS
+    // On vérifie que la route est enregistrée et répond 400 sans upgrade
+    const res = await app.inject({
+      method: 'GET',
+      url: '/relay',
+    })
+    // Sans header Upgrade: websocket, Fastify retourne 400
+    expect(res.statusCode).toBe(400)
+    await app.close()
+  })
+
+  it('retourne 400 si householdId absent dans la query', async () => {
+    const app = buildApp(testEnv(), { db: makeMockDb() })
+    await app.ready()
+    const res = await app.inject({
+      method: 'GET',
+      url: '/relay',
+      headers: { upgrade: 'websocket' },
+    })
+    // Paramètre householdId absent → validation échoue
+    expect([400, 101]).toContain(res.statusCode)
+    await app.close()
+  })
+})
+```
+
+- [ ] **Step 2 : Implémenter relay.ts**
+
+Remplacer `apps/api/src/routes/relay.ts` :
+
+```typescript
+import type { FastifyPluginAsync } from 'fastify'
+import type { WebSocket } from 'ws'
+import { mailboxMessages } from '../db/schema.js'
+
+/**
+ * Map in-memory pour le routing WS multi-device d'un même foyer.
+ * Sprint 0 : mono-node. Sprint 1 : Redis pub/sub pour multi-node.
+ */
+const householdSockets = new Map<string, Set<WebSocket>>()
+
+const relayRoute: FastifyPluginAsync = async (app) => {
+  /**
+   * GET /relay?householdId=xxx&deviceId=yyy
+   * Connexion WebSocket E2EE. Le client envoie des SyncMessage JSON.
+   * Le relay les stocke et les diffuse aux autres devices du foyer.
+   *
+   * Sprint 0 : pas de vérification JWT sur le WS (Auth WS en Sprint 1).
+   * Les blobs sont opaques — le relay ne peut pas les déchiffrer.
+   */
+  app.get(
+    '/',
+    { websocket: true },
+    (socket: WebSocket, request) => {
+      const { householdId, deviceId } = request.query as {
+        householdId?: string
+        deviceId?: string
+      }
+
+      if (!householdId || !deviceId) {
+        socket.close(1008, 'householdId et deviceId requis')
+        return
+      }
+
+      // Enregistre le socket dans la Map du foyer
+      if (!householdSockets.has(householdId)) {
+        householdSockets.set(householdId, new Set())
+      }
+      householdSockets.get(householdId)!.add(socket)
+
+      socket.on('message', async (raw) => {
+        let msg: unknown
+        try {
+          msg = JSON.parse(raw.toString())
+        } catch {
+          socket.send(JSON.stringify({ error: 'JSON invalide' }))
+          return
+        }
+
+        // Valide la structure minimale du SyncMessage
+        if (
+          typeof msg !== 'object' ||
+          msg === null ||
+          typeof (msg as Record<string, unknown>)['blobJson'] !== 'string'
+        ) {
+          socket.send(JSON.stringify({ error: 'SyncMessage invalide' }))
+          return
+        }
+
+        const message = msg as {
+          blobJson: string
+          seq: number
+          sentAtMs: number
+        }
+
+        // Stocke le blob chiffré (opaque pour le relay)
+        const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000) // 90 j
+        await app.db.insert(mailboxMessages).values({
+          householdId,
+          senderDeviceId: deviceId,
+          blobJson: message.blobJson,
+          seq: message.seq ?? 0,
+          sentAtMs: message.sentAtMs ?? Date.now(),
+          expiresAt,
+        })
+
+        // Diffuse aux autres devices du foyer
+        const peers = householdSockets.get(householdId)
+        if (peers) {
+          for (const peer of peers) {
+            if (peer !== socket && peer.readyState === peer.OPEN) {
+              peer.send(raw.toString())
+            }
+          }
+        }
+      })
+
+      socket.on('close', () => {
+        householdSockets.get(householdId)?.delete(socket)
+        if (householdSockets.get(householdId)?.size === 0) {
+          householdSockets.delete(householdId)
+        }
+      })
+
+      socket.on('error', (err) => {
+        app.log.error({ err }, 'WebSocket error')
+      })
+    },
+  )
+}
+
+export default relayRoute
+```
+
+- [ ] **Step 3 : Vérifier que les tests passent**
+
+```bash
+cd /Users/martial/development/asthma-tracker/apps/api && pnpm test src/routes/relay.test.ts
+```
+
+Expected : 2 tests PASS. Note : le test WS via inject est limité (inject ne supporte pas le vrai protocole WS) — les tests d'intégration WS complets viennent en Sprint 1.
+
+- [ ] **Step 4 : Commit**
+
+```bash
+git -C /Users/martial/development/asthma-tracker add apps/api/src/routes/relay.ts apps/api/src/routes/relay.test.ts
+git -C /Users/martial/development/asthma-tracker commit -m "feat(api): WebSocket relay E2EE (Sprint 0, mono-node)
+
+Route GET /relay : connexion WS, réception SyncMessage, stockage
+mailbox_messages (blobJson opaque), diffusion aux peers du foyer.
+Routing in-memory (householdSockets Map) — Redis Sprint 1.
+Blobs opaques : le relay ne déchiffre jamais le contenu.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7 : CI complète
+
+**Files:** aucun nouveau fichier — vérification de l'état complet.
+
+- [ ] **Step 1 : Lancer la suite complète apps/api**
+
+```bash
+cd /Users/martial/development/asthma-tracker/apps/api && pnpm test
+```
+
+Expected : tous les tests passent (health × 3, auth × 5, relay × 2 = 10 tests minimum).
+
+- [ ] **Step 2 : Typecheck**
+
+```bash
+cd /Users/martial/development/asthma-tracker/apps/api && pnpm typecheck
+```
+
+Expected : 0 erreurs TypeScript.
+
+- [ ] **Step 3 : Lint**
+
+```bash
+cd /Users/martial/development/asthma-tracker/apps/api && pnpm lint
+```
+
+Expected : 0 warnings.
+
+- [ ] **Step 4 : CI racine**
+
+```bash
+cd /Users/martial/development/asthma-tracker && pnpm lint && pnpm typecheck && pnpm test
+```
+
+Expected : 0 erreurs, tous les tests passent (domain + crypto + sync + api).
+
+- [ ] **Step 5 : Vérifier que l'API démarre (smoke test)**
+
+```bash
+cd /Users/martial/development/asthma-tracker/apps/api && \
+  DATABASE_URL="postgresql://kinhale:kinhale_dev_secret@localhost:5434/kinhale_dev" \
+  JWT_SECRET="dev-jwt-secret-minimum-32-characters-long" \
+  NODE_ENV=development \
+  timeout 5 tsx src/index.ts || echo "Démarrage OK (timeout attendu)"
+```
+
+Expected : le processus démarre, log Fastify s'affiche, timeout au bout de 5s (comportement normal).
+
+- [ ] **Step 6 : Commit de synthèse si nécessaire**
+
+```bash
+git -C /Users/martial/development/asthma-tracker status
+```
+
+Si des fichiers non commités restent, les stager et commiter :
+
+```bash
+git -C /Users/martial/development/asthma-tracker add -A
+git -C /Users/martial/development/asthma-tracker commit -m "chore(api): CI verte — Plan 3 complet
+
+10 tests (health × 3, auth × 5, relay × 2), 0 erreur lint/typecheck.
+API démarre avec docker-compose (Postgres 5434).
+Smoke test : listen sur PORT 3000.
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,10 +3,15 @@ import kinhale from '@kinhale/eslint-config';
 export default [
   ...kinhale,
   {
-    // Root-level configs (ESM) — assoupli car il s'agit de fichiers de configuration
     files: ['*.{js,mjs,cjs}', '*.config.{js,mjs,cjs,ts}'],
     rules: {
       'no-console': 'off',
+    },
+  },
+  {
+    files: ['**/*.test.ts', '**/*.spec.ts'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
     },
   },
 ];

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -1,0 +1,38 @@
+# Environnement de développement local Kinhale
+
+## Démarrage
+
+```bash
+# Depuis la racine du projet
+docker compose -f infra/docker/docker-compose.yml up -d
+
+# Vérifier que tout est healthy
+docker compose -f infra/docker/docker-compose.yml ps
+```
+
+## Services disponibles
+
+| Service | Port hôte | Port interne | UI |
+|---|---|---|---|
+| PostgreSQL 16 | 5434 | 5432 | — |
+| Redis 7 | 6379 | 6379 | — |
+| Mailpit (SMTP + UI) | 1027 / 8027 | 1025 / 8025 | http://localhost:8027 |
+| MinIO (S3-compatible / R2) | 9000 / 9001 | 9000 / 9001 | http://localhost:9001 |
+
+> **Note ports** : les ports hôtes 5432, 1025 et 8025 sont réservés aux autres projets du workspace.
+> Kinhale utilise 5434 (postgres), 1027/8027 (mailpit) pour éviter les conflits.
+
+## Initialiser MinIO (premier démarrage)
+
+```bash
+docker exec kinhale_minio mc alias set local http://localhost:9000 kinhale kinhale_minio_dev
+docker exec kinhale_minio mc mb local/kinhale-relay-blobs
+```
+
+## Arrêt
+
+```bash
+docker compose -f infra/docker/docker-compose.yml down
+# Pour supprimer les volumes (reset complet) :
+docker compose -f infra/docker/docker-compose.yml down -v
+```

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -12,11 +12,11 @@ services:
       POSTGRES_USER: kinhale
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-kinhale_dev_secret}
     ports:
-      - "5434:5432"
+      - '5434:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U kinhale -d kinhale_dev"]
+      test: ['CMD-SHELL', 'pg_isready -U kinhale -d kinhale_dev']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -27,11 +27,11 @@ services:
     restart: unless-stopped
     command: redis-server --requirepass ${REDIS_PASSWORD:-kinhale_redis_dev}
     ports:
-      - "6379:6379"
+      - '6379:6379'
     volumes:
       - redis_data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "--pass", "${REDIS_PASSWORD:-kinhale_redis_dev}", "ping"]
+      test: ['CMD', 'redis-cli', '--pass', '${REDIS_PASSWORD:-kinhale_redis_dev}', 'ping']
       interval: 10s
       timeout: 5s
       retries: 5
@@ -41,8 +41,8 @@ services:
     container_name: kinhale_mailpit
     restart: unless-stopped
     ports:
-      - "1027:1025"
-      - "8027:8025"
+      - '1027:1025'
+      - '8027:8025'
     environment:
       MP_SMTP_AUTH_ACCEPT_ANY: 1
       MP_SMTP_AUTH_ALLOW_INSECURE: 1
@@ -56,12 +56,12 @@ services:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-kinhale}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-kinhale_minio_dev}
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - '9000:9000'
+      - '9001:9001'
     volumes:
       - minio_data:/data
     healthcheck:
-      test: ["CMD", "mc", "ready", "local"]
+      test: ['CMD', 'mc', 'ready', 'local']
       interval: 30s
       timeout: 20s
       retries: 3

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -1,0 +1,76 @@
+# Environnement de développement local Kinhale
+# Usage : docker compose -f infra/docker/docker-compose.yml up -d
+# Compatible Coolify (production)
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: kinhale_postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: kinhale_dev
+      POSTGRES_USER: kinhale
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-kinhale_dev_secret}
+    ports:
+      - "5434:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U kinhale -d kinhale_dev"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: kinhale_redis
+    restart: unless-stopped
+    command: redis-server --requirepass ${REDIS_PASSWORD:-kinhale_redis_dev}
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "--pass", "${REDIS_PASSWORD:-kinhale_redis_dev}", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: kinhale_mailpit
+    restart: unless-stopped
+    ports:
+      - "1027:1025"
+      - "8027:8025"
+    environment:
+      MP_SMTP_AUTH_ACCEPT_ANY: 1
+      MP_SMTP_AUTH_ALLOW_INSECURE: 1
+
+  minio:
+    image: minio/minio:latest
+    container_name: kinhale_minio
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-kinhale}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-kinhale_minio_dev}
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+volumes:
+  postgres_data:
+  redis_data:
+  minio_data:
+
+networks:
+  default:
+    name: kinhale_dev

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -20,9 +20,13 @@
   "devDependencies": {
     "@kinhale/eslint-config": "workspace:*",
     "@kinhale/tsconfig": "workspace:*",
+    "@types/libsodium-wrappers-sumo": "^0.8.2",
     "@types/node": "^22.10.5",
     "eslint": "^9.18.0",
     "typescript": "^5.7.3",
     "vitest": "^3.0.2"
+  },
+  "dependencies": {
+    "libsodium-wrappers-sumo": "^0.8.4"
   }
 }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -22,6 +22,7 @@
     "@kinhale/tsconfig": "workspace:*",
     "@types/libsodium-wrappers-sumo": "^0.8.2",
     "@types/node": "^22.10.5",
+    "@vitest/coverage-v8": "^3.2.4",
     "eslint": "^9.18.0",
     "typescript": "^5.7.3",
     "vitest": "^3.0.2"

--- a/packages/crypto/src/box/xchacha20.test.ts
+++ b/packages/crypto/src/box/xchacha20.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import {
+  secretboxKeygen,
+  secretboxNonce,
+  secretbox,
+  secretboxOpen,
+} from './xchacha20.js'
+
+describe('XChaCha20-Poly1305', () => {
+  it('génère une clé de 32 octets', async () => {
+    const key = await secretboxKeygen()
+    expect(key).toHaveLength(32)
+  })
+
+  it('génère un nonce de 24 octets', async () => {
+    const nonce = await secretboxNonce()
+    expect(nonce).toHaveLength(24)
+  })
+
+  it('chiffre et déchiffre un blob', async () => {
+    const key = await secretboxKeygen()
+    const nonce = await secretboxNonce()
+    const plaintext = new TextEncoder().encode('données santé chiffrées')
+    const ciphertext = await secretbox(plaintext, nonce, key)
+    expect(ciphertext.length).toBeGreaterThan(plaintext.length)
+    const decrypted = await secretboxOpen(ciphertext, nonce, key)
+    expect(new TextDecoder().decode(decrypted)).toBe('données santé chiffrées')
+  })
+
+  it('rejette un ciphertext altéré', async () => {
+    const key = await secretboxKeygen()
+    const nonce = await secretboxNonce()
+    const plaintext = new TextEncoder().encode('données santé chiffrées')
+    const ciphertext = await secretbox(plaintext, nonce, key)
+    ciphertext[0] ^= 0xff
+    await expect(secretboxOpen(ciphertext, nonce, key)).rejects.toThrow()
+  })
+
+  it('deux nonces différents produisent deux ciphertexts différents', async () => {
+    const key = await secretboxKeygen()
+    const n1 = await secretboxNonce()
+    const n2 = await secretboxNonce()
+    const msg = new TextEncoder().encode('test')
+    const c1 = await secretbox(msg, n1, key)
+    const c2 = await secretbox(msg, n2, key)
+    expect(Buffer.from(c1).toString('hex')).not.toBe(Buffer.from(c2).toString('hex'))
+  })
+})

--- a/packages/crypto/src/box/xchacha20.test.ts
+++ b/packages/crypto/src/box/xchacha20.test.ts
@@ -1,48 +1,43 @@
-import { describe, it, expect } from 'vitest'
-import {
-  secretboxKeygen,
-  secretboxNonce,
-  secretbox,
-  secretboxOpen,
-} from './xchacha20.js'
+import { describe, it, expect } from 'vitest';
+import { secretboxKeygen, secretboxNonce, secretbox, secretboxOpen } from './xchacha20.js';
 
 describe('XChaCha20-Poly1305', () => {
   it('génère une clé de 32 octets', async () => {
-    const key = await secretboxKeygen()
-    expect(key).toHaveLength(32)
-  })
+    const key = await secretboxKeygen();
+    expect(key).toHaveLength(32);
+  });
 
   it('génère un nonce de 24 octets', async () => {
-    const nonce = await secretboxNonce()
-    expect(nonce).toHaveLength(24)
-  })
+    const nonce = await secretboxNonce();
+    expect(nonce).toHaveLength(24);
+  });
 
   it('chiffre et déchiffre un blob', async () => {
-    const key = await secretboxKeygen()
-    const nonce = await secretboxNonce()
-    const plaintext = new TextEncoder().encode('données santé chiffrées')
-    const ciphertext = await secretbox(plaintext, nonce, key)
-    expect(ciphertext.length).toBeGreaterThan(plaintext.length)
-    const decrypted = await secretboxOpen(ciphertext, nonce, key)
-    expect(new TextDecoder().decode(decrypted)).toBe('données santé chiffrées')
-  })
+    const key = await secretboxKeygen();
+    const nonce = await secretboxNonce();
+    const plaintext = new TextEncoder().encode('données santé chiffrées');
+    const ciphertext = await secretbox(plaintext, nonce, key);
+    expect(ciphertext.length).toBeGreaterThan(plaintext.length);
+    const decrypted = await secretboxOpen(ciphertext, nonce, key);
+    expect(new TextDecoder().decode(decrypted)).toBe('données santé chiffrées');
+  });
 
   it('rejette un ciphertext altéré', async () => {
-    const key = await secretboxKeygen()
-    const nonce = await secretboxNonce()
-    const plaintext = new TextEncoder().encode('données santé chiffrées')
-    const ciphertext = await secretbox(plaintext, nonce, key)
-    ciphertext[0] ^= 0xff
-    await expect(secretboxOpen(ciphertext, nonce, key)).rejects.toThrow()
-  })
+    const key = await secretboxKeygen();
+    const nonce = await secretboxNonce();
+    const plaintext = new TextEncoder().encode('données santé chiffrées');
+    const ciphertext = await secretbox(plaintext, nonce, key);
+    ciphertext[0] ^= 0xff;
+    await expect(secretboxOpen(ciphertext, nonce, key)).rejects.toThrow();
+  });
 
   it('deux nonces différents produisent deux ciphertexts différents', async () => {
-    const key = await secretboxKeygen()
-    const n1 = await secretboxNonce()
-    const n2 = await secretboxNonce()
-    const msg = new TextEncoder().encode('test')
-    const c1 = await secretbox(msg, n1, key)
-    const c2 = await secretbox(msg, n2, key)
-    expect(Buffer.from(c1).toString('hex')).not.toBe(Buffer.from(c2).toString('hex'))
-  })
-})
+    const key = await secretboxKeygen();
+    const n1 = await secretboxNonce();
+    const n2 = await secretboxNonce();
+    const msg = new TextEncoder().encode('test');
+    const c1 = await secretbox(msg, n1, key);
+    const c2 = await secretbox(msg, n2, key);
+    expect(Buffer.from(c1).toString('hex')).not.toBe(Buffer.from(c2).toString('hex'));
+  });
+});

--- a/packages/crypto/src/box/xchacha20.ts
+++ b/packages/crypto/src/box/xchacha20.ts
@@ -1,13 +1,13 @@
-import { getSodium } from '../sodium.js'
+import { getSodium } from '../sodium.js';
 
 export async function secretboxKeygen(): Promise<Uint8Array> {
-  const sodium = await getSodium()
-  return sodium.crypto_secretbox_keygen()
+  const sodium = await getSodium();
+  return sodium.crypto_secretbox_keygen();
 }
 
 export async function secretboxNonce(): Promise<Uint8Array> {
-  const sodium = await getSodium()
-  return sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES)
+  const sodium = await getSodium();
+  return sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES);
 }
 
 export async function secretbox(
@@ -15,8 +15,8 @@ export async function secretbox(
   nonce: Uint8Array,
   key: Uint8Array,
 ): Promise<Uint8Array> {
-  const sodium = await getSodium()
-  return sodium.crypto_secretbox_easy(plaintext, nonce, key)
+  const sodium = await getSodium();
+  return sodium.crypto_secretbox_easy(plaintext, nonce, key);
 }
 
 export async function secretboxOpen(
@@ -24,8 +24,8 @@ export async function secretboxOpen(
   nonce: Uint8Array,
   key: Uint8Array,
 ): Promise<Uint8Array> {
-  const sodium = await getSodium()
-  const result = sodium.crypto_secretbox_open_easy(ciphertext, nonce, key)
-  if (!result) throw new Error('crypto: déchiffrement échoué — MAC invalide')
-  return result
+  const sodium = await getSodium();
+  const result = sodium.crypto_secretbox_open_easy(ciphertext, nonce, key);
+  if (!result) throw new Error('crypto: déchiffrement échoué — MAC invalide');
+  return result;
 }

--- a/packages/crypto/src/box/xchacha20.ts
+++ b/packages/crypto/src/box/xchacha20.ts
@@ -1,0 +1,31 @@
+import { getSodium } from '../sodium.js'
+
+export async function secretboxKeygen(): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.crypto_secretbox_keygen()
+}
+
+export async function secretboxNonce(): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES)
+}
+
+export async function secretbox(
+  plaintext: Uint8Array,
+  nonce: Uint8Array,
+  key: Uint8Array,
+): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.crypto_secretbox_easy(plaintext, nonce, key)
+}
+
+export async function secretboxOpen(
+  ciphertext: Uint8Array,
+  nonce: Uint8Array,
+  key: Uint8Array,
+): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  const result = sodium.crypto_secretbox_open_easy(ciphertext, nonce, key)
+  if (!result) throw new Error('crypto: déchiffrement échoué — MAC invalide')
+  return result
+}

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,1 +1,7 @@
-export { CRYPTO_UNAVAILABLE_MESSAGE, sha256Hex, sha256HexFromString } from './hash/sha256';
+export { CRYPTO_UNAVAILABLE_MESSAGE, sha256Hex, sha256HexFromString } from './hash/sha256.js'
+export { getSodium } from './sodium.js'
+export { generateSigningKeypair, sign, verify } from './sign/ed25519.js'
+export type { SigningKeypair } from './sign/ed25519.js'
+export { secretboxKeygen, secretboxNonce, secretbox, secretboxOpen } from './box/xchacha20.js'
+export { deriveKey, generateSalt, ARGON2ID_PARAMS } from './kdf/argon2id.js'
+export { randomBytes } from './random/random.js'

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,7 +1,7 @@
-export { CRYPTO_UNAVAILABLE_MESSAGE, sha256Hex, sha256HexFromString } from './hash/sha256.js'
-export { getSodium } from './sodium.js'
-export { generateSigningKeypair, sign, verify } from './sign/ed25519.js'
-export type { SigningKeypair } from './sign/ed25519.js'
-export { secretboxKeygen, secretboxNonce, secretbox, secretboxOpen } from './box/xchacha20.js'
-export { deriveKey, generateSalt, ARGON2ID_PARAMS } from './kdf/argon2id.js'
-export { randomBytes } from './random/random.js'
+export { CRYPTO_UNAVAILABLE_MESSAGE, sha256Hex, sha256HexFromString } from './hash/sha256.js';
+export { getSodium } from './sodium.js';
+export { generateSigningKeypair, sign, verify } from './sign/ed25519.js';
+export type { SigningKeypair } from './sign/ed25519.js';
+export { secretboxKeygen, secretboxNonce, secretbox, secretboxOpen } from './box/xchacha20.js';
+export { deriveKey, generateSalt, ARGON2ID_PARAMS } from './kdf/argon2id.js';
+export { randomBytes } from './random/random.js';

--- a/packages/crypto/src/kdf/argon2id.test.ts
+++ b/packages/crypto/src/kdf/argon2id.test.ts
@@ -1,32 +1,32 @@
-import { describe, it, expect } from 'vitest'
-import { deriveKey, generateSalt, ARGON2ID_PARAMS } from './argon2id.js'
+import { describe, it, expect } from 'vitest';
+import { deriveKey, generateSalt, ARGON2ID_PARAMS } from './argon2id.js';
 
 describe('Argon2id', () => {
   it('dérive une clé de longueur demandée', async () => {
-    const salt = await generateSalt()
-    const key = await deriveKey('recovery seed mnemonic 24 words', salt, 32)
-    expect(key).toHaveLength(32)
-  }, 15_000)
+    const salt = await generateSalt();
+    const key = await deriveKey('recovery seed mnemonic 24 words', salt, 32);
+    expect(key).toHaveLength(32);
+  }, 15_000);
 
   it('deux appels identiques produisent la même clé', async () => {
-    const salt = await generateSalt()
-    const password = 'correct horse battery staple'
-    const k1 = await deriveKey(password, salt, 32)
-    const k2 = await deriveKey(password, salt, 32)
-    expect(Buffer.from(k1).toString('hex')).toBe(Buffer.from(k2).toString('hex'))
-  }, 30_000)
+    const salt = await generateSalt();
+    const password = 'correct horse battery staple';
+    const k1 = await deriveKey(password, salt, 32);
+    const k2 = await deriveKey(password, salt, 32);
+    expect(Buffer.from(k1).toString('hex')).toBe(Buffer.from(k2).toString('hex'));
+  }, 30_000);
 
   it('un salt différent produit une clé différente', async () => {
-    const s1 = await generateSalt()
-    const s2 = await generateSalt()
-    const password = 'correct horse battery staple'
-    const k1 = await deriveKey(password, s1, 32)
-    const k2 = await deriveKey(password, s2, 32)
-    expect(Buffer.from(k1).toString('hex')).not.toBe(Buffer.from(k2).toString('hex'))
-  }, 30_000)
+    const s1 = await generateSalt();
+    const s2 = await generateSalt();
+    const password = 'correct horse battery staple';
+    const k1 = await deriveKey(password, s1, 32);
+    const k2 = await deriveKey(password, s2, 32);
+    expect(Buffer.from(k1).toString('hex')).not.toBe(Buffer.from(k2).toString('hex'));
+  }, 30_000);
 
   it('expose les paramètres Argon2id conformes OWASP 2024', () => {
-    expect(ARGON2ID_PARAMS.memoryCost).toBeGreaterThanOrEqual(65536)
-    expect(ARGON2ID_PARAMS.timeCost).toBeGreaterThanOrEqual(3)
-  })
-})
+    expect(ARGON2ID_PARAMS.memoryCost).toBeGreaterThanOrEqual(65536);
+    expect(ARGON2ID_PARAMS.timeCost).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/packages/crypto/src/kdf/argon2id.test.ts
+++ b/packages/crypto/src/kdf/argon2id.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { deriveKey, generateSalt, ARGON2ID_PARAMS } from './argon2id.js'
+
+describe('Argon2id', () => {
+  it('dérive une clé de longueur demandée', async () => {
+    const salt = await generateSalt()
+    const key = await deriveKey('recovery seed mnemonic 24 words', salt, 32)
+    expect(key).toHaveLength(32)
+  }, 15_000)
+
+  it('deux appels identiques produisent la même clé', async () => {
+    const salt = await generateSalt()
+    const password = 'correct horse battery staple'
+    const k1 = await deriveKey(password, salt, 32)
+    const k2 = await deriveKey(password, salt, 32)
+    expect(Buffer.from(k1).toString('hex')).toBe(Buffer.from(k2).toString('hex'))
+  }, 30_000)
+
+  it('un salt différent produit une clé différente', async () => {
+    const s1 = await generateSalt()
+    const s2 = await generateSalt()
+    const password = 'correct horse battery staple'
+    const k1 = await deriveKey(password, s1, 32)
+    const k2 = await deriveKey(password, s2, 32)
+    expect(Buffer.from(k1).toString('hex')).not.toBe(Buffer.from(k2).toString('hex'))
+  }, 30_000)
+
+  it('expose les paramètres Argon2id conformes OWASP 2024', () => {
+    expect(ARGON2ID_PARAMS.memoryCost).toBeGreaterThanOrEqual(65536)
+    expect(ARGON2ID_PARAMS.timeCost).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/packages/crypto/src/kdf/argon2id.ts
+++ b/packages/crypto/src/kdf/argon2id.ts
@@ -1,0 +1,28 @@
+import { getSodium } from '../sodium.js'
+
+export const ARGON2ID_PARAMS = {
+  memoryCost: 65536,
+  timeCost: 3,
+  parallelism: 1,
+} as const
+
+export async function generateSalt(): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.randombytes_buf(sodium.crypto_pwhash_SALTBYTES)
+}
+
+export async function deriveKey(
+  password: string,
+  salt: Uint8Array,
+  outputLen: number,
+): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.crypto_pwhash(
+    outputLen,
+    password,
+    salt,
+    ARGON2ID_PARAMS.timeCost,
+    ARGON2ID_PARAMS.memoryCost * 1024,
+    sodium.crypto_pwhash_ALG_ARGON2ID13,
+  )
+}

--- a/packages/crypto/src/kdf/argon2id.ts
+++ b/packages/crypto/src/kdf/argon2id.ts
@@ -1,14 +1,14 @@
-import { getSodium } from '../sodium.js'
+import { getSodium } from '../sodium.js';
 
 export const ARGON2ID_PARAMS = {
   memoryCost: 65536,
   timeCost: 3,
   parallelism: 1,
-} as const
+} as const;
 
 export async function generateSalt(): Promise<Uint8Array> {
-  const sodium = await getSodium()
-  return sodium.randombytes_buf(sodium.crypto_pwhash_SALTBYTES)
+  const sodium = await getSodium();
+  return sodium.randombytes_buf(sodium.crypto_pwhash_SALTBYTES);
 }
 
 export async function deriveKey(
@@ -16,7 +16,7 @@ export async function deriveKey(
   salt: Uint8Array,
   outputLen: number,
 ): Promise<Uint8Array> {
-  const sodium = await getSodium()
+  const sodium = await getSodium();
   return sodium.crypto_pwhash(
     outputLen,
     password,
@@ -24,5 +24,5 @@ export async function deriveKey(
     ARGON2ID_PARAMS.timeCost,
     ARGON2ID_PARAMS.memoryCost * 1024,
     sodium.crypto_pwhash_ALG_ARGON2ID13,
-  )
+  );
 }

--- a/packages/crypto/src/kdf/index.ts
+++ b/packages/crypto/src/kdf/index.ts
@@ -1,0 +1,1 @@
+export { deriveKey, generateSalt, ARGON2ID_PARAMS } from './argon2id.js'

--- a/packages/crypto/src/kdf/index.ts
+++ b/packages/crypto/src/kdf/index.ts
@@ -1,1 +1,1 @@
-export { deriveKey, generateSalt, ARGON2ID_PARAMS } from './argon2id.js'
+export { deriveKey, generateSalt, ARGON2ID_PARAMS } from './argon2id.js';

--- a/packages/crypto/src/random/random.test.ts
+++ b/packages/crypto/src/random/random.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { randomBytes } from './random.js'
+
+describe('randomBytes', () => {
+  it('génère N octets aléatoires', async () => {
+    const bytes = await randomBytes(32)
+    expect(bytes).toHaveLength(32)
+  })
+
+  it('deux appels produisent des valeurs différentes', async () => {
+    const a = await randomBytes(32)
+    const b = await randomBytes(32)
+    expect(Buffer.from(a).toString('hex')).not.toBe(Buffer.from(b).toString('hex'))
+  })
+})

--- a/packages/crypto/src/random/random.test.ts
+++ b/packages/crypto/src/random/random.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect } from 'vitest'
-import { randomBytes } from './random.js'
+import { describe, it, expect } from 'vitest';
+import { randomBytes } from './random.js';
 
 describe('randomBytes', () => {
   it('génère N octets aléatoires', async () => {
-    const bytes = await randomBytes(32)
-    expect(bytes).toHaveLength(32)
-  })
+    const bytes = await randomBytes(32);
+    expect(bytes).toHaveLength(32);
+  });
 
   it('deux appels produisent des valeurs différentes', async () => {
-    const a = await randomBytes(32)
-    const b = await randomBytes(32)
-    expect(Buffer.from(a).toString('hex')).not.toBe(Buffer.from(b).toString('hex'))
-  })
-})
+    const a = await randomBytes(32);
+    const b = await randomBytes(32);
+    expect(Buffer.from(a).toString('hex')).not.toBe(Buffer.from(b).toString('hex'));
+  });
+});

--- a/packages/crypto/src/random/random.ts
+++ b/packages/crypto/src/random/random.ts
@@ -1,6 +1,6 @@
-import { getSodium } from '../sodium.js'
+import { getSodium } from '../sodium.js';
 
 export async function randomBytes(n: number): Promise<Uint8Array> {
-  const sodium = await getSodium()
-  return sodium.randombytes_buf(n)
+  const sodium = await getSodium();
+  return sodium.randombytes_buf(n);
 }

--- a/packages/crypto/src/random/random.ts
+++ b/packages/crypto/src/random/random.ts
@@ -1,0 +1,6 @@
+import { getSodium } from '../sodium.js'
+
+export async function randomBytes(n: number): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.randombytes_buf(n)
+}

--- a/packages/crypto/src/sign/ed25519.test.ts
+++ b/packages/crypto/src/sign/ed25519.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import {
+  generateSigningKeypair,
+  sign,
+  verify,
+} from './ed25519.js'
+
+describe('Ed25519', () => {
+  it('génère une paire de clés valide (32 + 64 octets)', async () => {
+    const kp = await generateSigningKeypair()
+    expect(kp.publicKey).toHaveLength(32)
+    expect(kp.secretKey).toHaveLength(64)
+  })
+
+  it('signe un message et le vérifie correctement', async () => {
+    const kp = await generateSigningKeypair()
+    const message = new TextEncoder().encode('événement:dose_administered')
+    const sig = await sign(message, kp.secretKey)
+    expect(sig).toHaveLength(64)
+    const ok = await verify(message, sig, kp.publicKey)
+    expect(ok).toBe(true)
+  })
+
+  it('rejette une signature modifiée', async () => {
+    const kp = await generateSigningKeypair()
+    const message = new TextEncoder().encode('événement:dose_administered')
+    const sig = await sign(message, kp.secretKey)
+    sig[0] ^= 0xff
+    const ok = await verify(message, sig, kp.publicKey)
+    expect(ok).toBe(false)
+  })
+
+  it('rejette une signature avec la mauvaise clé publique', async () => {
+    const kp1 = await generateSigningKeypair()
+    const kp2 = await generateSigningKeypair()
+    const message = new TextEncoder().encode('événement:dose_administered')
+    const sig = await sign(message, kp1.secretKey)
+    const ok = await verify(message, sig, kp2.publicKey)
+    expect(ok).toBe(false)
+  })
+})

--- a/packages/crypto/src/sign/ed25519.test.ts
+++ b/packages/crypto/src/sign/ed25519.test.ts
@@ -1,41 +1,37 @@
-import { describe, it, expect } from 'vitest'
-import {
-  generateSigningKeypair,
-  sign,
-  verify,
-} from './ed25519.js'
+import { describe, it, expect } from 'vitest';
+import { generateSigningKeypair, sign, verify } from './ed25519.js';
 
 describe('Ed25519', () => {
   it('génère une paire de clés valide (32 + 64 octets)', async () => {
-    const kp = await generateSigningKeypair()
-    expect(kp.publicKey).toHaveLength(32)
-    expect(kp.secretKey).toHaveLength(64)
-  })
+    const kp = await generateSigningKeypair();
+    expect(kp.publicKey).toHaveLength(32);
+    expect(kp.secretKey).toHaveLength(64);
+  });
 
   it('signe un message et le vérifie correctement', async () => {
-    const kp = await generateSigningKeypair()
-    const message = new TextEncoder().encode('événement:dose_administered')
-    const sig = await sign(message, kp.secretKey)
-    expect(sig).toHaveLength(64)
-    const ok = await verify(message, sig, kp.publicKey)
-    expect(ok).toBe(true)
-  })
+    const kp = await generateSigningKeypair();
+    const message = new TextEncoder().encode('événement:dose_administered');
+    const sig = await sign(message, kp.secretKey);
+    expect(sig).toHaveLength(64);
+    const ok = await verify(message, sig, kp.publicKey);
+    expect(ok).toBe(true);
+  });
 
   it('rejette une signature modifiée', async () => {
-    const kp = await generateSigningKeypair()
-    const message = new TextEncoder().encode('événement:dose_administered')
-    const sig = await sign(message, kp.secretKey)
-    sig[0] ^= 0xff
-    const ok = await verify(message, sig, kp.publicKey)
-    expect(ok).toBe(false)
-  })
+    const kp = await generateSigningKeypair();
+    const message = new TextEncoder().encode('événement:dose_administered');
+    const sig = await sign(message, kp.secretKey);
+    sig[0] ^= 0xff;
+    const ok = await verify(message, sig, kp.publicKey);
+    expect(ok).toBe(false);
+  });
 
   it('rejette une signature avec la mauvaise clé publique', async () => {
-    const kp1 = await generateSigningKeypair()
-    const kp2 = await generateSigningKeypair()
-    const message = new TextEncoder().encode('événement:dose_administered')
-    const sig = await sign(message, kp1.secretKey)
-    const ok = await verify(message, sig, kp2.publicKey)
-    expect(ok).toBe(false)
-  })
-})
+    const kp1 = await generateSigningKeypair();
+    const kp2 = await generateSigningKeypair();
+    const message = new TextEncoder().encode('événement:dose_administered');
+    const sig = await sign(message, kp1.secretKey);
+    const ok = await verify(message, sig, kp2.publicKey);
+    expect(ok).toBe(false);
+  });
+});

--- a/packages/crypto/src/sign/ed25519.ts
+++ b/packages/crypto/src/sign/ed25519.ts
@@ -1,22 +1,19 @@
-import { getSodium } from '../sodium.js'
+import { getSodium } from '../sodium.js';
 
 export interface SigningKeypair {
-  publicKey: Uint8Array
-  secretKey: Uint8Array
+  publicKey: Uint8Array;
+  secretKey: Uint8Array;
 }
 
 export async function generateSigningKeypair(): Promise<SigningKeypair> {
-  const sodium = await getSodium()
-  const kp = sodium.crypto_sign_keypair()
-  return { publicKey: kp.publicKey, secretKey: kp.privateKey }
+  const sodium = await getSodium();
+  const kp = sodium.crypto_sign_keypair();
+  return { publicKey: kp.publicKey, secretKey: kp.privateKey };
 }
 
-export async function sign(
-  message: Uint8Array,
-  secretKey: Uint8Array,
-): Promise<Uint8Array> {
-  const sodium = await getSodium()
-  return sodium.crypto_sign_detached(message, secretKey)
+export async function sign(message: Uint8Array, secretKey: Uint8Array): Promise<Uint8Array> {
+  const sodium = await getSodium();
+  return sodium.crypto_sign_detached(message, secretKey);
 }
 
 export async function verify(
@@ -24,10 +21,10 @@ export async function verify(
   signature: Uint8Array,
   publicKey: Uint8Array,
 ): Promise<boolean> {
-  const sodium = await getSodium()
+  const sodium = await getSodium();
   try {
-    return sodium.crypto_sign_verify_detached(signature, message, publicKey)
+    return sodium.crypto_sign_verify_detached(signature, message, publicKey);
   } catch {
-    return false
+    return false;
   }
 }

--- a/packages/crypto/src/sign/ed25519.ts
+++ b/packages/crypto/src/sign/ed25519.ts
@@ -1,0 +1,33 @@
+import { getSodium } from '../sodium.js'
+
+export interface SigningKeypair {
+  publicKey: Uint8Array
+  secretKey: Uint8Array
+}
+
+export async function generateSigningKeypair(): Promise<SigningKeypair> {
+  const sodium = await getSodium()
+  const kp = sodium.crypto_sign_keypair()
+  return { publicKey: kp.publicKey, secretKey: kp.privateKey }
+}
+
+export async function sign(
+  message: Uint8Array,
+  secretKey: Uint8Array,
+): Promise<Uint8Array> {
+  const sodium = await getSodium()
+  return sodium.crypto_sign_detached(message, secretKey)
+}
+
+export async function verify(
+  message: Uint8Array,
+  signature: Uint8Array,
+  publicKey: Uint8Array,
+): Promise<boolean> {
+  const sodium = await getSodium()
+  try {
+    return sodium.crypto_sign_verify_detached(signature, message, publicKey)
+  } catch {
+    return false
+  }
+}

--- a/packages/crypto/src/sodium.test.ts
+++ b/packages/crypto/src/sodium.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { getSodium } from './sodium.js'
+
+describe('getSodium', () => {
+  it('retourne une instance libsodium initialisée', async () => {
+    const sodium = await getSodium()
+    expect(sodium.SODIUM_VERSION_STRING).toMatch(/^\d+\.\d+\.\d+$/)
+  })
+
+  it('retourne la même instance au second appel', async () => {
+    const a = await getSodium()
+    const b = await getSodium()
+    expect(a).toBe(b)
+  })
+})

--- a/packages/crypto/src/sodium.test.ts
+++ b/packages/crypto/src/sodium.test.ts
@@ -12,4 +12,10 @@ describe('getSodium', () => {
     const b = await getSodium()
     expect(a).toBe(b)
   })
+
+  it('retourne la même instance avec appels parallèles simultanés', async () => {
+    const [a, b, c] = await Promise.all([getSodium(), getSodium(), getSodium()])
+    expect(a).toBe(b)
+    expect(b).toBe(c)
+  })
 })

--- a/packages/crypto/src/sodium.test.ts
+++ b/packages/crypto/src/sodium.test.ts
@@ -1,21 +1,21 @@
-import { describe, it, expect } from 'vitest'
-import { getSodium } from './sodium.js'
+import { describe, it, expect } from 'vitest';
+import { getSodium } from './sodium.js';
 
 describe('getSodium', () => {
   it('retourne une instance libsodium initialisée', async () => {
-    const sodium = await getSodium()
-    expect(sodium.SODIUM_VERSION_STRING).toMatch(/^\d+\.\d+\.\d+$/)
-  })
+    const sodium = await getSodium();
+    expect(sodium.SODIUM_VERSION_STRING).toMatch(/^\d+\.\d+\.\d+$/);
+  });
 
   it('retourne la même instance au second appel', async () => {
-    const a = await getSodium()
-    const b = await getSodium()
-    expect(a).toBe(b)
-  })
+    const a = await getSodium();
+    const b = await getSodium();
+    expect(a).toBe(b);
+  });
 
   it('retourne la même instance avec appels parallèles simultanés', async () => {
-    const [a, b, c] = await Promise.all([getSodium(), getSodium(), getSodium()])
-    expect(a).toBe(b)
-    expect(b).toBe(c)
-  })
-})
+    const [a, b, c] = await Promise.all([getSodium(), getSodium(), getSodium()]);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+});

--- a/packages/crypto/src/sodium.ts
+++ b/packages/crypto/src/sodium.ts
@@ -1,8 +1,8 @@
-import _sodium from 'libsodium-wrappers-sumo'
+import _sodium from 'libsodium-wrappers-sumo';
 
-let _instance: Promise<typeof _sodium> | null = null
+let _instance: Promise<typeof _sodium> | null = null;
 
 export async function getSodium(): Promise<typeof _sodium> {
-  _instance ??= _sodium.ready.then(() => _sodium)
-  return _instance
+  _instance ??= _sodium.ready.then(() => _sodium);
+  return _instance;
 }

--- a/packages/crypto/src/sodium.ts
+++ b/packages/crypto/src/sodium.ts
@@ -1,11 +1,8 @@
 import _sodium from 'libsodium-wrappers-sumo'
 
-let _ready = false
+let _instance: Promise<typeof _sodium> | null = null
 
 export async function getSodium(): Promise<typeof _sodium> {
-  if (!_ready) {
-    await _sodium.ready
-    _ready = true
-  }
-  return _sodium
+  _instance ??= _sodium.ready.then(() => _sodium)
+  return _instance
 }

--- a/packages/crypto/src/sodium.ts
+++ b/packages/crypto/src/sodium.ts
@@ -1,0 +1,11 @@
+import _sodium from 'libsodium-wrappers-sumo'
+
+let _ready = false
+
+export async function getSodium(): Promise<typeof _sodium> {
+  if (!_ready) {
+    await _sodium.ready
+    _ready = true
+  }
+  return _sodium
+}

--- a/packages/domain/README.md
+++ b/packages/domain/README.md
@@ -23,26 +23,36 @@ src/
 
 | Règle   | Description                                                        | Source specs |
 | ------- | ------------------------------------------------------------------ | ------------ |
-| **RM1** | Un foyer a au moins un Admin en permanence                         | §4, RM1      |
-| **RM2** | Fenêtre de confirmation \[10-120 min\] + rattrapage borné à 24 h    | §4, RM2      |
-| **RM3** | Pas de plan de traitement sur une pompe `rescue`                   | §4, RM3      |
-| **RM4** | Prise `rescue` exige symptôme, circonstance ou tag libre           | §4, RM4      |
-| **RM5** | Notification croisée aux autres aidants actifs non-restricted      | §4, RM5      |
-| **RM6** | Détection double saisie : même pompe + type à moins de 2 min       | §4, RM6      |
-| **RM7** | Décompte doses pompe + alertes `pump_low` / `pump_emptied`         | §4, RM7      |
-| **RM14**| Horodatage serveur autoritaire (`recordedAtUtc`) + flag sync tardive | §4, RM14     |
-| **RM15**| Idempotence des saisies via `clientEventId` (UUID v4)              | §4, RM15     |
-| **RM17**| Rattrapage borné : backfill ≤ 24 h, futur refusé, confirmation au-delà | §4, RM17 |
-| **RM18**| Annulation : 30 min libres pour l'auteur ou un Admin, puis Admin + raison | §4, RM18 |
-| **RM25**| Rappels bornés : 2 relances max (push T+15 min, e-mail T+30 min)   | §4, RM25     |
-| **RM26**| Regroupement notifications peer : ≥ 3 prises/h + cap 15 notif/jour | §4, RM26     |
-| **RM21**| Limite anti-spam : max 10 invitations actives simultanées par foyer | §4, RM21     |
-| **RM22**| Consentement aidant invité : propres données uniquement, pas l'enfant | §4, RM22   |
-| **RM24**| Intégrité rapport : SHA-256 du contenu + timestamp + générateur (pied PDF) | §4, RM24 |
-| **RM27**| Disclaimer omniprésent aux 4 surfaces (onboarding, CGU, rapport, À propos) | §4, RM27 |
-| **RM28**| Purge invitations : `expired > 30 j`, `consumed > 90 j`, `revoked > 30 j` | §4, RM28 |
+| **RM1**  | Un foyer a au moins un Admin en permanence                                  | §4, RM1  |
+| **RM2**  | Fenêtre de confirmation \[10-120 min\] + rattrapage borné à 24 h            | §4, RM2  |
+| **RM3**  | Pas de plan de traitement sur une pompe `rescue`                            | §4, RM3  |
+| **RM4**  | Prise `rescue` exige symptôme, circonstance ou tag libre                    | §4, RM4  |
+| **RM5**  | Notification croisée aux autres aidants actifs non-restricted               | §4, RM5  |
+| **RM6**  | Détection double saisie : même pompe + type à moins de 2 min                | §4, RM6  |
+| **RM7**  | Décompte doses pompe + alertes `pump_low` / `pump_emptied`                  | §4, RM7  |
+| **RM8**  | Rapport médecin : agrégation confirmed/voided, fréquence rescue hebdomadaire | §4, RM8 |
+| **RM9**  | Acceptation CGU / Politique : version semver, tolérance NTP, majeurs cohérents | §4, RM9 |
+| **RM10** | Suppression foyer : grâce 7 j, portabilité, pseudonymisation audit          | §4, RM10 |
+| **RM11** | Multi-tenant : anti-IDOR tenant + caregiver (token vs requête)              | §4, RM11 |
+| **RM12** | Session restreinte : TTL 8 h, révocation Admin, idempotente                 | §4, RM12 |
+| **RM13** | Un seul enfant par foyer en v1.0 (1:1, 1:N en v1.1)                         | §4, RM13 |
+| **RM14** | Horodatage serveur autoritaire (`recordedAtUtc`) + flag sync tardive        | §4, RM14 |
+| **RM15** | Idempotence des saisies via `clientEventId` (UUID v4)                       | §4, RM15 |
+| **RM16** | Push opaque : titre/corps génériques, zéro donnée santé dans le payload     | §4, RM16 |
+| **RM17** | Rattrapage borné : backfill ≤ 24 h, futur refusé, confirmation au-delà      | §4, RM17 |
+| **RM18** | Annulation : 30 min libres pour l'auteur ou un Admin, puis Admin + raison   | §4, RM18 |
+| **RM19** | Expiration pompe : warning J-30, blocage à échéance sauf override Admin     | §4, RM19 |
+| **RM20** | Hors-ligne : lecture 30 j + écriture toujours autorisée                     | §4, RM20 |
+| **RM21** | Limite anti-spam : max 10 invitations actives simultanées par foyer         | §4, RM21 |
+| **RM22** | Consentement aidant invité : propres données uniquement, pas l'enfant       | §4, RM22 |
+| **RM23** | Opt-in géoloc par aidant, jamais pour `restricted_contributor`              | §4, RM23 |
+| **RM24** | Intégrité rapport : SHA-256 du contenu + timestamp + générateur (pied PDF)  | §4, RM24 |
+| **RM25** | Rappels bornés : 2 relances max (push T+15 min, e-mail T+30 min)            | §4, RM25 |
+| **RM26** | Regroupement notifications peer : ≥ 3 prises/h + cap 15 notif/jour          | §4, RM26 |
+| **RM27** | Disclaimer omniprésent aux 4 surfaces (onboarding, CGU, rapport, À propos)  | §4, RM27 |
+| **RM28** | Purge invitations : `expired > 30 j`, `consumed > 90 j`, `revoked > 30 j`   | §4, RM28 |
 
-Les règles RM8-RM13, RM16, RM19, RM20, RM23 arrivent dans les PRs suivantes.
+La v1.0 du domaine est **complète à 28/28** : toutes les règles métier définies dans SPECS §4 sont implémentées, testées (`packages/domain/src/rules/`) et exportées par `@kinhale/domain`.
 
 ## Usage
 

--- a/packages/domain/src/errors.ts
+++ b/packages/domain/src/errors.ts
@@ -70,6 +70,21 @@ export type DomainErrorCode =
   | 'RM22_CONSENT_INVITATION_MISMATCH'
   /** RM22 — `consentedAtUtc` est strictement postérieur à `nowUtc` (tricherie d'horloge). */
   | 'RM22_INVALID_CONSENT_TIMESTAMP'
+  /** RM23 — géoloc fournie alors que l'aidant n'a pas opt-in. */
+  | 'RM23_OPT_IN_MISSING'
+  /**
+   * RM23 — géoloc fournie par un `restricted_contributor` : refus strict du
+   * domaine, quelle que soit la préférence prétendue (règle souveraine).
+   */
+  | 'RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE'
+  /** RM23 — coordonnées hors bornes (`lat ∉ [-90,90]` ou `lon ∉ [-180,180]`, ou non finies). */
+  | 'RM23_INVALID_COORDINATES'
+  /**
+   * RM23 — la préférence fournie ne concerne pas l'auteur de la prise
+   * (`authorPreference.caregiverId !== dose.caregiverId`). Vérification
+   * défensive contre un bug d'intégration API.
+   */
+  | 'RM23_PREFERENCE_MISMATCH'
   /** RM24 — `generator` fourni vide ou whitespace-only lors du calcul du pied d'intégrité. */
   | 'RM24_INVALID_GENERATOR'
   /** RM8 — période invalide (ex: `fromUtc` strictement postérieur à `toUtc`). */

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -106,6 +106,17 @@ export {
 export { ensureInviteeConsentValid, isInviteeConsentValid } from './rm22-invitee-consent';
 export type { InviteeConsent } from './rm22-invitee-consent';
 export {
+  ensureGeolocationAllowed,
+  isGeolocationAllowed,
+  isValidGeolocation,
+  sanitizeDoseGeolocation,
+} from './rm23-geolocation-opt-in';
+export type {
+  CaregiverGeolocationPreference,
+  DoseWithOptionalGeolocation,
+  Geolocation,
+} from './rm23-geolocation-opt-in';
+export {
   findInvitationsToPurge,
   PURGE_CONSUMED_AFTER_DAYS,
   PURGE_EXPIRED_AFTER_DAYS,

--- a/packages/domain/src/rules/rm23-geolocation-opt-in.test.ts
+++ b/packages/domain/src/rules/rm23-geolocation-opt-in.test.ts
@@ -1,0 +1,487 @@
+import { describe, expect, it } from 'vitest';
+import { DomainError } from '../errors';
+import type { Role } from '../entities/role';
+import {
+  type CaregiverGeolocationPreference,
+  type DoseWithOptionalGeolocation,
+  type Geolocation,
+  ensureGeolocationAllowed,
+  isGeolocationAllowed,
+  isValidGeolocation,
+  sanitizeDoseGeolocation,
+} from './rm23-geolocation-opt-in';
+
+function makeDose(
+  overrides: Partial<DoseWithOptionalGeolocation> & { caregiverId: string },
+): DoseWithOptionalGeolocation {
+  return {
+    geolocation: null,
+    ...overrides,
+  };
+}
+
+function makePreference(
+  overrides: Partial<CaregiverGeolocationPreference> & { caregiverId: string; role: Role },
+): CaregiverGeolocationPreference {
+  return {
+    geolocationOptIn: false,
+    ...overrides,
+  };
+}
+
+describe('RM23 — isValidGeolocation', () => {
+  it('accepte les bornes inclusives {lat: 90, lon: 180}', () => {
+    expect(isValidGeolocation({ lat: 90, lon: 180 })).toBe(true);
+  });
+
+  it('accepte les bornes inclusives {lat: -90, lon: -180}', () => {
+    expect(isValidGeolocation({ lat: -90, lon: -180 })).toBe(true);
+  });
+
+  it('accepte les coordonnées usuelles', () => {
+    expect(isValidGeolocation({ lat: 45.5, lon: -73.5 })).toBe(true);
+    expect(isValidGeolocation({ lat: 0, lon: 0 })).toBe(true);
+  });
+
+  it('rejette lat > 90', () => {
+    expect(isValidGeolocation({ lat: 91, lon: 0 })).toBe(false);
+  });
+
+  it('rejette lat < -90', () => {
+    expect(isValidGeolocation({ lat: -91, lon: 0 })).toBe(false);
+  });
+
+  it('rejette lon > 180', () => {
+    expect(isValidGeolocation({ lat: 0, lon: 181 })).toBe(false);
+  });
+
+  it('rejette lon < -180', () => {
+    expect(isValidGeolocation({ lat: 0, lon: -181 })).toBe(false);
+  });
+
+  it('rejette NaN sur lat', () => {
+    expect(isValidGeolocation({ lat: Number.NaN, lon: 0 })).toBe(false);
+  });
+
+  it('rejette NaN sur lon', () => {
+    expect(isValidGeolocation({ lat: 0, lon: Number.NaN })).toBe(false);
+  });
+
+  it('rejette Infinity', () => {
+    expect(isValidGeolocation({ lat: Number.POSITIVE_INFINITY, lon: 0 })).toBe(false);
+    expect(isValidGeolocation({ lat: 0, lon: Number.NEGATIVE_INFINITY })).toBe(false);
+  });
+
+  it('considère `null` et `undefined` comme valides (absence = safe)', () => {
+    expect(isValidGeolocation(null)).toBe(true);
+    expect(isValidGeolocation(undefined)).toBe(true);
+  });
+});
+
+describe('RM23 — isGeolocationAllowed', () => {
+  it('OK : pas de géoloc + opt-in true + contributor', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: null });
+    const pref = makePreference({ caregiverId: 'c1', role: 'contributor', geolocationOptIn: true });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(true);
+  });
+
+  it('OK : pas de géoloc + opt-in false', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: null });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(true);
+  });
+
+  it('OK : pas de géoloc + restricted_contributor', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: null });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: false,
+    });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(true);
+  });
+
+  it('OK : géoloc + opt-in true + admin', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(true);
+  });
+
+  it('OK : géoloc + opt-in true + contributor', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'contributor', geolocationOptIn: true });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(true);
+  });
+
+  it('KO : géoloc + opt-in false + contributor', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(false);
+  });
+
+  it('KO : géoloc + opt-in true + restricted_contributor', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(false);
+  });
+
+  it('KO : géoloc + coords hors bornes', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 91, lon: 0 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(false);
+  });
+
+  it('KO : préférence rattachée à un autre caregiver (mismatch défensif)', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c2', role: 'admin', geolocationOptIn: true });
+    expect(isGeolocationAllowed({ dose, authorPreference: pref })).toBe(false);
+  });
+});
+
+describe('RM23 — ensureGeolocationAllowed', () => {
+  it('ne lève pas pour une dose sans géoloc, quel que soit le rôle/opt-in', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: null });
+
+    expect(() =>
+      ensureGeolocationAllowed({
+        dose,
+        authorPreference: makePreference({
+          caregiverId: 'c1',
+          role: 'admin',
+          geolocationOptIn: true,
+        }),
+      }),
+    ).not.toThrow();
+
+    expect(() =>
+      ensureGeolocationAllowed({
+        dose,
+        authorPreference: makePreference({
+          caregiverId: 'c1',
+          role: 'restricted_contributor',
+          geolocationOptIn: false,
+        }),
+      }),
+    ).not.toThrow();
+  });
+
+  it('ne lève pas pour une dose avec géoloc valide + opt-in + rôle non restreint', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+
+    for (const role of ['admin', 'contributor'] as const) {
+      expect(() =>
+        ensureGeolocationAllowed({
+          dose,
+          authorPreference: makePreference({
+            caregiverId: 'c1',
+            role,
+            geolocationOptIn: true,
+          }),
+        }),
+      ).not.toThrow();
+    }
+  });
+
+  it('lève RM23_OPT_IN_MISSING quand géoloc fournie sans opt-in (contributor)', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(DomainError);
+      expect((err as DomainError).code).toBe('RM23_OPT_IN_MISSING');
+      expect((err as DomainError).context).toMatchObject({
+        caregiverId: 'c1',
+        role: 'contributor',
+      });
+    }
+  });
+
+  it('lève RM23_OPT_IN_MISSING quand géoloc fournie sans opt-in (admin)', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: false });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_OPT_IN_MISSING');
+    }
+  });
+
+  it('lève RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE même si opt-in=true (règle souveraine)', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE');
+      expect((err as DomainError).context).toMatchObject({
+        caregiverId: 'c1',
+        role: 'restricted_contributor',
+      });
+    }
+  });
+
+  it('lève RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE en priorité sur OPT_IN_MISSING', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: false,
+    });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      // Priorité : role restreint > opt-in manquant (rôle plus spécifique)
+      expect((err as DomainError).code).toBe('RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE');
+    }
+  });
+
+  it('lève RM23_INVALID_COORDINATES pour lat > 90', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 91, lon: 0 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_INVALID_COORDINATES');
+    }
+  });
+
+  it('lève RM23_INVALID_COORDINATES pour lat < -90', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: -91, lon: 0 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_INVALID_COORDINATES');
+    }
+  });
+
+  it('lève RM23_INVALID_COORDINATES pour lon > 180 ou lon < -180', () => {
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    expect(() =>
+      ensureGeolocationAllowed({
+        dose: makeDose({ caregiverId: 'c1', geolocation: { lat: 0, lon: 181 } }),
+        authorPreference: pref,
+      }),
+    ).toThrowError(DomainError);
+
+    expect(() =>
+      ensureGeolocationAllowed({
+        dose: makeDose({ caregiverId: 'c1', geolocation: { lat: 0, lon: -181 } }),
+        authorPreference: pref,
+      }),
+    ).toThrowError(DomainError);
+  });
+
+  it('lève RM23_INVALID_COORDINATES pour NaN ou Infinity', () => {
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    const cases: Geolocation[] = [
+      { lat: Number.NaN, lon: 0 },
+      { lat: 0, lon: Number.NaN },
+      { lat: Number.POSITIVE_INFINITY, lon: 0 },
+      { lat: 0, lon: Number.NEGATIVE_INFINITY },
+    ];
+
+    for (const geolocation of cases) {
+      try {
+        ensureGeolocationAllowed({
+          dose: makeDose({ caregiverId: 'c1', geolocation }),
+          authorPreference: pref,
+        });
+        expect.fail(`should have thrown for ${JSON.stringify(geolocation)}`);
+      } catch (err) {
+        expect((err as DomainError).code).toBe('RM23_INVALID_COORDINATES');
+      }
+    }
+  });
+
+  it('priorité des refus : role restreint > opt-in manquant > coords invalides', () => {
+    // role restreint > coords invalides : même avec coords KO, c'est le rôle qui tranche
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 999, lon: 999 } });
+    const prefRestricted = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: prefRestricted });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE');
+    }
+
+    // opt-in manquant > coords invalides
+    const prefNoOptIn = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: prefNoOptIn });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_OPT_IN_MISSING');
+    }
+  });
+
+  it('lève RM23_PREFERENCE_MISMATCH si la préférence ne correspond pas au caregiver auteur', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c2', role: 'admin', geolocationOptIn: true });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_PREFERENCE_MISMATCH');
+    }
+  });
+
+  it('ne fuite pas de coordonnées dans le context des erreurs', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5012, lon: -73.5678 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      const raw = JSON.stringify((err as DomainError).context ?? {});
+      expect(raw).not.toContain('45.5012');
+      expect(raw).not.toContain('-73.5678');
+      expect(raw).not.toContain('lat');
+      expect(raw).not.toContain('lon');
+    }
+  });
+});
+
+describe('RM23 — sanitizeDoseGeolocation', () => {
+  it('retourne la dose inchangée si géoloc autorisée', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toEqual({ lat: 45.5, lon: -73.5 });
+  });
+
+  it('retourne la dose inchangée si absence de géoloc', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: null });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: false,
+    });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+  });
+
+  it('strip la géoloc si opt-in manquant', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'contributor',
+      geolocationOptIn: false,
+    });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+  });
+
+  it('strip la géoloc si restricted_contributor (même avec opt-in)', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+  });
+
+  it('strip la géoloc si coords hors bornes', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 91, lon: 0 } });
+    const pref = makePreference({ caregiverId: 'c1', role: 'admin', geolocationOptIn: true });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+  });
+
+  it('strip la géoloc si mismatch de caregiver', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({ caregiverId: 'c2', role: 'admin', geolocationOptIn: true });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+  });
+
+  it('est pur : ne mute pas `dose` ni `authorPreference`', () => {
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+    const doseSnapshot = JSON.stringify(dose);
+    const prefSnapshot = JSON.stringify(pref);
+
+    sanitizeDoseGeolocation({ dose, authorPreference: pref });
+
+    expect(JSON.stringify(dose)).toBe(doseSnapshot);
+    expect(JSON.stringify(pref)).toBe(prefSnapshot);
+  });
+
+  it('préserve les autres champs de la dose', () => {
+    const dose: DoseWithOptionalGeolocation & { readonly extra: string } = {
+      caregiverId: 'c1',
+      geolocation: { lat: 45.5, lon: -73.5 },
+      extra: 'should-survive',
+    };
+    const pref = makePreference({
+      caregiverId: 'c1',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+
+    const result = sanitizeDoseGeolocation({ dose, authorPreference: pref });
+    expect(result.geolocation).toBeNull();
+    expect((result as { extra?: string }).extra).toBe('should-survive');
+  });
+});

--- a/packages/domain/src/rules/rm23-geolocation-opt-in.test.ts
+++ b/packages/domain/src/rules/rm23-geolocation-opt-in.test.ts
@@ -370,6 +370,27 @@ describe('RM23 — ensureGeolocationAllowed', () => {
     }
   });
 
+  it('PREFERENCE_MISMATCH prime sur RESTRICTED_CAREGIVER (ordre des refus formalisé)', () => {
+    // Si la préférence ne correspond pas au caregiver auteur ET que le
+    // rôle fourni est restricted_contributor, on remonte MISMATCH d'abord
+    // (la cohérence du flux est le premier invariant — si l'input est
+    // incohérent, les autres checks n'ont pas de base fiable pour se
+    // prononcer).
+    const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5, lon: -73.5 } });
+    const pref = makePreference({
+      caregiverId: 'c2',
+      role: 'restricted_contributor',
+      geolocationOptIn: true,
+    });
+
+    try {
+      ensureGeolocationAllowed({ dose, authorPreference: pref });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect((err as DomainError).code).toBe('RM23_PREFERENCE_MISMATCH');
+    }
+  });
+
   it('ne fuite pas de coordonnées dans le context des erreurs', () => {
     const dose = makeDose({ caregiverId: 'c1', geolocation: { lat: 45.5012, lon: -73.5678 } });
     const pref = makePreference({

--- a/packages/domain/src/rules/rm23-geolocation-opt-in.ts
+++ b/packages/domain/src/rules/rm23-geolocation-opt-in.ts
@@ -1,0 +1,200 @@
+import type { Role } from '../entities/role';
+import { DomainError } from '../errors';
+
+/**
+ * Coordonnées géographiques attachées à une prise (opt-in strict, RM23).
+ *
+ * Ces coordonnées sont déclarées côté client et stockées **chiffrées
+ * E2EE** : le relais Kamez ne les voit jamais en clair. Le domaine se
+ * limite à valider la structure et les contraintes métier (bornes
+ * standard du géoïde). La précision (arrondi, bucketing pour réduire la
+ * fingerprintabilité) est une décision d'UI/API, hors scope du domaine.
+ */
+export interface Geolocation {
+  /** Latitude en degrés décimaux, plage inclusive `[-90, 90]`. */
+  readonly lat: number;
+  /** Longitude en degrés décimaux, plage inclusive `[-180, 180]`. */
+  readonly lon: number;
+}
+
+/**
+ * Vue minimale d'une prise pour l'évaluation RM23. Le domaine ne
+ * s'intéresse ici qu'au `caregiverId` auteur et à la présence
+ * éventuelle d'une géolocalisation. Les autres champs de la prise
+ * restent gérés par les règles dédiées (RM2, RM4, RM6…).
+ */
+export interface DoseWithOptionalGeolocation {
+  readonly caregiverId: string;
+  readonly geolocation?: Geolocation | null;
+}
+
+/**
+ * Préférence opt-in géoloc d'un aidant. Par défaut `geolocationOptIn =
+ * false`. Stockée côté profil aidant (infra), lue par le domaine lors
+ * de la validation d'une saisie.
+ *
+ * Invariant souverain domaine : quand `role === 'restricted_contributor'`,
+ * le domaine refuse la géoloc **quel que soit** `geolocationOptIn` —
+ * une session restreinte ne peut jamais opt-in légalement (garderie,
+ * nounou, session 8 h). Voir {@link ensureGeolocationAllowed}.
+ */
+export interface CaregiverGeolocationPreference {
+  readonly caregiverId: string;
+  readonly role: Role;
+  readonly geolocationOptIn: boolean;
+}
+
+/** Options partagées par {@link ensureGeolocationAllowed} et {@link isGeolocationAllowed}. */
+interface GeolocationOptions {
+  readonly dose: DoseWithOptionalGeolocation;
+  readonly authorPreference: CaregiverGeolocationPreference;
+}
+
+type GeolocationErrorCode =
+  | 'RM23_OPT_IN_MISSING'
+  | 'RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE'
+  | 'RM23_INVALID_COORDINATES'
+  | 'RM23_PREFERENCE_MISMATCH';
+
+type GeolocationDecision =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly code: GeolocationErrorCode; readonly detail: string };
+
+/**
+ * RM23 — valide que les coordonnées respectent les bornes standard du
+ * géoïde : `lat ∈ [-90, 90]` et `lon ∈ [-180, 180]`, bornes inclusives,
+ * valeurs finies (rejette NaN / Infinity).
+ *
+ * `null` et `undefined` sont considérés valides car l'absence de
+ * géolocalisation est toujours un état safe (RM23 refuse l'ajout, pas
+ * l'absence).
+ */
+export function isValidGeolocation(geo: Geolocation | null | undefined): boolean {
+  if (geo === null || geo === undefined) {
+    return true;
+  }
+  const { lat, lon } = geo;
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return false;
+  }
+  return lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+}
+
+/**
+ * RM23 — prédicat : la dose peut-elle porter cette géolocalisation ?
+ * Retourne `true` si la règle accepte (dont : absence de géoloc),
+ * `false` sinon. Ne lève jamais.
+ */
+export function isGeolocationAllowed(options: GeolocationOptions): boolean {
+  return evaluateGeolocation(options).ok;
+}
+
+/**
+ * RM23 — assertion : la dose respecte la politique d'opt-in
+ * géolocalisation. Refuse dans l'ordre de priorité suivant :
+ *
+ * 1. `RM23_PREFERENCE_MISMATCH` — `authorPreference.caregiverId` ne
+ *    correspond pas à `dose.caregiverId`. Vérification défensive :
+ *    l'API est responsable de passer la bonne préférence, mais le
+ *    domaine ferme la porte plutôt que d'appliquer une préférence
+ *    étrangère à l'auteur.
+ * 2. `RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE` — l'auteur est un
+ *    `restricted_contributor`. **Règle souveraine** : le domaine
+ *    refuse même si `geolocationOptIn === true` (une préférence qui
+ *    prétendrait l'opt-in sur ce rôle est un bug amont à clore ici).
+ * 3. `RM23_OPT_IN_MISSING` — l'auteur n'a pas opt-in.
+ * 4. `RM23_INVALID_COORDINATES` — coordonnées hors bornes ou non
+ *    finies.
+ *
+ * L'absence de géolocalisation (`geolocation` null/undefined) est
+ * toujours acceptée, quel que soit le rôle ou l'opt-in. Le
+ * `context` d'erreur ne contient **jamais** les coordonnées elles-mêmes
+ * (pas plus que `lat`/`lon` comme clés), uniquement `caregiverId` et
+ * `role` — métadonnées déjà connues de l'appelant légitime.
+ *
+ * @throws {DomainError} avec l'un des codes ci-dessus.
+ */
+export function ensureGeolocationAllowed(options: GeolocationOptions): void {
+  const decision = evaluateGeolocation(options);
+  if (decision.ok) {
+    return;
+  }
+
+  throw new DomainError(decision.code, decision.detail, {
+    caregiverId: options.dose.caregiverId,
+    role: options.authorPreference.role,
+  });
+}
+
+/**
+ * RM23 — sanitize une prise candidate : retourne une nouvelle dose
+ * avec `geolocation: null` si la règle ne permet pas d'attacher la
+ * géolocalisation, sinon retourne la dose inchangée.
+ *
+ * Utile côté ingestion pour forcer l'invariant « jamais de géoloc non
+ * autorisée » plutôt que rejeter l'ensemble de la prise — si un client
+ * buggé joint une géoloc sans opt-in, le domaine préfère strip
+ * silencieusement que perdre la prise (qui, elle, est précieuse pour
+ * le suivi santé).
+ *
+ * Fonction **pure** : ne mute ni `dose` ni `authorPreference`.
+ */
+export function sanitizeDoseGeolocation<D extends DoseWithOptionalGeolocation>(options: {
+  readonly dose: D;
+  readonly authorPreference: CaregiverGeolocationPreference;
+}): D {
+  const { dose, authorPreference } = options;
+  if (isGeolocationAllowed({ dose, authorPreference })) {
+    return dose;
+  }
+  return { ...dose, geolocation: null };
+}
+
+function evaluateGeolocation(options: GeolocationOptions): GeolocationDecision {
+  const { dose, authorPreference } = options;
+
+  // Absence de géoloc : toujours safe, court-circuit toutes les vérifications
+  // (pas de mismatch à valider tant qu'on n'attache rien).
+  if (dose.geolocation === null || dose.geolocation === undefined) {
+    return { ok: true };
+  }
+
+  // 1. Check défensif : la préférence doit concerner l'auteur de la prise.
+  if (authorPreference.caregiverId !== dose.caregiverId) {
+    return {
+      ok: false,
+      code: 'RM23_PREFERENCE_MISMATCH',
+      detail: 'authorPreference.caregiverId does not match dose.caregiverId.',
+    };
+  }
+
+  // 2. Règle souveraine : un restricted_contributor ne peut jamais géolocaliser,
+  //    même si la préférence prétend l'opt-in (bug amont ignoré).
+  if (authorPreference.role === 'restricted_contributor') {
+    return {
+      ok: false,
+      code: 'RM23_RESTRICTED_CAREGIVER_CANNOT_GEOLOCATE',
+      detail: 'Restricted contributors cannot attach geolocation to a dose.',
+    };
+  }
+
+  // 3. Opt-in explicite requis, absent par défaut.
+  if (!authorPreference.geolocationOptIn) {
+    return {
+      ok: false,
+      code: 'RM23_OPT_IN_MISSING',
+      detail: 'Caregiver has not opted in to attach geolocation to doses.',
+    };
+  }
+
+  // 4. Bornes du géoïde — dernière ligne de défense.
+  if (!isValidGeolocation(dose.geolocation)) {
+    return {
+      ok: false,
+      code: 'RM23_INVALID_COORDINATES',
+      detail: 'Geolocation coordinates are out of bounds or not finite.',
+    };
+  }
+
+  return { ok: true };
+}

--- a/packages/sync/eslint.config.js
+++ b/packages/sync/eslint.config.js
@@ -1,0 +1,17 @@
+import kinhale from '@kinhale/eslint-config'
+
+export default [
+  ...kinhale,
+  {
+    files: ['src/**/*.ts'],
+    rules: {
+      'no-console': 'error',
+    },
+  },
+  {
+    files: ['src/**/*.test.ts'],
+    rules: {
+      '@typescript-eslint/no-non-null-assertion': 'off',
+    },
+  },
+]

--- a/packages/sync/eslint.config.js
+++ b/packages/sync/eslint.config.js
@@ -1,4 +1,4 @@
-import kinhale from '@kinhale/eslint-config'
+import kinhale from '@kinhale/eslint-config';
 
 export default [
   ...kinhale,
@@ -14,4 +14,4 @@ export default [
       '@typescript-eslint/no-non-null-assertion': 'off',
     },
   },
-]
+];

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@kinhale/sync",
+  "version": "0.1.0",
+  "private": true,
+  "license": "AGPL-3.0-only",
+  "description": "Moteur de synchronisation local-first Kinhale (Automerge 2 + E2EE mailbox)",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint --max-warnings=0 .",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@automerge/automerge": "^2.2.0",
+    "@kinhale/crypto": "workspace:*"
+  },
+  "devDependencies": {
+    "@kinhale/eslint-config": "workspace:*",
+    "@kinhale/tsconfig": "workspace:*",
+    "@kinhale/test-utils": "workspace:*",
+    "@types/node": "^22.10.5",
+    "@vitest/coverage-v8": "^3.0.0",
+    "eslint": "^9.18.0",
+    "typescript": "^5.7.3",
+    "vitest": "^3.0.2"
+  }
+}

--- a/packages/sync/src/doc/lifecycle.test.ts
+++ b/packages/sync/src/doc/lifecycle.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import * as A from '@automerge/automerge'
+import { describe, it, expect } from 'vitest';
+import * as A from '@automerge/automerge';
 import {
   createDoc,
   loadDoc,
@@ -7,8 +7,8 @@ import {
   getDocChanges,
   getAllDocChanges,
   mergeChanges,
-} from './lifecycle.js'
-import type { SignedEventRecord } from './schema.js'
+} from './lifecycle.js';
+import type { SignedEventRecord } from './schema.js';
 
 const makeRecord = (id: string): SignedEventRecord => ({
   id,
@@ -18,60 +18,60 @@ const makeRecord = (id: string): SignedEventRecord => ({
   signatureHex: 'bb',
   deviceId: 'dev-1',
   occurredAtMs: 1_700_000_000_000,
-})
+});
 
 describe('Document lifecycle', () => {
   it('createDoc initialise un document avec householdId', () => {
-    const doc = createDoc('hh-test-1')
-    expect(doc.householdId).toBe('hh-test-1')
-    expect(doc.events).toHaveLength(0)
-  })
+    const doc = createDoc('hh-test-1');
+    expect(doc.householdId).toBe('hh-test-1');
+    expect(doc.events).toHaveLength(0);
+  });
 
   it('saveDoc + loadDoc : aller-retour binaire', () => {
-    const doc = createDoc('hh-test-2')
-    const bytes = saveDoc(doc)
-    expect(bytes).toBeInstanceOf(Uint8Array)
-    expect(bytes.length).toBeGreaterThan(0)
-    const loaded = loadDoc(bytes)
-    expect(loaded.householdId).toBe('hh-test-2')
-    expect(loaded.events).toHaveLength(0)
-  })
+    const doc = createDoc('hh-test-2');
+    const bytes = saveDoc(doc);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.length).toBeGreaterThan(0);
+    const loaded = loadDoc(bytes);
+    expect(loaded.householdId).toBe('hh-test-2');
+    expect(loaded.events).toHaveLength(0);
+  });
 
   it('getAllDocChanges retourne des Uint8Array non vides', () => {
-    const doc = createDoc('hh-test-3')
-    const changes = getAllDocChanges(doc)
-    expect(Array.isArray(changes)).toBe(true)
-    expect(changes.length).toBeGreaterThan(0)
-    expect(changes[0]).toBeInstanceOf(Uint8Array)
-  })
+    const doc = createDoc('hh-test-3');
+    const changes = getAllDocChanges(doc);
+    expect(Array.isArray(changes)).toBe(true);
+    expect(changes.length).toBeGreaterThan(0);
+    expect(changes[0]).toBeInstanceOf(Uint8Array);
+  });
 
   it('getDocChanges retourne 0 changements si doc identique', () => {
-    const doc = createDoc('hh-test-4')
-    const changes = getDocChanges(doc, doc)
-    expect(changes).toHaveLength(0)
-  })
+    const doc = createDoc('hh-test-4');
+    const changes = getDocChanges(doc, doc);
+    expect(changes).toHaveLength(0);
+  });
 
   it('mergeChanges applique un delta sur une copie du document', () => {
-    const base = createDoc('hh-merge-1')
-    const copy = loadDoc(saveDoc(base))
+    const base = createDoc('hh-merge-1');
+    const copy = loadDoc(saveDoc(base));
     const updated = A.change(base, (d) => {
-      d.events.push(makeRecord('evt-1'))
-    })
-    const delta = getDocChanges(base, updated)
-    const merged = mergeChanges(copy, delta)
-    expect(merged.events).toHaveLength(1)
-    expect(merged.events[0]!.id).toBe('evt-1')
-  })
+      d.events.push(makeRecord('evt-1'));
+    });
+    const delta = getDocChanges(base, updated);
+    const merged = mergeChanges(copy, delta);
+    expect(merged.events).toHaveLength(1);
+    expect(merged.events[0]!.id).toBe('evt-1');
+  });
 
   it('mergeChanges est idempotent (double application)', () => {
-    const base = createDoc('hh-merge-2')
-    const copy = loadDoc(saveDoc(base))
+    const base = createDoc('hh-merge-2');
+    const copy = loadDoc(saveDoc(base));
     const updated = A.change(base, (d) => {
-      d.events.push(makeRecord('evt-2'))
-    })
-    const delta = getDocChanges(base, updated)
-    const merged1 = mergeChanges(copy, delta)
-    const merged2 = mergeChanges(merged1, delta)
-    expect(merged2.events).toHaveLength(1)
-  })
-})
+      d.events.push(makeRecord('evt-2'));
+    });
+    const delta = getDocChanges(base, updated);
+    const merged1 = mergeChanges(copy, delta);
+    const merged2 = mergeChanges(merged1, delta);
+    expect(merged2.events).toHaveLength(1);
+  });
+});

--- a/packages/sync/src/doc/lifecycle.test.ts
+++ b/packages/sync/src/doc/lifecycle.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import * as A from '@automerge/automerge'
+import {
+  createDoc,
+  loadDoc,
+  saveDoc,
+  getDocChanges,
+  getAllDocChanges,
+  mergeChanges,
+} from './lifecycle.js'
+import type { SignedEventRecord } from './schema.js'
+
+const makeRecord = (id: string): SignedEventRecord => ({
+  id,
+  type: 'DoseAdministered',
+  payloadJson: '{}',
+  signerPublicKeyHex: 'aa',
+  signatureHex: 'bb',
+  deviceId: 'dev-1',
+  occurredAtMs: 1_700_000_000_000,
+})
+
+describe('Document lifecycle', () => {
+  it('createDoc initialise un document avec householdId', () => {
+    const doc = createDoc('hh-test-1')
+    expect(doc.householdId).toBe('hh-test-1')
+    expect(doc.events).toHaveLength(0)
+  })
+
+  it('saveDoc + loadDoc : aller-retour binaire', () => {
+    const doc = createDoc('hh-test-2')
+    const bytes = saveDoc(doc)
+    expect(bytes).toBeInstanceOf(Uint8Array)
+    expect(bytes.length).toBeGreaterThan(0)
+    const loaded = loadDoc(bytes)
+    expect(loaded.householdId).toBe('hh-test-2')
+    expect(loaded.events).toHaveLength(0)
+  })
+
+  it('getAllDocChanges retourne des Uint8Array non vides', () => {
+    const doc = createDoc('hh-test-3')
+    const changes = getAllDocChanges(doc)
+    expect(Array.isArray(changes)).toBe(true)
+    expect(changes.length).toBeGreaterThan(0)
+    expect(changes[0]).toBeInstanceOf(Uint8Array)
+  })
+
+  it('getDocChanges retourne 0 changements si doc identique', () => {
+    const doc = createDoc('hh-test-4')
+    const changes = getDocChanges(doc, doc)
+    expect(changes).toHaveLength(0)
+  })
+
+  it('mergeChanges applique un delta sur une copie du document', () => {
+    const base = createDoc('hh-merge-1')
+    const copy = loadDoc(saveDoc(base))
+    const updated = A.change(base, (d) => {
+      d.events.push(makeRecord('evt-1'))
+    })
+    const delta = getDocChanges(base, updated)
+    const merged = mergeChanges(copy, delta)
+    expect(merged.events).toHaveLength(1)
+    expect(merged.events[0]!.id).toBe('evt-1')
+  })
+
+  it('mergeChanges est idempotent (double application)', () => {
+    const base = createDoc('hh-merge-2')
+    const copy = loadDoc(saveDoc(base))
+    const updated = A.change(base, (d) => {
+      d.events.push(makeRecord('evt-2'))
+    })
+    const delta = getDocChanges(base, updated)
+    const merged1 = mergeChanges(copy, delta)
+    const merged2 = mergeChanges(merged1, delta)
+    expect(merged2.events).toHaveLength(1)
+  })
+})

--- a/packages/sync/src/doc/lifecycle.ts
+++ b/packages/sync/src/doc/lifecycle.ts
@@ -1,0 +1,48 @@
+import * as A from '@automerge/automerge'
+import type { KinhaleDoc } from './schema.js'
+
+export function createDoc(householdId: string): A.Doc<KinhaleDoc> {
+  return A.change(A.init<KinhaleDoc>(), (d) => {
+    d.householdId = householdId
+    d.events = []
+  })
+}
+
+export function saveDoc(doc: A.Doc<KinhaleDoc>): Uint8Array {
+  return A.save(doc)
+}
+
+export function loadDoc(bytes: Uint8Array): A.Doc<KinhaleDoc> {
+  return A.load<KinhaleDoc>(bytes)
+}
+
+/**
+ * Retourne les changements delta entre before et after.
+ * Pré-condition : before est un ancêtre de after (même acteur).
+ */
+export function getDocChanges(
+  before: A.Doc<KinhaleDoc>,
+  after: A.Doc<KinhaleDoc>,
+): Uint8Array[] {
+  return A.getChanges(before, after).map((c) => new Uint8Array(c))
+}
+
+/**
+ * Retourne tous les changements du document depuis sa création.
+ * Pour la synchronisation initiale avec un nouveau device.
+ */
+export function getAllDocChanges(doc: A.Doc<KinhaleDoc>): Uint8Array[] {
+  return A.getAllChanges(doc).map((c) => new Uint8Array(c))
+}
+
+/**
+ * Applique des changements reçus du relais sur un document local.
+ * Automerge garantit la convergence CRDT (idempotent).
+ */
+export function mergeChanges(
+  doc: A.Doc<KinhaleDoc>,
+  changes: Uint8Array[],
+): A.Doc<KinhaleDoc> {
+  const [newDoc] = A.applyChanges(doc, changes as unknown as A.Change[])
+  return newDoc
+}

--- a/packages/sync/src/doc/lifecycle.ts
+++ b/packages/sync/src/doc/lifecycle.ts
@@ -1,30 +1,27 @@
-import * as A from '@automerge/automerge'
-import type { KinhaleDoc } from './schema.js'
+import * as A from '@automerge/automerge';
+import type { KinhaleDoc } from './schema.js';
 
 export function createDoc(householdId: string): A.Doc<KinhaleDoc> {
   return A.change(A.init<KinhaleDoc>(), (d) => {
-    d.householdId = householdId
-    d.events = []
-  })
+    d.householdId = householdId;
+    d.events = [];
+  });
 }
 
 export function saveDoc(doc: A.Doc<KinhaleDoc>): Uint8Array {
-  return A.save(doc)
+  return A.save(doc);
 }
 
 export function loadDoc(bytes: Uint8Array): A.Doc<KinhaleDoc> {
-  return A.load<KinhaleDoc>(bytes)
+  return A.load<KinhaleDoc>(bytes);
 }
 
 /**
  * Retourne les changements delta entre before et after.
  * Pré-condition : before est un ancêtre de after (même acteur).
  */
-export function getDocChanges(
-  before: A.Doc<KinhaleDoc>,
-  after: A.Doc<KinhaleDoc>,
-): Uint8Array[] {
-  return A.getChanges(before, after).map((c) => new Uint8Array(c))
+export function getDocChanges(before: A.Doc<KinhaleDoc>, after: A.Doc<KinhaleDoc>): Uint8Array[] {
+  return A.getChanges(before, after).map((c) => new Uint8Array(c));
 }
 
 /**
@@ -32,17 +29,14 @@ export function getDocChanges(
  * Pour la synchronisation initiale avec un nouveau device.
  */
 export function getAllDocChanges(doc: A.Doc<KinhaleDoc>): Uint8Array[] {
-  return A.getAllChanges(doc).map((c) => new Uint8Array(c))
+  return A.getAllChanges(doc).map((c) => new Uint8Array(c));
 }
 
 /**
  * Applique des changements reçus du relais sur un document local.
  * Automerge garantit la convergence CRDT (idempotent).
  */
-export function mergeChanges(
-  doc: A.Doc<KinhaleDoc>,
-  changes: Uint8Array[],
-): A.Doc<KinhaleDoc> {
-  const [newDoc] = A.applyChanges(doc, changes as unknown as A.Change[])
-  return newDoc
+export function mergeChanges(doc: A.Doc<KinhaleDoc>, changes: Uint8Array[]): A.Doc<KinhaleDoc> {
+  const [newDoc] = A.applyChanges(doc, changes as unknown as A.Change[]);
+  return newDoc;
 }

--- a/packages/sync/src/doc/schema.test.ts
+++ b/packages/sync/src/doc/schema.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import type { KinhaleDoc, SignedEventRecord } from './schema.js'
+import { describe, it, expect } from 'vitest';
+import type { KinhaleDoc, SignedEventRecord } from './schema.js';
 
 describe('KinhaleDoc schema', () => {
   it('SignedEventRecord a toutes les propriétés requises', () => {
@@ -11,18 +11,18 @@ describe('KinhaleDoc schema', () => {
       signatureHex: 'ddeeff',
       deviceId: 'device-001',
       occurredAtMs: 1_700_000_000_000,
-    }
-    expect(record.id).toBe('evt-001')
-    expect(record.type).toBe('DoseAdministered')
-    expect(record.occurredAtMs).toBeGreaterThan(0)
-  })
+    };
+    expect(record.id).toBe('evt-001');
+    expect(record.type).toBe('DoseAdministered');
+    expect(record.occurredAtMs).toBeGreaterThan(0);
+  });
 
   it('KinhaleDoc a householdId et events', () => {
     const doc: KinhaleDoc = {
       householdId: 'hh-001',
       events: [],
-    }
-    expect(doc.householdId).toBe('hh-001')
-    expect(doc.events).toHaveLength(0)
-  })
-})
+    };
+    expect(doc.householdId).toBe('hh-001');
+    expect(doc.events).toHaveLength(0);
+  });
+});

--- a/packages/sync/src/doc/schema.test.ts
+++ b/packages/sync/src/doc/schema.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import type { KinhaleDoc, SignedEventRecord } from './schema.js'
+
+describe('KinhaleDoc schema', () => {
+  it('SignedEventRecord a toutes les propriétés requises', () => {
+    const record: SignedEventRecord = {
+      id: 'evt-001',
+      type: 'DoseAdministered',
+      payloadJson: JSON.stringify({ doseId: 'd1' }),
+      signerPublicKeyHex: 'aabbcc',
+      signatureHex: 'ddeeff',
+      deviceId: 'device-001',
+      occurredAtMs: 1_700_000_000_000,
+    }
+    expect(record.id).toBe('evt-001')
+    expect(record.type).toBe('DoseAdministered')
+    expect(record.occurredAtMs).toBeGreaterThan(0)
+  })
+
+  it('KinhaleDoc a householdId et events', () => {
+    const doc: KinhaleDoc = {
+      householdId: 'hh-001',
+      events: [],
+    }
+    expect(doc.householdId).toBe('hh-001')
+    expect(doc.events).toHaveLength(0)
+  })
+})

--- a/packages/sync/src/doc/schema.ts
+++ b/packages/sync/src/doc/schema.ts
@@ -4,17 +4,17 @@
  * compatibilité native avec le CRDT Automerge.
  */
 export interface SignedEventRecord {
-  readonly id: string
-  readonly type: string
+  readonly id: string;
+  readonly type: string;
   /** JSON.stringify du payload domaine (DoseAdministeredPayload, etc.) */
-  readonly payloadJson: string
+  readonly payloadJson: string;
   /** Clé publique Ed25519 du device émetteur (hex 64 chars) */
-  readonly signerPublicKeyHex: string
+  readonly signerPublicKeyHex: string;
   /** Signature Ed25519 du canonical bytes (hex 128 chars) */
-  readonly signatureHex: string
-  readonly deviceId: string
+  readonly signatureHex: string;
+  readonly deviceId: string;
   /** Timestamp UTC en millisecondes */
-  readonly occurredAtMs: number
+  readonly occurredAtMs: number;
 }
 
 /**
@@ -23,6 +23,6 @@ export interface SignedEventRecord {
  * sont des projections calculées à la lecture depuis la liste d'événements.
  */
 export interface KinhaleDoc {
-  householdId: string
-  events: SignedEventRecord[]
+  householdId: string;
+  events: SignedEventRecord[];
 }

--- a/packages/sync/src/doc/schema.ts
+++ b/packages/sync/src/doc/schema.ts
@@ -1,0 +1,28 @@
+/**
+ * Événement domaine stocké dans le document Automerge.
+ * Les Uint8Array (clé publique, signature) sont encodés en hex pour
+ * compatibilité native avec le CRDT Automerge.
+ */
+export interface SignedEventRecord {
+  readonly id: string
+  readonly type: string
+  /** JSON.stringify du payload domaine (DoseAdministeredPayload, etc.) */
+  readonly payloadJson: string
+  /** Clé publique Ed25519 du device émetteur (hex 64 chars) */
+  readonly signerPublicKeyHex: string
+  /** Signature Ed25519 du canonical bytes (hex 128 chars) */
+  readonly signatureHex: string
+  readonly deviceId: string
+  /** Timestamp UTC en millisecondes */
+  readonly occurredAtMs: number
+}
+
+/**
+ * Document Automerge d'un foyer Kinhale.
+ * Un foyer = un document. Les entités (pompes, plans, historique)
+ * sont des projections calculées à la lecture depuis la liste d'événements.
+ */
+export interface KinhaleDoc {
+  householdId: string
+  events: SignedEventRecord[]
+}

--- a/packages/sync/src/events/append.test.ts
+++ b/packages/sync/src/events/append.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { generateSigningKeypair } from '@kinhale/crypto'
+import { createDoc } from '../doc/lifecycle.js'
+import { signEvent } from './sign.js'
+import { appendEvent } from './append.js'
+import type { UnsignedEvent } from './types.js'
+
+const makeUnsigned = (id: string): UnsignedEvent => ({
+  id,
+  deviceId: 'device-001',
+  occurredAtMs: 1_700_000_000_000 + parseInt(id.slice(-1), 10),
+  event: {
+    type: 'DoseAdministered',
+    payload: {
+      doseId: id,
+      pumpId: 'p1',
+      childId: 'c1',
+      caregiverId: 'cg1',
+      administeredAtMs: 1_700_000_000_000,
+      doseType: 'maintenance',
+      dosesAdministered: 1,
+      symptoms: [],
+      circumstances: [],
+      freeFormTag: null,
+    },
+  },
+})
+
+describe('appendEvent', () => {
+  it('ajoute un SignedEventRecord au document', async () => {
+    const kp = await generateSigningKeypair()
+    const doc = createDoc('hh-append-1')
+    const record = await signEvent(makeUnsigned('evt-1'), kp.secretKey)
+    const doc2 = appendEvent(doc, record)
+    expect(doc2.events).toHaveLength(1)
+    expect(doc2.events[0]!.id).toBe('evt-1')
+  })
+
+  it('ne modifie pas le document original (immutabilité Automerge)', async () => {
+    const kp = await generateSigningKeypair()
+    const doc = createDoc('hh-append-2')
+    const record = await signEvent(makeUnsigned('evt-2'), kp.secretKey)
+    const doc2 = appendEvent(doc, record)
+    expect(doc.events).toHaveLength(0)
+    expect(doc2.events).toHaveLength(1)
+  })
+
+  it("plusieurs appendEvent préservent l'ordre d'insertion", async () => {
+    const kp = await generateSigningKeypair()
+    let doc = createDoc('hh-append-3')
+    for (let i = 1; i <= 3; i++) {
+      const record = await signEvent(makeUnsigned(`evt-${i}`), kp.secretKey)
+      doc = appendEvent(doc, record)
+    }
+    expect(doc.events).toHaveLength(3)
+    expect(doc.events[0]!.id).toBe('evt-1')
+    expect(doc.events[2]!.id).toBe('evt-3')
+  })
+})

--- a/packages/sync/src/events/append.test.ts
+++ b/packages/sync/src/events/append.test.ts
@@ -1,9 +1,9 @@
-import { describe, it, expect } from 'vitest'
-import { generateSigningKeypair } from '@kinhale/crypto'
-import { createDoc } from '../doc/lifecycle.js'
-import { signEvent } from './sign.js'
-import { appendEvent } from './append.js'
-import type { UnsignedEvent } from './types.js'
+import { describe, it, expect } from 'vitest';
+import { generateSigningKeypair } from '@kinhale/crypto';
+import { createDoc } from '../doc/lifecycle.js';
+import { signEvent } from './sign.js';
+import { appendEvent } from './append.js';
+import type { UnsignedEvent } from './types.js';
 
 const makeUnsigned = (id: string): UnsignedEvent => ({
   id,
@@ -24,36 +24,36 @@ const makeUnsigned = (id: string): UnsignedEvent => ({
       freeFormTag: null,
     },
   },
-})
+});
 
 describe('appendEvent', () => {
   it('ajoute un SignedEventRecord au document', async () => {
-    const kp = await generateSigningKeypair()
-    const doc = createDoc('hh-append-1')
-    const record = await signEvent(makeUnsigned('evt-1'), kp.secretKey)
-    const doc2 = appendEvent(doc, record)
-    expect(doc2.events).toHaveLength(1)
-    expect(doc2.events[0]!.id).toBe('evt-1')
-  })
+    const kp = await generateSigningKeypair();
+    const doc = createDoc('hh-append-1');
+    const record = await signEvent(makeUnsigned('evt-1'), kp.secretKey);
+    const doc2 = appendEvent(doc, record);
+    expect(doc2.events).toHaveLength(1);
+    expect(doc2.events[0]!.id).toBe('evt-1');
+  });
 
   it('ne modifie pas le document original (immutabilité Automerge)', async () => {
-    const kp = await generateSigningKeypair()
-    const doc = createDoc('hh-append-2')
-    const record = await signEvent(makeUnsigned('evt-2'), kp.secretKey)
-    const doc2 = appendEvent(doc, record)
-    expect(doc.events).toHaveLength(0)
-    expect(doc2.events).toHaveLength(1)
-  })
+    const kp = await generateSigningKeypair();
+    const doc = createDoc('hh-append-2');
+    const record = await signEvent(makeUnsigned('evt-2'), kp.secretKey);
+    const doc2 = appendEvent(doc, record);
+    expect(doc.events).toHaveLength(0);
+    expect(doc2.events).toHaveLength(1);
+  });
 
   it("plusieurs appendEvent préservent l'ordre d'insertion", async () => {
-    const kp = await generateSigningKeypair()
-    let doc = createDoc('hh-append-3')
+    const kp = await generateSigningKeypair();
+    let doc = createDoc('hh-append-3');
     for (let i = 1; i <= 3; i++) {
-      const record = await signEvent(makeUnsigned(`evt-${i}`), kp.secretKey)
-      doc = appendEvent(doc, record)
+      const record = await signEvent(makeUnsigned(`evt-${i}`), kp.secretKey);
+      doc = appendEvent(doc, record);
     }
-    expect(doc.events).toHaveLength(3)
-    expect(doc.events[0]!.id).toBe('evt-1')
-    expect(doc.events[2]!.id).toBe('evt-3')
-  })
-})
+    expect(doc.events).toHaveLength(3);
+    expect(doc.events[0]!.id).toBe('evt-1');
+    expect(doc.events[2]!.id).toBe('evt-3');
+  });
+});

--- a/packages/sync/src/events/append.ts
+++ b/packages/sync/src/events/append.ts
@@ -1,16 +1,13 @@
-import * as A from '@automerge/automerge'
-import type { KinhaleDoc, SignedEventRecord } from '../doc/schema.js'
+import * as A from '@automerge/automerge';
+import type { KinhaleDoc, SignedEventRecord } from '../doc/schema.js';
 
 /**
  * Ajoute un SignedEventRecord au document Automerge du foyer.
  * Retourne un nouveau document (Automerge est immutable).
  * L'appelant doit vérifier la signature avant d'appeler appendEvent.
  */
-export function appendEvent(
-  doc: A.Doc<KinhaleDoc>,
-  record: SignedEventRecord,
-): A.Doc<KinhaleDoc> {
+export function appendEvent(doc: A.Doc<KinhaleDoc>, record: SignedEventRecord): A.Doc<KinhaleDoc> {
   return A.change(doc, (d) => {
-    d.events.push(record)
-  })
+    d.events.push(record);
+  });
 }

--- a/packages/sync/src/events/append.ts
+++ b/packages/sync/src/events/append.ts
@@ -1,0 +1,16 @@
+import * as A from '@automerge/automerge'
+import type { KinhaleDoc, SignedEventRecord } from '../doc/schema.js'
+
+/**
+ * Ajoute un SignedEventRecord au document Automerge du foyer.
+ * Retourne un nouveau document (Automerge est immutable).
+ * L'appelant doit vérifier la signature avant d'appeler appendEvent.
+ */
+export function appendEvent(
+  doc: A.Doc<KinhaleDoc>,
+  record: SignedEventRecord,
+): A.Doc<KinhaleDoc> {
+  return A.change(doc, (d) => {
+    d.events.push(record)
+  })
+}

--- a/packages/sync/src/events/sign.test.ts
+++ b/packages/sync/src/events/sign.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest'
+import { generateSigningKeypair } from '@kinhale/crypto'
+import { signEvent, verifySignedEvent, canonicalBytes } from './sign.js'
+import type { UnsignedEvent } from './types.js'
+
+const makeUnsigned = (): UnsignedEvent => ({
+  id: 'evt-sign-1',
+  deviceId: 'device-001',
+  occurredAtMs: 1_700_000_000_000,
+  event: {
+    type: 'DoseAdministered',
+    payload: {
+      doseId: 'd1',
+      pumpId: 'p1',
+      childId: 'c1',
+      caregiverId: 'cg1',
+      administeredAtMs: 1_700_000_000_000,
+      doseType: 'maintenance',
+      dosesAdministered: 1,
+      symptoms: [],
+      circumstances: [],
+      freeFormTag: null,
+    },
+  },
+})
+
+describe('Event signing', () => {
+  it('signEvent produit un SignedEventRecord avec signatureHex non vide', async () => {
+    const kp = await generateSigningKeypair()
+    const record = await signEvent(makeUnsigned(), kp.secretKey)
+    expect(record.id).toBe('evt-sign-1')
+    expect(record.type).toBe('DoseAdministered')
+    expect(record.signatureHex).toHaveLength(128) // 64 bytes Ed25519 → 128 hex chars
+    expect(record.signerPublicKeyHex).toHaveLength(64) // 32 bytes → 64 hex chars
+    expect(record.deviceId).toBe('device-001')
+  })
+
+  it('verifySignedEvent retourne true pour une signature valide', async () => {
+    const kp = await generateSigningKeypair()
+    const record = await signEvent(makeUnsigned(), kp.secretKey)
+    const valid = await verifySignedEvent(record)
+    expect(valid).toBe(true)
+  })
+
+  it('verifySignedEvent retourne false si le payload est altéré', async () => {
+    const kp = await generateSigningKeypair()
+    const record = await signEvent(makeUnsigned(), kp.secretKey)
+    const tampered = { ...record, payloadJson: JSON.stringify({ doseId: 'HACKED' }) }
+    const valid = await verifySignedEvent(tampered)
+    expect(valid).toBe(false)
+  })
+
+  it('verifySignedEvent retourne false si la signature est corrompue', async () => {
+    const kp = await generateSigningKeypair()
+    const record = await signEvent(makeUnsigned(), kp.secretKey)
+    const corrupted = { ...record, signatureHex: 'a'.repeat(128) }
+    const valid = await verifySignedEvent(corrupted)
+    expect(valid).toBe(false)
+  })
+
+  it('deux signEvent sur le même UnsignedEvent produisent la même signature', async () => {
+    const kp = await generateSigningKeypair()
+    const unsigned = makeUnsigned()
+    const r1 = await signEvent(unsigned, kp.secretKey)
+    const r2 = await signEvent(unsigned, kp.secretKey)
+    expect(r1.signatureHex).toBe(r2.signatureHex)
+  })
+
+  it('canonicalBytes est déterministe', () => {
+    const unsigned = makeUnsigned()
+    const b1 = canonicalBytes(unsigned)
+    const b2 = canonicalBytes(unsigned)
+    expect(Buffer.from(b1).toString('hex')).toBe(Buffer.from(b2).toString('hex'))
+  })
+})

--- a/packages/sync/src/events/sign.test.ts
+++ b/packages/sync/src/events/sign.test.ts
@@ -1,7 +1,7 @@
-import { describe, it, expect } from 'vitest'
-import { generateSigningKeypair } from '@kinhale/crypto'
-import { signEvent, verifySignedEvent, canonicalBytes } from './sign.js'
-import type { UnsignedEvent } from './types.js'
+import { describe, it, expect } from 'vitest';
+import { generateSigningKeypair } from '@kinhale/crypto';
+import { signEvent, verifySignedEvent, canonicalBytes } from './sign.js';
+import type { UnsignedEvent } from './types.js';
 
 const makeUnsigned = (): UnsignedEvent => ({
   id: 'evt-sign-1',
@@ -22,54 +22,54 @@ const makeUnsigned = (): UnsignedEvent => ({
       freeFormTag: null,
     },
   },
-})
+});
 
 describe('Event signing', () => {
   it('signEvent produit un SignedEventRecord avec signatureHex non vide', async () => {
-    const kp = await generateSigningKeypair()
-    const record = await signEvent(makeUnsigned(), kp.secretKey)
-    expect(record.id).toBe('evt-sign-1')
-    expect(record.type).toBe('DoseAdministered')
-    expect(record.signatureHex).toHaveLength(128) // 64 bytes Ed25519 → 128 hex chars
-    expect(record.signerPublicKeyHex).toHaveLength(64) // 32 bytes → 64 hex chars
-    expect(record.deviceId).toBe('device-001')
-  })
+    const kp = await generateSigningKeypair();
+    const record = await signEvent(makeUnsigned(), kp.secretKey);
+    expect(record.id).toBe('evt-sign-1');
+    expect(record.type).toBe('DoseAdministered');
+    expect(record.signatureHex).toHaveLength(128); // 64 bytes Ed25519 → 128 hex chars
+    expect(record.signerPublicKeyHex).toHaveLength(64); // 32 bytes → 64 hex chars
+    expect(record.deviceId).toBe('device-001');
+  });
 
   it('verifySignedEvent retourne true pour une signature valide', async () => {
-    const kp = await generateSigningKeypair()
-    const record = await signEvent(makeUnsigned(), kp.secretKey)
-    const valid = await verifySignedEvent(record)
-    expect(valid).toBe(true)
-  })
+    const kp = await generateSigningKeypair();
+    const record = await signEvent(makeUnsigned(), kp.secretKey);
+    const valid = await verifySignedEvent(record);
+    expect(valid).toBe(true);
+  });
 
   it('verifySignedEvent retourne false si le payload est altéré', async () => {
-    const kp = await generateSigningKeypair()
-    const record = await signEvent(makeUnsigned(), kp.secretKey)
-    const tampered = { ...record, payloadJson: JSON.stringify({ doseId: 'HACKED' }) }
-    const valid = await verifySignedEvent(tampered)
-    expect(valid).toBe(false)
-  })
+    const kp = await generateSigningKeypair();
+    const record = await signEvent(makeUnsigned(), kp.secretKey);
+    const tampered = { ...record, payloadJson: JSON.stringify({ doseId: 'HACKED' }) };
+    const valid = await verifySignedEvent(tampered);
+    expect(valid).toBe(false);
+  });
 
   it('verifySignedEvent retourne false si la signature est corrompue', async () => {
-    const kp = await generateSigningKeypair()
-    const record = await signEvent(makeUnsigned(), kp.secretKey)
-    const corrupted = { ...record, signatureHex: 'a'.repeat(128) }
-    const valid = await verifySignedEvent(corrupted)
-    expect(valid).toBe(false)
-  })
+    const kp = await generateSigningKeypair();
+    const record = await signEvent(makeUnsigned(), kp.secretKey);
+    const corrupted = { ...record, signatureHex: 'a'.repeat(128) };
+    const valid = await verifySignedEvent(corrupted);
+    expect(valid).toBe(false);
+  });
 
   it('deux signEvent sur le même UnsignedEvent produisent la même signature', async () => {
-    const kp = await generateSigningKeypair()
-    const unsigned = makeUnsigned()
-    const r1 = await signEvent(unsigned, kp.secretKey)
-    const r2 = await signEvent(unsigned, kp.secretKey)
-    expect(r1.signatureHex).toBe(r2.signatureHex)
-  })
+    const kp = await generateSigningKeypair();
+    const unsigned = makeUnsigned();
+    const r1 = await signEvent(unsigned, kp.secretKey);
+    const r2 = await signEvent(unsigned, kp.secretKey);
+    expect(r1.signatureHex).toBe(r2.signatureHex);
+  });
 
   it('canonicalBytes est déterministe', () => {
-    const unsigned = makeUnsigned()
-    const b1 = canonicalBytes(unsigned)
-    const b2 = canonicalBytes(unsigned)
-    expect(Buffer.from(b1).toString('hex')).toBe(Buffer.from(b2).toString('hex'))
-  })
-})
+    const unsigned = makeUnsigned();
+    const b1 = canonicalBytes(unsigned);
+    const b2 = canonicalBytes(unsigned);
+    expect(Buffer.from(b1).toString('hex')).toBe(Buffer.from(b2).toString('hex'));
+  });
+});

--- a/packages/sync/src/events/sign.ts
+++ b/packages/sync/src/events/sign.ts
@@ -1,0 +1,67 @@
+import { sign, verify } from '@kinhale/crypto'
+import type { SignedEventRecord } from '../doc/schema.js'
+import type { UnsignedEvent } from './types.js'
+
+/**
+ * Retourne les bytes canoniques à signer pour un UnsignedEvent.
+ * JSON.stringify avec clés ordonnées pour déterminisme.
+ */
+export function canonicalBytes(unsigned: UnsignedEvent): Uint8Array {
+  const canonical = JSON.stringify({
+    id: unsigned.id,
+    type: unsigned.event.type,
+    payloadJson: JSON.stringify(unsigned.event.payload),
+    deviceId: unsigned.deviceId,
+    occurredAtMs: unsigned.occurredAtMs,
+  })
+  return new TextEncoder().encode(canonical)
+}
+
+/**
+ * Signe un événement domaine avec la clé Ed25519 du device.
+ * secretKey libsodium = 64 bytes : [32 seed][32 publicKey].
+ */
+export async function signEvent(
+  unsigned: UnsignedEvent,
+  secretKey: Uint8Array,
+): Promise<SignedEventRecord> {
+  const signerPublicKey = secretKey.slice(32, 64)
+  const payloadJson = JSON.stringify(unsigned.event.payload)
+  const bytes = canonicalBytes(unsigned)
+  const signature = await sign(bytes, secretKey)
+
+  return {
+    id: unsigned.id,
+    type: unsigned.event.type,
+    payloadJson,
+    signerPublicKeyHex: Buffer.from(signerPublicKey).toString('hex'),
+    signatureHex: Buffer.from(signature).toString('hex'),
+    deviceId: unsigned.deviceId,
+    occurredAtMs: unsigned.occurredAtMs,
+  }
+}
+
+/**
+ * Vérifie la signature Ed25519 d'un SignedEventRecord.
+ * Retourne false (jamais throw) si la signature est invalide ou corrompue.
+ */
+export async function verifySignedEvent(record: SignedEventRecord): Promise<boolean> {
+  try {
+    const parsedPayload = JSON.parse(record.payloadJson) as UnsignedEvent['event']['payload']
+    const unsigned: UnsignedEvent = {
+      id: record.id,
+      deviceId: record.deviceId,
+      occurredAtMs: record.occurredAtMs,
+      event: {
+        type: record.type as UnsignedEvent['event']['type'],
+        payload: parsedPayload,
+      } as UnsignedEvent['event'],
+    }
+    const bytes = canonicalBytes(unsigned)
+    const signature = Buffer.from(record.signatureHex, 'hex')
+    const publicKey = Buffer.from(record.signerPublicKeyHex, 'hex')
+    return await verify(bytes, signature, publicKey)
+  } catch {
+    return false
+  }
+}

--- a/packages/sync/src/events/sign.ts
+++ b/packages/sync/src/events/sign.ts
@@ -1,6 +1,6 @@
-import { sign, verify } from '@kinhale/crypto'
-import type { SignedEventRecord } from '../doc/schema.js'
-import type { UnsignedEvent } from './types.js'
+import { sign, verify } from '@kinhale/crypto';
+import type { SignedEventRecord } from '../doc/schema.js';
+import type { UnsignedEvent } from './types.js';
 
 /**
  * Retourne les bytes canoniques à signer pour un UnsignedEvent.
@@ -13,8 +13,8 @@ export function canonicalBytes(unsigned: UnsignedEvent): Uint8Array {
     payloadJson: JSON.stringify(unsigned.event.payload),
     deviceId: unsigned.deviceId,
     occurredAtMs: unsigned.occurredAtMs,
-  })
-  return new TextEncoder().encode(canonical)
+  });
+  return new TextEncoder().encode(canonical);
 }
 
 /**
@@ -25,10 +25,10 @@ export async function signEvent(
   unsigned: UnsignedEvent,
   secretKey: Uint8Array,
 ): Promise<SignedEventRecord> {
-  const signerPublicKey = secretKey.slice(32, 64)
-  const payloadJson = JSON.stringify(unsigned.event.payload)
-  const bytes = canonicalBytes(unsigned)
-  const signature = await sign(bytes, secretKey)
+  const signerPublicKey = secretKey.slice(32, 64);
+  const payloadJson = JSON.stringify(unsigned.event.payload);
+  const bytes = canonicalBytes(unsigned);
+  const signature = await sign(bytes, secretKey);
 
   return {
     id: unsigned.id,
@@ -38,7 +38,7 @@ export async function signEvent(
     signatureHex: Buffer.from(signature).toString('hex'),
     deviceId: unsigned.deviceId,
     occurredAtMs: unsigned.occurredAtMs,
-  }
+  };
 }
 
 /**
@@ -47,7 +47,7 @@ export async function signEvent(
  */
 export async function verifySignedEvent(record: SignedEventRecord): Promise<boolean> {
   try {
-    const parsedPayload = JSON.parse(record.payloadJson) as UnsignedEvent['event']['payload']
+    const parsedPayload = JSON.parse(record.payloadJson) as UnsignedEvent['event']['payload'];
     const unsigned: UnsignedEvent = {
       id: record.id,
       deviceId: record.deviceId,
@@ -56,12 +56,12 @@ export async function verifySignedEvent(record: SignedEventRecord): Promise<bool
         type: record.type as UnsignedEvent['event']['type'],
         payload: parsedPayload,
       } as UnsignedEvent['event'],
-    }
-    const bytes = canonicalBytes(unsigned)
-    const signature = Buffer.from(record.signatureHex, 'hex')
-    const publicKey = Buffer.from(record.signerPublicKeyHex, 'hex')
-    return await verify(bytes, signature, publicKey)
+    };
+    const bytes = canonicalBytes(unsigned);
+    const signature = Buffer.from(record.signatureHex, 'hex');
+    const publicKey = Buffer.from(record.signerPublicKeyHex, 'hex');
+    return await verify(bytes, signature, publicKey);
   } catch {
-    return false
+    return false;
   }
 }

--- a/packages/sync/src/events/types.ts
+++ b/packages/sync/src/events/types.ts
@@ -4,58 +4,58 @@ export type DomainEventType =
   | 'PumpReplaced'
   | 'PlanUpdated'
   | 'CaregiverInvited'
-  | 'CaregiverRevoked'
+  | 'CaregiverRevoked';
 
 /** Payload pour DoseAdministered */
 export interface DoseAdministeredPayload {
-  doseId: string
-  pumpId: string
-  childId: string
-  caregiverId: string
+  doseId: string;
+  pumpId: string;
+  childId: string;
+  caregiverId: string;
   /** UTC ms */
-  administeredAtMs: number
+  administeredAtMs: number;
   /** 'maintenance' | 'rescue' */
-  doseType: string
-  dosesAdministered: number
-  symptoms: string[]
-  circumstances: string[]
-  freeFormTag: string | null
+  doseType: string;
+  dosesAdministered: number;
+  symptoms: string[];
+  circumstances: string[];
+  freeFormTag: string | null;
 }
 
 /** Payload pour PumpReplaced */
 export interface PumpReplacedPayload {
-  pumpId: string
-  name: string
+  pumpId: string;
+  name: string;
   /** 'maintenance' | 'rescue' */
-  pumpType: string
-  totalDoses: number
+  pumpType: string;
+  totalDoses: number;
   /** UTC ms, null si pas de date d'expiration connue */
-  expiresAtMs: number | null
+  expiresAtMs: number | null;
 }
 
 /** Payload pour PlanUpdated */
 export interface PlanUpdatedPayload {
-  planId: string
-  pumpId: string
+  planId: string;
+  pumpId: string;
   /** Heures cibles en UTC (ex : [8, 20]) */
-  scheduledHoursUtc: number[]
+  scheduledHoursUtc: number[];
   /** UTC ms */
-  startAtMs: number
+  startAtMs: number;
   /** UTC ms, null si durée indéfinie */
-  endAtMs: number | null
+  endAtMs: number | null;
 }
 
 /** Payload pour CaregiverInvited */
 export interface CaregiverInvitedPayload {
-  caregiverId: string
+  caregiverId: string;
   /** 'admin' | 'contributor' | 'restricted_contributor' */
-  role: string
-  displayName: string
+  role: string;
+  displayName: string;
 }
 
 /** Payload pour CaregiverRevoked */
 export interface CaregiverRevokedPayload {
-  caregiverId: string
+  caregiverId: string;
 }
 
 /** Union discriminée des payloads */
@@ -64,14 +64,14 @@ export type DomainEventPayload =
   | { type: 'PumpReplaced'; payload: PumpReplacedPayload }
   | { type: 'PlanUpdated'; payload: PlanUpdatedPayload }
   | { type: 'CaregiverInvited'; payload: CaregiverInvitedPayload }
-  | { type: 'CaregiverRevoked'; payload: CaregiverRevokedPayload }
+  | { type: 'CaregiverRevoked'; payload: CaregiverRevokedPayload };
 
 /**
  * Événement non signé : données à signer avant insertion dans le document.
  */
 export interface UnsignedEvent {
-  id: string
-  deviceId: string
-  occurredAtMs: number
-  event: DomainEventPayload
+  id: string;
+  deviceId: string;
+  occurredAtMs: number;
+  event: DomainEventPayload;
 }

--- a/packages/sync/src/events/types.ts
+++ b/packages/sync/src/events/types.ts
@@ -1,0 +1,77 @@
+/** Types d'événements domaine persistés dans le document Automerge. */
+export type DomainEventType =
+  | 'DoseAdministered'
+  | 'PumpReplaced'
+  | 'PlanUpdated'
+  | 'CaregiverInvited'
+  | 'CaregiverRevoked'
+
+/** Payload pour DoseAdministered */
+export interface DoseAdministeredPayload {
+  doseId: string
+  pumpId: string
+  childId: string
+  caregiverId: string
+  /** UTC ms */
+  administeredAtMs: number
+  /** 'maintenance' | 'rescue' */
+  doseType: string
+  dosesAdministered: number
+  symptoms: string[]
+  circumstances: string[]
+  freeFormTag: string | null
+}
+
+/** Payload pour PumpReplaced */
+export interface PumpReplacedPayload {
+  pumpId: string
+  name: string
+  /** 'maintenance' | 'rescue' */
+  pumpType: string
+  totalDoses: number
+  /** UTC ms, null si pas de date d'expiration connue */
+  expiresAtMs: number | null
+}
+
+/** Payload pour PlanUpdated */
+export interface PlanUpdatedPayload {
+  planId: string
+  pumpId: string
+  /** Heures cibles en UTC (ex : [8, 20]) */
+  scheduledHoursUtc: number[]
+  /** UTC ms */
+  startAtMs: number
+  /** UTC ms, null si durée indéfinie */
+  endAtMs: number | null
+}
+
+/** Payload pour CaregiverInvited */
+export interface CaregiverInvitedPayload {
+  caregiverId: string
+  /** 'admin' | 'contributor' | 'restricted_contributor' */
+  role: string
+  displayName: string
+}
+
+/** Payload pour CaregiverRevoked */
+export interface CaregiverRevokedPayload {
+  caregiverId: string
+}
+
+/** Union discriminée des payloads */
+export type DomainEventPayload =
+  | { type: 'DoseAdministered'; payload: DoseAdministeredPayload }
+  | { type: 'PumpReplaced'; payload: PumpReplacedPayload }
+  | { type: 'PlanUpdated'; payload: PlanUpdatedPayload }
+  | { type: 'CaregiverInvited'; payload: CaregiverInvitedPayload }
+  | { type: 'CaregiverRevoked'; payload: CaregiverRevokedPayload }
+
+/**
+ * Événement non signé : données à signer avant insertion dans le document.
+ */
+export interface UnsignedEvent {
+  id: string
+  deviceId: string
+  occurredAtMs: number
+  event: DomainEventPayload
+}

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -1,0 +1,4 @@
+// Moteur de synchronisation local-first Kinhale
+// (Automerge 2 + E2EE mailbox)
+
+export {}

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -1,4 +1,23 @@
-// Moteur de synchronisation local-first Kinhale
-// (Automerge 2 + E2EE mailbox)
+// Document Automerge
+export type { KinhaleDoc, SignedEventRecord } from './doc/schema.js'
+export { createDoc, loadDoc, saveDoc, getDocChanges, getAllDocChanges, mergeChanges } from './doc/lifecycle.js'
 
-export {}
+// Événements domaine
+export type {
+  DomainEventType,
+  DomainEventPayload,
+  UnsignedEvent,
+  DoseAdministeredPayload,
+  PumpReplacedPayload,
+  PlanUpdatedPayload,
+  CaregiverInvitedPayload,
+  CaregiverRevokedPayload,
+} from './events/types.js'
+export { canonicalBytes, signEvent, verifySignedEvent } from './events/sign.js'
+export { appendEvent } from './events/append.js'
+
+// Mailbox E2EE
+export type { EncryptedBlob } from './mailbox/encrypt.js'
+export { encryptChanges, decryptChanges } from './mailbox/encrypt.js'
+export type { SyncMessage } from './mailbox/message.js'
+export { encodeSyncMessage, decodeSyncMessage } from './mailbox/message.js'

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -1,6 +1,13 @@
 // Document Automerge
-export type { KinhaleDoc, SignedEventRecord } from './doc/schema.js'
-export { createDoc, loadDoc, saveDoc, getDocChanges, getAllDocChanges, mergeChanges } from './doc/lifecycle.js'
+export type { KinhaleDoc, SignedEventRecord } from './doc/schema.js';
+export {
+  createDoc,
+  loadDoc,
+  saveDoc,
+  getDocChanges,
+  getAllDocChanges,
+  mergeChanges,
+} from './doc/lifecycle.js';
 
 // Événements domaine
 export type {
@@ -12,12 +19,12 @@ export type {
   PlanUpdatedPayload,
   CaregiverInvitedPayload,
   CaregiverRevokedPayload,
-} from './events/types.js'
-export { canonicalBytes, signEvent, verifySignedEvent } from './events/sign.js'
-export { appendEvent } from './events/append.js'
+} from './events/types.js';
+export { canonicalBytes, signEvent, verifySignedEvent } from './events/sign.js';
+export { appendEvent } from './events/append.js';
 
 // Mailbox E2EE
-export type { EncryptedBlob } from './mailbox/encrypt.js'
-export { encryptChanges, decryptChanges } from './mailbox/encrypt.js'
-export type { SyncMessage } from './mailbox/message.js'
-export { encodeSyncMessage, decodeSyncMessage } from './mailbox/message.js'
+export type { EncryptedBlob } from './mailbox/encrypt.js';
+export { encryptChanges, decryptChanges } from './mailbox/encrypt.js';
+export type { SyncMessage } from './mailbox/message.js';
+export { encodeSyncMessage, decodeSyncMessage } from './mailbox/message.js';

--- a/packages/sync/src/mailbox/encrypt.test.ts
+++ b/packages/sync/src/mailbox/encrypt.test.ts
@@ -1,48 +1,48 @@
-import { describe, it, expect } from 'vitest'
-import { secretboxKeygen } from '@kinhale/crypto'
-import { encryptChanges, decryptChanges } from './encrypt.js'
+import { describe, it, expect } from 'vitest';
+import { secretboxKeygen } from '@kinhale/crypto';
+import { encryptChanges, decryptChanges } from './encrypt.js';
 
 describe('encryptChanges / decryptChanges', () => {
   it('encryptChanges retourne un EncryptedBlob avec nonce et ciphertext hex', async () => {
-    const key = await secretboxKeygen()
-    const changes = [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])]
-    const blob = await encryptChanges(changes, key)
-    expect(typeof blob.nonce).toBe('string')
-    expect(typeof blob.ciphertext).toBe('string')
-    expect(blob.nonce).toHaveLength(48) // 24 bytes × 2 hex chars
-    expect(blob.ciphertext.length).toBeGreaterThan(0)
-  })
+    const key = await secretboxKeygen();
+    const changes = [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])];
+    const blob = await encryptChanges(changes, key);
+    expect(typeof blob.nonce).toBe('string');
+    expect(typeof blob.ciphertext).toBe('string');
+    expect(blob.nonce).toHaveLength(48); // 24 bytes × 2 hex chars
+    expect(blob.ciphertext.length).toBeGreaterThan(0);
+  });
 
   it('decryptChanges restitue les Uint8Array originaux', async () => {
-    const key = await secretboxKeygen()
-    const original = [new Uint8Array([10, 20, 30]), new Uint8Array([40, 50])]
-    const blob = await encryptChanges(original, key)
-    const restored = await decryptChanges(blob, key)
-    expect(restored).toHaveLength(2)
-    expect(Array.from(restored[0]!)).toEqual([10, 20, 30])
-    expect(Array.from(restored[1]!)).toEqual([40, 50])
-  })
+    const key = await secretboxKeygen();
+    const original = [new Uint8Array([10, 20, 30]), new Uint8Array([40, 50])];
+    const blob = await encryptChanges(original, key);
+    const restored = await decryptChanges(blob, key);
+    expect(restored).toHaveLength(2);
+    expect(Array.from(restored[0]!)).toEqual([10, 20, 30]);
+    expect(Array.from(restored[1]!)).toEqual([40, 50]);
+  });
 
   it('deux encryptChanges du même plaintext → nonces différents', async () => {
-    const key = await secretboxKeygen()
-    const changes = [new Uint8Array([1, 2, 3])]
-    const b1 = await encryptChanges(changes, key)
-    const b2 = await encryptChanges(changes, key)
-    expect(b1.nonce).not.toBe(b2.nonce)
-    expect(b1.ciphertext).not.toBe(b2.ciphertext)
-  })
+    const key = await secretboxKeygen();
+    const changes = [new Uint8Array([1, 2, 3])];
+    const b1 = await encryptChanges(changes, key);
+    const b2 = await encryptChanges(changes, key);
+    expect(b1.nonce).not.toBe(b2.nonce);
+    expect(b1.ciphertext).not.toBe(b2.ciphertext);
+  });
 
   it('decryptChanges throw si la clé est incorrecte', async () => {
-    const key1 = await secretboxKeygen()
-    const key2 = await secretboxKeygen()
-    const blob = await encryptChanges([new Uint8Array([1, 2, 3])], key1)
-    await expect(decryptChanges(blob, key2)).rejects.toThrow()
-  })
+    const key1 = await secretboxKeygen();
+    const key2 = await secretboxKeygen();
+    const blob = await encryptChanges([new Uint8Array([1, 2, 3])], key1);
+    await expect(decryptChanges(blob, key2)).rejects.toThrow();
+  });
 
   it('decryptChanges fonctionne sur liste vide', async () => {
-    const key = await secretboxKeygen()
-    const blob = await encryptChanges([], key)
-    const restored = await decryptChanges(blob, key)
-    expect(restored).toHaveLength(0)
-  })
-})
+    const key = await secretboxKeygen();
+    const blob = await encryptChanges([], key);
+    const restored = await decryptChanges(blob, key);
+    expect(restored).toHaveLength(0);
+  });
+});

--- a/packages/sync/src/mailbox/encrypt.test.ts
+++ b/packages/sync/src/mailbox/encrypt.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { secretboxKeygen } from '@kinhale/crypto'
+import { encryptChanges, decryptChanges } from './encrypt.js'
+import type { EncryptedBlob } from './encrypt.js'
+
+describe('encryptChanges / decryptChanges', () => {
+  it('encryptChanges retourne un EncryptedBlob avec nonce et ciphertext hex', async () => {
+    const key = await secretboxKeygen()
+    const changes = [new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])]
+    const blob = await encryptChanges(changes, key)
+    expect(typeof blob.nonce).toBe('string')
+    expect(typeof blob.ciphertext).toBe('string')
+    expect(blob.nonce).toHaveLength(48) // 24 bytes × 2 hex chars
+    expect(blob.ciphertext.length).toBeGreaterThan(0)
+  })
+
+  it('decryptChanges restitue les Uint8Array originaux', async () => {
+    const key = await secretboxKeygen()
+    const original = [new Uint8Array([10, 20, 30]), new Uint8Array([40, 50])]
+    const blob = await encryptChanges(original, key)
+    const restored = await decryptChanges(blob, key)
+    expect(restored).toHaveLength(2)
+    expect(Array.from(restored[0]!)).toEqual([10, 20, 30])
+    expect(Array.from(restored[1]!)).toEqual([40, 50])
+  })
+
+  it('deux encryptChanges du même plaintext → nonces différents', async () => {
+    const key = await secretboxKeygen()
+    const changes = [new Uint8Array([1, 2, 3])]
+    const b1 = await encryptChanges(changes, key)
+    const b2 = await encryptChanges(changes, key)
+    expect(b1.nonce).not.toBe(b2.nonce)
+    expect(b1.ciphertext).not.toBe(b2.ciphertext)
+  })
+
+  it('decryptChanges throw si la clé est incorrecte', async () => {
+    const key1 = await secretboxKeygen()
+    const key2 = await secretboxKeygen()
+    const blob = await encryptChanges([new Uint8Array([1, 2, 3])], key1)
+    await expect(decryptChanges(blob, key2)).rejects.toThrow()
+  })
+
+  it('decryptChanges fonctionne sur liste vide', async () => {
+    const key = await secretboxKeygen()
+    const blob = await encryptChanges([], key)
+    const restored = await decryptChanges(blob, key)
+    expect(restored).toHaveLength(0)
+  })
+})

--- a/packages/sync/src/mailbox/encrypt.test.ts
+++ b/packages/sync/src/mailbox/encrypt.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { secretboxKeygen } from '@kinhale/crypto'
 import { encryptChanges, decryptChanges } from './encrypt.js'
-import type { EncryptedBlob } from './encrypt.js'
 
 describe('encryptChanges / decryptChanges', () => {
   it('encryptChanges retourne un EncryptedBlob avec nonce et ciphertext hex', async () => {

--- a/packages/sync/src/mailbox/encrypt.ts
+++ b/packages/sync/src/mailbox/encrypt.ts
@@ -1,0 +1,47 @@
+import { secretbox, secretboxOpen, secretboxNonce } from '@kinhale/crypto'
+
+/**
+ * Blob chiffré à envoyer au relais.
+ * Nonce et ciphertext encodés en hex pour sérialisation JSON.
+ */
+export interface EncryptedBlob {
+  /** Hex, 24 bytes XChaCha20 nonce (48 chars) */
+  readonly nonce: string
+  /** Hex, plaintext chiffré + MAC Poly1305 */
+  readonly ciphertext: string
+}
+
+/**
+ * Chiffre un tableau de Uint8Array (changes Automerge) avec la clé de groupe.
+ * Sérialisation : JSON d'un tableau de hex strings, puis XChaCha20-Poly1305.
+ */
+export async function encryptChanges(
+  changes: Uint8Array[],
+  groupKey: Uint8Array,
+): Promise<EncryptedBlob> {
+  const serialized = JSON.stringify(
+    changes.map((c) => Buffer.from(c).toString('hex')),
+  )
+  const plaintext = new TextEncoder().encode(serialized)
+  const nonce = await secretboxNonce()
+  const ciphertext = await secretbox(plaintext, nonce, groupKey)
+  return {
+    nonce: Buffer.from(nonce).toString('hex'),
+    ciphertext: Buffer.from(ciphertext).toString('hex'),
+  }
+}
+
+/**
+ * Déchiffre un EncryptedBlob et restitue le tableau de Uint8Array d'origine.
+ * Throws si le MAC est invalide (clé incorrecte ou blob corrompu).
+ */
+export async function decryptChanges(
+  blob: EncryptedBlob,
+  groupKey: Uint8Array,
+): Promise<Uint8Array[]> {
+  const nonce = Buffer.from(blob.nonce, 'hex')
+  const ciphertext = Buffer.from(blob.ciphertext, 'hex')
+  const plaintext = await secretboxOpen(ciphertext, nonce, groupKey)
+  const hexArray = JSON.parse(new TextDecoder().decode(plaintext)) as string[]
+  return hexArray.map((h) => Buffer.from(h, 'hex'))
+}

--- a/packages/sync/src/mailbox/encrypt.ts
+++ b/packages/sync/src/mailbox/encrypt.ts
@@ -1,4 +1,4 @@
-import { secretbox, secretboxOpen, secretboxNonce } from '@kinhale/crypto'
+import { secretbox, secretboxOpen, secretboxNonce } from '@kinhale/crypto';
 
 /**
  * Blob chiffré à envoyer au relais.
@@ -6,9 +6,9 @@ import { secretbox, secretboxOpen, secretboxNonce } from '@kinhale/crypto'
  */
 export interface EncryptedBlob {
   /** Hex, 24 bytes XChaCha20 nonce (48 chars) */
-  readonly nonce: string
+  readonly nonce: string;
   /** Hex, plaintext chiffré + MAC Poly1305 */
-  readonly ciphertext: string
+  readonly ciphertext: string;
 }
 
 /**
@@ -19,16 +19,14 @@ export async function encryptChanges(
   changes: Uint8Array[],
   groupKey: Uint8Array,
 ): Promise<EncryptedBlob> {
-  const serialized = JSON.stringify(
-    changes.map((c) => Buffer.from(c).toString('hex')),
-  )
-  const plaintext = new TextEncoder().encode(serialized)
-  const nonce = await secretboxNonce()
-  const ciphertext = await secretbox(plaintext, nonce, groupKey)
+  const serialized = JSON.stringify(changes.map((c) => Buffer.from(c).toString('hex')));
+  const plaintext = new TextEncoder().encode(serialized);
+  const nonce = await secretboxNonce();
+  const ciphertext = await secretbox(plaintext, nonce, groupKey);
   return {
     nonce: Buffer.from(nonce).toString('hex'),
     ciphertext: Buffer.from(ciphertext).toString('hex'),
-  }
+  };
 }
 
 /**
@@ -39,9 +37,9 @@ export async function decryptChanges(
   blob: EncryptedBlob,
   groupKey: Uint8Array,
 ): Promise<Uint8Array[]> {
-  const nonce = Buffer.from(blob.nonce, 'hex')
-  const ciphertext = Buffer.from(blob.ciphertext, 'hex')
-  const plaintext = await secretboxOpen(ciphertext, nonce, groupKey)
-  const hexArray = JSON.parse(new TextDecoder().decode(plaintext)) as string[]
-  return hexArray.map((h) => Buffer.from(h, 'hex'))
+  const nonce = Buffer.from(blob.nonce, 'hex');
+  const ciphertext = Buffer.from(blob.ciphertext, 'hex');
+  const plaintext = await secretboxOpen(ciphertext, nonce, groupKey);
+  const hexArray = JSON.parse(new TextDecoder().decode(plaintext)) as string[];
+  return hexArray.map((h) => Buffer.from(h, 'hex'));
 }

--- a/packages/sync/src/mailbox/message.test.ts
+++ b/packages/sync/src/mailbox/message.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
-import { encodeSyncMessage, decodeSyncMessage } from './message.js'
-import type { SyncMessage } from './message.js'
+import { describe, it, expect } from 'vitest';
+import { encodeSyncMessage, decodeSyncMessage } from './message.js';
+import type { SyncMessage } from './message.js';
 
 const makeMsg = (): SyncMessage => ({
   mailboxId: 'mailbox-opaque-001',
@@ -8,33 +8,33 @@ const makeMsg = (): SyncMessage => ({
   blob: { nonce: 'a'.repeat(48), ciphertext: 'b'.repeat(64) },
   seq: 1,
   sentAtMs: 1_700_000_000_000,
-})
+});
 
 describe('SyncMessage encode/decode', () => {
   it('encodeSyncMessage retourne une string JSON valide', () => {
-    const json = encodeSyncMessage(makeMsg())
-    expect(typeof json).toBe('string')
-    const parsed = JSON.parse(json)
-    expect(parsed.mailboxId).toBe('mailbox-opaque-001')
-    expect(parsed.seq).toBe(1)
-  })
+    const json = encodeSyncMessage(makeMsg());
+    expect(typeof json).toBe('string');
+    const parsed = JSON.parse(json);
+    expect(parsed.mailboxId).toBe('mailbox-opaque-001');
+    expect(parsed.seq).toBe(1);
+  });
 
   it('decodeSyncMessage restitue le message original', () => {
-    const original = makeMsg()
-    const json = encodeSyncMessage(original)
-    const decoded = decodeSyncMessage(json)
-    expect(decoded.mailboxId).toBe(original.mailboxId)
-    expect(decoded.deviceId).toBe(original.deviceId)
-    expect(decoded.seq).toBe(original.seq)
-    expect(decoded.blob.nonce).toBe(original.blob.nonce)
-  })
+    const original = makeMsg();
+    const json = encodeSyncMessage(original);
+    const decoded = decodeSyncMessage(json);
+    expect(decoded.mailboxId).toBe(original.mailboxId);
+    expect(decoded.deviceId).toBe(original.deviceId);
+    expect(decoded.seq).toBe(original.seq);
+    expect(decoded.blob.nonce).toBe(original.blob.nonce);
+  });
 
   it('decodeSyncMessage throw sur JSON invalide', () => {
-    expect(() => decodeSyncMessage('not json')).toThrow()
-  })
+    expect(() => decodeSyncMessage('not json')).toThrow();
+  });
 
   it('decodeSyncMessage throw si champ obligatoire manquant', () => {
-    const incomplete = JSON.stringify({ mailboxId: 'x', deviceId: 'y' })
-    expect(() => decodeSyncMessage(incomplete)).toThrow('sync: message invalide')
-  })
-})
+    const incomplete = JSON.stringify({ mailboxId: 'x', deviceId: 'y' });
+    expect(() => decodeSyncMessage(incomplete)).toThrow('sync: message invalide');
+  });
+});

--- a/packages/sync/src/mailbox/message.test.ts
+++ b/packages/sync/src/mailbox/message.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest'
+import { encodeSyncMessage, decodeSyncMessage } from './message.js'
+import type { SyncMessage } from './message.js'
+
+const makeMsg = (): SyncMessage => ({
+  mailboxId: 'mailbox-opaque-001',
+  deviceId: 'device-001',
+  blob: { nonce: 'a'.repeat(48), ciphertext: 'b'.repeat(64) },
+  seq: 1,
+  sentAtMs: 1_700_000_000_000,
+})
+
+describe('SyncMessage encode/decode', () => {
+  it('encodeSyncMessage retourne une string JSON valide', () => {
+    const json = encodeSyncMessage(makeMsg())
+    expect(typeof json).toBe('string')
+    const parsed = JSON.parse(json)
+    expect(parsed.mailboxId).toBe('mailbox-opaque-001')
+    expect(parsed.seq).toBe(1)
+  })
+
+  it('decodeSyncMessage restitue le message original', () => {
+    const original = makeMsg()
+    const json = encodeSyncMessage(original)
+    const decoded = decodeSyncMessage(json)
+    expect(decoded.mailboxId).toBe(original.mailboxId)
+    expect(decoded.deviceId).toBe(original.deviceId)
+    expect(decoded.seq).toBe(original.seq)
+    expect(decoded.blob.nonce).toBe(original.blob.nonce)
+  })
+
+  it('decodeSyncMessage throw sur JSON invalide', () => {
+    expect(() => decodeSyncMessage('not json')).toThrow()
+  })
+
+  it('decodeSyncMessage throw si champ obligatoire manquant', () => {
+    const incomplete = JSON.stringify({ mailboxId: 'x', deviceId: 'y' })
+    expect(() => decodeSyncMessage(incomplete)).toThrow('sync: message invalide')
+  })
+})

--- a/packages/sync/src/mailbox/message.ts
+++ b/packages/sync/src/mailbox/message.ts
@@ -1,4 +1,4 @@
-import type { EncryptedBlob } from './encrypt.js'
+import type { EncryptedBlob } from './encrypt.js';
 
 /**
  * Enveloppe de synchronisation envoyée au relais (WebSocket ou HTTP).
@@ -6,42 +6,42 @@ import type { EncryptedBlob } from './encrypt.js'
  */
 export interface SyncMessage {
   /** Identifiant opaque du groupe/foyer */
-  readonly mailboxId: string
-  readonly deviceId: string
+  readonly mailboxId: string;
+  readonly deviceId: string;
   /** Contenu chiffré : changes Automerge chiffrés XChaCha20 */
-  readonly blob: EncryptedBlob
+  readonly blob: EncryptedBlob;
   /** Numéro de séquence monotone côté émetteur */
-  readonly seq: number
+  readonly seq: number;
   /** Timestamp d'émission UTC ms */
-  readonly sentAtMs: number
+  readonly sentAtMs: number;
 }
 
 export function encodeSyncMessage(msg: SyncMessage): string {
-  return JSON.stringify(msg)
+  return JSON.stringify(msg);
 }
 
 export function decodeSyncMessage(json: string): SyncMessage {
-  const parsed: unknown = JSON.parse(json)
+  const parsed: unknown = JSON.parse(json);
   if (!isSyncMessage(parsed)) {
-    throw new Error('sync: message invalide')
+    throw new Error('sync: message invalide');
   }
-  return parsed
+  return parsed;
 }
 
 function isSyncMessage(v: unknown): v is SyncMessage {
-  if (typeof v !== 'object' || v === null) return false
-  const m = v as Record<string, unknown>
+  if (typeof v !== 'object' || v === null) return false;
+  const m = v as Record<string, unknown>;
   return (
     typeof m['mailboxId'] === 'string' &&
     typeof m['deviceId'] === 'string' &&
     typeof m['seq'] === 'number' &&
     typeof m['sentAtMs'] === 'number' &&
     isEncryptedBlob(m['blob'])
-  )
+  );
 }
 
 function isEncryptedBlob(v: unknown): v is EncryptedBlob {
-  if (typeof v !== 'object' || v === null) return false
-  const b = v as Record<string, unknown>
-  return typeof b['nonce'] === 'string' && typeof b['ciphertext'] === 'string'
+  if (typeof v !== 'object' || v === null) return false;
+  const b = v as Record<string, unknown>;
+  return typeof b['nonce'] === 'string' && typeof b['ciphertext'] === 'string';
 }

--- a/packages/sync/src/mailbox/message.ts
+++ b/packages/sync/src/mailbox/message.ts
@@ -1,0 +1,47 @@
+import type { EncryptedBlob } from './encrypt.js'
+
+/**
+ * Enveloppe de synchronisation envoyée au relais (WebSocket ou HTTP).
+ * Le relais indexe par mailboxId + seq mais ne peut jamais lire blob.
+ */
+export interface SyncMessage {
+  /** Identifiant opaque du groupe/foyer */
+  readonly mailboxId: string
+  readonly deviceId: string
+  /** Contenu chiffré : changes Automerge chiffrés XChaCha20 */
+  readonly blob: EncryptedBlob
+  /** Numéro de séquence monotone côté émetteur */
+  readonly seq: number
+  /** Timestamp d'émission UTC ms */
+  readonly sentAtMs: number
+}
+
+export function encodeSyncMessage(msg: SyncMessage): string {
+  return JSON.stringify(msg)
+}
+
+export function decodeSyncMessage(json: string): SyncMessage {
+  const parsed: unknown = JSON.parse(json)
+  if (!isSyncMessage(parsed)) {
+    throw new Error('sync: message invalide')
+  }
+  return parsed
+}
+
+function isSyncMessage(v: unknown): v is SyncMessage {
+  if (typeof v !== 'object' || v === null) return false
+  const m = v as Record<string, unknown>
+  return (
+    typeof m['mailboxId'] === 'string' &&
+    typeof m['deviceId'] === 'string' &&
+    typeof m['seq'] === 'number' &&
+    typeof m['sentAtMs'] === 'number' &&
+    isEncryptedBlob(m['blob'])
+  )
+}
+
+function isEncryptedBlob(v: unknown): v is EncryptedBlob {
+  if (typeof v !== 'object' || v === null) return false
+  const b = v as Record<string, unknown>
+  return typeof b['nonce'] === 'string' && typeof b['ciphertext'] === 'string'
+}

--- a/packages/sync/tsconfig.json
+++ b/packages/sync/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "@kinhale/tsconfig/library.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/sync/vitest.config.ts
+++ b/packages/sync/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: false,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/*.test.ts', 'src/**/index.ts'],
+      thresholds: {
+        lines: 80,
+        functions: 80,
+        branches: 80,
+        statements: 80,
+      },
+    },
+  },
+})

--- a/packages/sync/vitest.config.ts
+++ b/packages/sync/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vitest/config'
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
@@ -17,4 +17,4 @@ export default defineConfig({
       },
     },
   },
-})
+});

--- a/packages/test-utils/eslint.config.js
+++ b/packages/test-utils/eslint.config.js
@@ -1,2 +1,2 @@
-import config from '@kinhale/eslint-config'
-export default config
+import config from '@kinhale/eslint-config';
+export default config;

--- a/packages/test-utils/eslint.config.js
+++ b/packages/test-utils/eslint.config.js
@@ -1,0 +1,2 @@
+import config from '@kinhale/eslint-config'
+export default config

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@kinhale/test-utils",
+  "version": "0.1.0",
+  "description": "Helpers de test partagés pour Kinhale (factories, fixtures, crypto deterministe)",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "lint": "eslint src",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@kinhale/crypto": "workspace:*",
+    "@kinhale/domain": "workspace:*"
+  },
+  "devDependencies": {
+    "@kinhale/eslint-config": "workspace:*",
+    "@kinhale/tsconfig": "workspace:*",
+    "@types/node": "^22.10.5",
+    "typescript": "^5.7.3",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/test-utils/src/crypto/test-keys.ts
+++ b/packages/test-utils/src/crypto/test-keys.ts
@@ -1,0 +1,14 @@
+import { generateSigningKeypair } from '@kinhale/crypto'
+
+let _adminKeypair: Awaited<ReturnType<typeof generateSigningKeypair>> | null = null
+let _caregiverKeypair: Awaited<ReturnType<typeof generateSigningKeypair>> | null = null
+
+export async function getAdminTestKeypair() {
+  if (!_adminKeypair) _adminKeypair = await generateSigningKeypair()
+  return _adminKeypair
+}
+
+export async function getCaregiverTestKeypair() {
+  if (!_caregiverKeypair) _caregiverKeypair = await generateSigningKeypair()
+  return _caregiverKeypair
+}

--- a/packages/test-utils/src/crypto/test-keys.ts
+++ b/packages/test-utils/src/crypto/test-keys.ts
@@ -1,14 +1,14 @@
-import { generateSigningKeypair } from '@kinhale/crypto'
+import { generateSigningKeypair } from '@kinhale/crypto';
 
-let _adminKeypair: Awaited<ReturnType<typeof generateSigningKeypair>> | null = null
-let _caregiverKeypair: Awaited<ReturnType<typeof generateSigningKeypair>> | null = null
+let _adminKeypair: Awaited<ReturnType<typeof generateSigningKeypair>> | null = null;
+let _caregiverKeypair: Awaited<ReturnType<typeof generateSigningKeypair>> | null = null;
 
 export async function getAdminTestKeypair() {
-  if (!_adminKeypair) _adminKeypair = await generateSigningKeypair()
-  return _adminKeypair
+  if (!_adminKeypair) _adminKeypair = await generateSigningKeypair();
+  return _adminKeypair;
 }
 
 export async function getCaregiverTestKeypair() {
-  if (!_caregiverKeypair) _caregiverKeypair = await generateSigningKeypair()
-  return _caregiverKeypair
+  if (!_caregiverKeypair) _caregiverKeypair = await generateSigningKeypair();
+  return _caregiverKeypair;
 }

--- a/packages/test-utils/src/factories/caregiver.ts
+++ b/packages/test-utils/src/factories/caregiver.ts
@@ -1,9 +1,9 @@
-import type { Caregiver } from '@kinhale/domain'
+import type { Caregiver } from '@kinhale/domain';
 
-let _counter = 0
+let _counter = 0;
 
 export function createTestCaregiver(overrides: Partial<Caregiver> = {}): Caregiver {
-  const id = `caregiver-test-${++_counter}`
+  const id = `caregiver-test-${++_counter}`;
   return {
     id,
     householdId: 'household-test-1',
@@ -14,5 +14,5 @@ export function createTestCaregiver(overrides: Partial<Caregiver> = {}): Caregiv
     activatedAt: new Date('2026-01-01T00:01:00Z'),
     revokedAt: null,
     ...overrides,
-  }
+  };
 }

--- a/packages/test-utils/src/factories/caregiver.ts
+++ b/packages/test-utils/src/factories/caregiver.ts
@@ -1,0 +1,18 @@
+import type { Caregiver } from '@kinhale/domain'
+
+let _counter = 0
+
+export function createTestCaregiver(overrides: Partial<Caregiver> = {}): Caregiver {
+  const id = `caregiver-test-${++_counter}`
+  return {
+    id,
+    householdId: 'household-test-1',
+    role: 'admin',
+    status: 'active',
+    displayName: `Aidant Test ${_counter}`,
+    invitedAt: new Date('2026-01-01T00:00:00Z'),
+    activatedAt: new Date('2026-01-01T00:01:00Z'),
+    revokedAt: null,
+    ...overrides,
+  }
+}

--- a/packages/test-utils/src/factories/dose.ts
+++ b/packages/test-utils/src/factories/dose.ts
@@ -1,9 +1,9 @@
-import type { Dose } from '@kinhale/domain'
+import type { Dose } from '@kinhale/domain';
 
-let _counter = 0
+let _counter = 0;
 
 export function createTestDose(overrides: Partial<Dose> = {}): Dose {
-  const id = `dose-test-${++_counter}`
+  const id = `dose-test-${++_counter}`;
   return {
     id,
     householdId: 'household-test-1',
@@ -21,5 +21,5 @@ export function createTestDose(overrides: Partial<Dose> = {}): Dose {
     freeFormTag: null,
     voidedReason: null,
     ...overrides,
-  }
+  };
 }

--- a/packages/test-utils/src/factories/dose.ts
+++ b/packages/test-utils/src/factories/dose.ts
@@ -1,0 +1,25 @@
+import type { Dose } from '@kinhale/domain'
+
+let _counter = 0
+
+export function createTestDose(overrides: Partial<Dose> = {}): Dose {
+  const id = `dose-test-${++_counter}`
+  return {
+    id,
+    householdId: 'household-test-1',
+    childId: 'child-test-1',
+    pumpId: 'pump-test-1',
+    caregiverId: 'caregiver-test-1',
+    type: 'maintenance',
+    status: 'confirmed',
+    source: 'manual',
+    dosesAdministered: 1,
+    administeredAtUtc: new Date('2026-01-01T08:00:00Z'),
+    recordedAtUtc: new Date('2026-01-01T08:00:05Z'),
+    symptoms: [],
+    circumstances: [],
+    freeFormTag: null,
+    voidedReason: null,
+    ...overrides,
+  }
+}

--- a/packages/test-utils/src/factories/household.ts
+++ b/packages/test-utils/src/factories/household.ts
@@ -1,9 +1,9 @@
-import type { Household } from '@kinhale/domain'
+import type { Household } from '@kinhale/domain';
 
-let _counter = 0
+let _counter = 0;
 
 export function createTestHousehold(overrides: Partial<Household> = {}): Household {
-  const id = `household-test-${++_counter}`
+  const id = `household-test-${++_counter}`;
   return {
     id,
     createdAt: new Date('2026-01-01T00:00:00Z'),
@@ -11,5 +11,5 @@ export function createTestHousehold(overrides: Partial<Household> = {}): Househo
     locale: 'fr',
     caregivers: [],
     ...overrides,
-  }
+  };
 }

--- a/packages/test-utils/src/factories/household.ts
+++ b/packages/test-utils/src/factories/household.ts
@@ -1,0 +1,15 @@
+import type { Household } from '@kinhale/domain'
+
+let _counter = 0
+
+export function createTestHousehold(overrides: Partial<Household> = {}): Household {
+  const id = `household-test-${++_counter}`
+  return {
+    id,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    timezone: 'America/Montreal',
+    locale: 'fr',
+    caregivers: [],
+    ...overrides,
+  }
+}

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,4 +1,4 @@
-export { createTestHousehold } from './factories/household.js'
-export { createTestCaregiver } from './factories/caregiver.js'
-export { createTestDose } from './factories/dose.js'
-export { getAdminTestKeypair, getCaregiverTestKeypair } from './crypto/test-keys.js'
+export { createTestHousehold } from './factories/household.js';
+export { createTestCaregiver } from './factories/caregiver.js';
+export { createTestDose } from './factories/dose.js';
+export { getAdminTestKeypair, getCaregiverTestKeypair } from './crypto/test-keys.js';

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,0 +1,4 @@
+export { createTestHousehold } from './factories/household.js'
+export { createTestCaregiver } from './factories/caregiver.js'
+export { createTestDose } from './factories/dose.js'
+export { getAdminTestKeypair, getCaregiverTestKeypair } from './crypto/test-keys.js'

--- a/packages/test-utils/tsconfig.json
+++ b/packages/test-utils/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "@kinhale/tsconfig/library.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "types": ["node"]
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,10 @@ importers:
         version: 5.9.3
 
   packages/crypto:
+    dependencies:
+      libsodium-wrappers-sumo:
+        specifier: ^0.8.4
+        version: 0.8.4
     devDependencies:
       '@kinhale/eslint-config':
         specifier: workspace:*
@@ -35,6 +39,9 @@ importers:
       '@kinhale/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/libsodium-wrappers-sumo':
+        specifier: ^0.8.2
+        version: 0.8.2
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.17
@@ -489,6 +496,10 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/libsodium-wrappers-sumo@0.8.2':
+    resolution: {integrity: sha512-uFOBpg/r21hExVlh2ty8YpDfSR+Yy3Jn8XS4+SSjitbhTxdYq+pBz/49XRxyUFe8SzqujHf/Wu0/O4d+FUtNfQ==}
+    deprecated: This is a stub types definition. libsodium-wrappers-sumo provides its own type definitions, so you do not need this installed.
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -836,6 +847,12 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  libsodium-sumo@0.8.4:
+    resolution: {integrity: sha512-TMtHShQfVVsaxDygyapvUC3o7YsPgXa/hRWeIgzyFz6w5k/1hirGptCxp1U7XwW3rCskaTTYKgV10v86UiGgNw==}
+
+  libsodium-wrappers-sumo@0.8.4:
+    resolution: {integrity: sha512-ql7hcgulKZ3ekfa2DGAogcCKsWU0diA/0nArz1CFzh93WQdb46/Kj18ka/Hifq6uA3Ush34Pc6vU/6HXeRwUkg==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1362,6 +1379,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/libsodium-wrappers-sumo@0.8.2':
+    dependencies:
+      libsodium-wrappers-sumo: 0.8.4
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -1759,6 +1780,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  libsodium-sumo@0.8.4: {}
+
+  libsodium-wrappers-sumo@0.8.4:
+    dependencies:
+      libsodium-sumo: 0.8.4
 
   locate-path@6.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,70 @@ importers:
         specifier: ^5.7.3
         version: 5.9.3
 
+  apps/api:
+    dependencies:
+      '@fastify/cors':
+        specifier: ^10.0.0
+        version: 10.1.0
+      '@fastify/jwt':
+        specifier: ^9.0.0
+        version: 9.1.0
+      '@fastify/websocket':
+        specifier: ^11.0.0
+        version: 11.2.0
+      '@kinhale/crypto':
+        specifier: workspace:*
+        version: link:../../packages/crypto
+      drizzle-orm:
+        specifier: ^0.38.0
+        version: 0.38.4(@types/pg@8.20.0)(pg@8.20.0)
+      fastify:
+        specifier: ^5.0.0
+        version: 5.8.5
+      fastify-plugin:
+        specifier: ^5.0.0
+        version: 5.1.0
+      pg:
+        specifier: ^8.13.0
+        version: 8.20.0
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+    devDependencies:
+      '@kinhale/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@kinhale/tsconfig':
+        specifier: workspace:*
+        version: link:../../packages/tsconfig
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.17
+      '@types/pg':
+        specifier: ^8.11.0
+        version: 8.20.0
+      '@types/ws':
+        specifier: ^8.5.0
+        version: 8.18.1
+      drizzle-kit:
+        specifier: ^0.30.0
+        version: 0.30.6
+      eslint:
+        specifier: ^9.18.0
+        version: 9.39.4
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.2
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
+      ws:
+        specifier: ^8.18.0
+        version: 8.20.0
+
   packages/crypto:
     dependencies:
       libsodium-wrappers-sumo:
@@ -47,7 +111,7 @@ importers:
         version: 22.19.17
       '@vitest/coverage-v8':
         specifier: ^3.2.4
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.17))
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0))
       eslint:
         specifier: ^9.18.0
         version: 9.39.4
@@ -56,7 +120,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.2
-        version: 3.2.4(@types/node@22.19.17)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
   packages/domain:
     dependencies:
@@ -81,7 +145,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.2
-        version: 3.2.4(@types/node@22.19.17)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
   packages/eslint-config:
     dependencies:
@@ -121,7 +185,7 @@ importers:
         version: 22.19.17
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/node@22.19.17))
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0))
       eslint:
         specifier: ^9.18.0
         version: 9.39.4
@@ -130,7 +194,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.2
-        version: 3.2.4(@types/node@22.19.17)
+        version: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
 
   packages/test-utils:
     dependencies:
@@ -189,6 +253,23 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild/aix-ppc64@0.19.12':
+    resolution: {integrity: sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
     engines: {node: '>=12'}
@@ -201,6 +282,18 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.19.12':
+    resolution: {integrity: sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -211,6 +304,18 @@ packages:
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.19.12':
+    resolution: {integrity: sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.21.5':
@@ -225,6 +330,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.19.12':
+    resolution: {integrity: sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -237,6 +354,18 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.19.12':
+    resolution: {integrity: sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.21.5':
     resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
     engines: {node: '>=12'}
@@ -247,6 +376,18 @@ packages:
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.19.12':
+    resolution: {integrity: sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.21.5':
@@ -261,6 +402,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.19.12':
+    resolution: {integrity: sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.21.5':
     resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
     engines: {node: '>=12'}
@@ -271,6 +424,18 @@ packages:
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.19.12':
+    resolution: {integrity: sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.21.5':
@@ -285,6 +450,18 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.19.12':
+    resolution: {integrity: sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.21.5':
     resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
     engines: {node: '>=12'}
@@ -295,6 +472,18 @@ packages:
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.19.12':
+    resolution: {integrity: sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.21.5':
@@ -309,6 +498,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.19.12':
+    resolution: {integrity: sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.21.5':
     resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
     engines: {node: '>=12'}
@@ -319,6 +520,18 @@ packages:
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.19.12':
+    resolution: {integrity: sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.21.5':
@@ -333,6 +546,18 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.19.12':
+    resolution: {integrity: sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.21.5':
     resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
     engines: {node: '>=12'}
@@ -343,6 +568,18 @@ packages:
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.19.12':
+    resolution: {integrity: sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.21.5':
@@ -357,6 +594,18 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.19.12':
+    resolution: {integrity: sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.21.5':
     resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
     engines: {node: '>=12'}
@@ -369,6 +618,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.19.12':
+    resolution: {integrity: sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -379,6 +640,18 @@ packages:
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.19.12':
+    resolution: {integrity: sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.21.5':
@@ -399,6 +672,18 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.19.12':
+    resolution: {integrity: sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
@@ -415,6 +700,18 @@ packages:
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.19.12':
+    resolution: {integrity: sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -435,6 +732,18 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.19.12':
+    resolution: {integrity: sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
@@ -446,6 +755,18 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.19.12':
+    resolution: {integrity: sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
@@ -459,6 +780,18 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.19.12':
+    resolution: {integrity: sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
@@ -469,6 +802,18 @@ packages:
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.19.12':
+    resolution: {integrity: sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.21.5':
@@ -521,6 +866,33 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cors@10.1.0':
+    resolution: {integrity: sha512-MZyBCBJtII60CU9Xme/iE4aEy8G7QpzGR8zkdXZkDFt7ElEMachbE61tfhAG/bvSaULlqlf0huMT12T7iqEmdQ==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/jwt@9.1.0':
+    resolution: {integrity: sha512-CiGHCnS5cPMdb004c70sUWhQTfzrJHAeTywt7nVw6dAiI0z1o4WRvU94xfijhkaId4bIxTCOjFgn4sU+Gvk43w==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/websocket@11.2.0':
+    resolution: {integrity: sha512-3HrDPbAG1CzUCqnslgJxppvzaAZffieOVbLp1DAy1huCSynUWPifSvfdEDUR8HlJLp3sp1A36uOM2tJogADS8w==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -561,6 +933,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
+
+  '@petamoriken/float16@3.9.3':
+    resolution: {integrity: sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -753,6 +1135,12 @@ packages:
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.58.2':
     resolution: {integrity: sha512-aC2qc5thQahutKjP+cl8cgN9DWe3ZUqVko30CMSZHnFEHyhOYoZSzkGtAI2mcwZ38xeImDucI4dnqsHiOYuuCw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -879,6 +1267,9 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -889,8 +1280,19 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
+
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -911,6 +1313,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  asn1.js@5.4.1:
+    resolution: {integrity: sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -918,12 +1323,22 @@ packages:
   ast-v8-to-istanbul@0.3.12:
     resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bn.js@4.12.3:
+    resolution: {integrity: sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
@@ -934,6 +1349,9 @@ packages:
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -965,6 +1383,10 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -985,8 +1407,114 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  drizzle-kit@0.30.6:
+    resolution: {integrity: sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g==}
+    hasBin: true
+
+  drizzle-orm@0.38.4:
+    resolution: {integrity: sha512-s7/5BpLKO+WJRHspvpqTydxFob8i1vo2rEx4pY6TGY7QSMuUfWUuzaY0DIpXCkgHOo37BaFC+SJQb99dDUXT3Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/react': '>=18'
+      '@types/sql.js': '*'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      react: '>=18'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/react':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -994,8 +1522,30 @@ packages:
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.19.12:
+    resolution: {integrity: sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -1064,14 +1614,49 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-json-stringify@6.3.0:
+    resolution: {integrity: sha512-oRCntNDY/329HJPlmdNLIdogNtt6Vyjb1WuT01Soss3slIdyUp8kAcDU3saQTOquEK8KFVfwIIF7FebxUAu+yA==}
+
+  fast-jwt@5.0.6:
+    resolution: {integrity: sha512-LPE7OCGUl11q3ZgW681cEU2d0d2JZ37hhJAmetCgNyW8waVaJVZXhyFF6U2so1Iim58Yc7pfxJe2P7MNetQH2g==}
+    engines: {node: '>=20'}
+
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fastfall@1.5.1:
+    resolution: {integrity: sha512-KH6p+Z8AKPXnmA7+Iz2Lh8ARCMr+8WNPVludm1LGkZoD2MjY6LVnRMtTKhkdzI+jr0RzQWXKzKyBJm1zoHEL4Q==}
+    engines: {node: '>=0.10.0'}
+
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
+
+  fastparallel@2.4.1:
+    resolution: {integrity: sha512-qUmhxPgNHmvRjZKBFUNI0oZuuH9OlSIOXmJ98lhKPxMZZ7zS/Fi0wRHOihDSz0R1YiIOjxzOY4bq65YTcdBi2Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fastseries@1.7.2:
+    resolution: {integrity: sha512-dTPFrPGS8SNSzAt7u/CbMKCJ3s01N04s4JFbORHcmyvVfVKmbhMD1VtRbh5enGHxkaQDqWyLefiKOGGmohGDDQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1085,6 +1670,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  find-my-way@9.5.0:
+    resolution: {integrity: sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==}
+    engines: {node: '>=20'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -1105,6 +1694,14 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  gel@2.2.0:
+    resolution: {integrity: sha512-q0ma7z2swmoamHQusey8ayo8+ilVdzDt4WTxSPzq/yRqvucWRfymRVMvNgmSC0XK7eNjjEZEcplxpgaNojKdmQ==}
+    engines: {node: '>= 18.0.0'}
+    hasBin: true
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -1146,6 +1743,13 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@2.3.0:
+    resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
+    engines: {node: '>= 10'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1160,6 +1764,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.5:
+    resolution: {integrity: sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w==}
+    engines: {node: '>=18'}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -1193,8 +1801,14 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1211,6 +1825,9 @@ packages:
 
   libsodium-wrappers-sumo@0.8.4:
     resolution: {integrity: sha512-ql7hcgulKZ3ekfa2DGAogcCKsWU0diA/0nArz1CFzh93WQdb46/Kj18ka/Hifq6uA3Ush34Pc6vU/6HXeRwUkg==}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -1235,6 +1852,9 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
+  minimalistic-assert@1.0.1:
+    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1250,6 +1870,12 @@ packages:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  mnemonist@0.40.0:
+    resolution: {integrity: sha512-kdd8AFNig2AD5Rkih7EPCXhu/iMvwevQFX/uEiGhZyPZi7fHqOoF4V4kHLpCfysxXMgQ4B52kdPMCwARshKvEg==}
+
+  mnemonist@0.40.3:
+    resolution: {integrity: sha512-Vjyr90sJ23CKKH/qPAgUKicw/v6pRoamxIEDFOF8uSgFME7DqPRpHgRTejWVjkdGg5dXj0/NyxZHZ9bcjH+2uQ==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -1260,6 +1886,16 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  obliterator@2.0.5:
+    resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1302,6 +1938,40 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pg-cloudflare@1.3.0:
+    resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
+
+  pg-connection-string@2.12.0:
+    resolution: {integrity: sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.13.0:
+    resolution: {integrity: sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.13.0:
+    resolution: {integrity: sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.20.0:
+    resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1309,9 +1979,35 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -1322,23 +2018,78 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex2@5.1.1:
+    resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
+    hasBin: true
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1348,6 +2099,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  shell-quote@1.8.3:
+    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+    engines: {node: '>= 0.4'}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -1355,15 +2110,35 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  steed@1.1.3:
+    resolution: {integrity: sha512-EUkci0FAUiE4IvGTSKcDJIQ/eRUP2JJb56+fvZ4sdnguLTqIdKjSxUe138poW8mkvKWXW2sFPrgTsxqoISnmoA==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -1372,6 +2147,9 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1395,6 +2173,10 @@ packages:
   test-exclude@7.0.2:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
     engines: {node: '>=18'}
+
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1426,11 +2208,20 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  toad-cache@3.7.0:
+    resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
+    engines: {node: '>=12'}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   turbo@2.9.6:
     resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
@@ -1457,6 +2248,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -1601,6 +2395,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@4.0.0:
+    resolution: {integrity: sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==}
+    engines: {node: ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -1618,9 +2417,31 @@ packages:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -1648,10 +2469,31 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@drizzle-team/brocli@0.10.2': {}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.0
+
+  '@esbuild/aix-ppc64@0.19.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.19.12':
     optional: true
 
   '@esbuild/android-arm64@0.21.5':
@@ -1660,10 +2502,22 @@ snapshots:
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm@0.19.12':
+    optional: true
+
   '@esbuild/android-arm@0.21.5':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.19.12':
     optional: true
 
   '@esbuild/android-x64@0.21.5':
@@ -1672,10 +2526,22 @@ snapshots:
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.19.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.19.12':
     optional: true
 
   '@esbuild/darwin-x64@0.21.5':
@@ -1684,10 +2550,22 @@ snapshots:
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.19.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.19.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.21.5':
@@ -1696,10 +2574,22 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm64@0.19.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.19.12':
     optional: true
 
   '@esbuild/linux-arm@0.21.5':
@@ -1708,10 +2598,22 @@ snapshots:
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ia32@0.19.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.19.12':
     optional: true
 
   '@esbuild/linux-loong64@0.21.5':
@@ -1720,10 +2622,22 @@ snapshots:
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.19.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.19.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.21.5':
@@ -1732,16 +2646,34 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.19.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
+  '@esbuild/linux-s390x@0.19.12':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.19.12':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -1753,6 +2685,12 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.19.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
     optional: true
 
@@ -1760,6 +2698,12 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.19.12':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -1771,10 +2715,22 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
+  '@esbuild/sunos-x64@0.19.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.19.12':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
@@ -1783,10 +2739,22 @@ snapshots:
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/win32-ia32@0.19.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.19.12':
     optional: true
 
   '@esbuild/win32-x64@0.21.5':
@@ -1841,6 +2809,51 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+
+  '@fastify/cors@10.1.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      mnemonist: 0.40.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.3.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/jwt@9.1.0':
+    dependencies:
+      '@fastify/error': 4.2.0
+      '@lukeed/ms': 2.0.2
+      fast-jwt: 5.0.6
+      fastify-plugin: 5.1.0
+      steed: 1.1.3
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.3.0
+
+  '@fastify/websocket@11.2.0':
+    dependencies:
+      duplexify: 4.1.3
+      fastify-plugin: 5.1.0
+      ws: 8.20.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -1881,6 +2894,12 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lukeed/ms@2.0.2': {}
+
+  '@petamoriken/float16@3.9.3': {}
+
+  '@pinojs/redact@0.4.0': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -1997,6 +3016,16 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 22.19.17
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.17
+
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -2088,7 +3117,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.17))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -2103,7 +3132,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@22.19.17)
+      vitest: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -2130,13 +3159,13 @@ snapshots:
     optionalDependencies:
       vite: 5.4.21(@types/node@22.19.17)
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.17)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -2189,11 +3218,17 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  abstract-logging@2.0.1: {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  ajv-formats@3.0.1(ajv@8.18.0):
+    optionalDependencies:
+      ajv: 8.18.0
 
   ajv@6.14.0:
     dependencies:
@@ -2201,6 +3236,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.18.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -2214,6 +3256,13 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  asn1.js@5.4.1:
+    dependencies:
+      bn.js: 4.12.3
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-v8-to-istanbul@0.3.12:
@@ -2222,9 +3271,18 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 10.0.0
 
+  atomic-sleep@1.0.0: {}
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.20.1
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bn.js@4.12.3: {}
 
   brace-expansion@1.1.14:
     dependencies:
@@ -2238,6 +3296,8 @@ snapshots:
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
+
+  buffer-from@1.1.2: {}
 
   cac@6.7.14: {}
 
@@ -2266,6 +3326,8 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  cookie@1.1.1: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -2280,13 +3342,105 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  dequal@2.0.3: {}
+
+  drizzle-kit@0.30.6:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.19.12
+      esbuild-register: 3.6.0(esbuild@0.19.12)
+      gel: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  drizzle-orm@0.38.4(@types/pg@8.20.0)(pg@8.20.0):
+    optionalDependencies:
+      '@types/pg': 8.20.0
+      pg: 8.20.0
+
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
+
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
 
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  env-paths@3.0.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  esbuild-register@3.6.0(esbuild@0.19.12):
+    dependencies:
+      debug: 4.4.3
+      esbuild: 0.19.12
+    transitivePeerDependencies:
+      - supports-color
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.19.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.19.12
+      '@esbuild/android-arm': 0.19.12
+      '@esbuild/android-arm64': 0.19.12
+      '@esbuild/android-x64': 0.19.12
+      '@esbuild/darwin-arm64': 0.19.12
+      '@esbuild/darwin-x64': 0.19.12
+      '@esbuild/freebsd-arm64': 0.19.12
+      '@esbuild/freebsd-x64': 0.19.12
+      '@esbuild/linux-arm': 0.19.12
+      '@esbuild/linux-arm64': 0.19.12
+      '@esbuild/linux-ia32': 0.19.12
+      '@esbuild/linux-loong64': 0.19.12
+      '@esbuild/linux-mips64el': 0.19.12
+      '@esbuild/linux-ppc64': 0.19.12
+      '@esbuild/linux-riscv64': 0.19.12
+      '@esbuild/linux-s390x': 0.19.12
+      '@esbuild/linux-x64': 0.19.12
+      '@esbuild/netbsd-x64': 0.19.12
+      '@esbuild/openbsd-x64': 0.19.12
+      '@esbuild/sunos-x64': 0.19.12
+      '@esbuild/win32-arm64': 0.19.12
+      '@esbuild/win32-ia32': 0.19.12
+      '@esbuild/win32-x64': 0.19.12
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -2419,11 +3573,73 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-decode-uri-component@1.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-json-stringify@6.3.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      fast-uri: 3.1.0
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
+  fast-jwt@5.0.6:
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      asn1.js: 5.4.1
+      ecdsa-sig-formatter: 1.0.11
+      mnemonist: 0.40.3
+
   fast-levenshtein@2.0.6: {}
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+
+  fast-uri@3.1.0: {}
+
+  fastfall@1.5.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fastify-plugin@5.1.0: {}
+
+  fastify@5.8.5:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.3.0
+      find-my-way: 9.5.0
+      light-my-request: 6.6.0
+      pino: 10.3.1
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.7.4
+      toad-cache: 3.7.0
+
+  fastparallel@2.4.1:
+    dependencies:
+      reusify: 1.1.0
+      xtend: 4.0.2
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fastseries@1.7.2:
+    dependencies:
+      reusify: 1.1.0
+      xtend: 4.0.2
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -2432,6 +3648,12 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  find-my-way@9.5.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.1
 
   find-up@5.0.0:
     dependencies:
@@ -2452,6 +3674,21 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  gel@2.2.0:
+    dependencies:
+      '@petamoriken/float16': 3.9.3
+      debug: 4.4.3
+      env-paths: 3.0.0
+      semver: 7.7.4
+      shell-quote: 1.8.3
+      which: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob-parent@6.0.2:
     dependencies:
@@ -2485,6 +3722,10 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
+  ipaddr.js@2.3.0: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -2494,6 +3735,8 @@ snapshots:
       is-extglob: 2.1.1
 
   isexe@2.0.0: {}
+
+  isexe@3.1.5: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -2532,7 +3775,13 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -2550,6 +3799,12 @@ snapshots:
   libsodium-wrappers-sumo@0.8.4:
     dependencies:
       libsodium-sumo: 0.8.4
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
 
   locate-path@6.0.0:
     dependencies:
@@ -2575,6 +3830,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
+  minimalistic-assert@1.0.1: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -2589,11 +3846,27 @@ snapshots:
 
   minipass@7.1.3: {}
 
+  mnemonist@0.40.0:
+    dependencies:
+      obliterator: 2.0.5
+
+  mnemonist@0.40.3:
+    dependencies:
+      obliterator: 2.0.5
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  obliterator@2.0.5: {}
+
+  on-exit-leak-free@2.1.2: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
 
   optionator@0.9.4:
     dependencies:
@@ -2633,9 +3906,64 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pg-cloudflare@1.3.0:
+    optional: true
+
+  pg-connection-string@2.12.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.13.0(pg@8.20.0):
+    dependencies:
+      pg: 8.20.0
+
+  pg-protocol@1.13.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.20.0:
+    dependencies:
+      pg-connection-string: 2.12.0
+      pg-pool: 3.13.0(pg@8.20.0)
+      pg-protocol: 1.13.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.3.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
 
   postcss@8.5.10:
     dependencies:
@@ -2643,13 +3971,47 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
   prelude-ls@1.2.1: {}
 
   prettier@3.8.3: {}
 
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
+
   punycode@2.3.1: {}
 
+  quick-format-unescaped@4.0.4: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
+  real-require@0.2.0: {}
+
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  ret@0.5.0: {}
+
+  reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rollup@4.60.2:
     dependencies:
@@ -2682,7 +4044,21 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  safe-buffer@5.2.1: {}
+
+  safe-regex2@5.1.1:
+    dependencies:
+      ret: 0.5.0
+
+  safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  secure-json-parse@4.1.0: {}
+
   semver@7.7.4: {}
+
+  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -2690,15 +4066,40 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  shell-quote@1.8.3: {}
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
 
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  split2@4.2.0: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  steed@1.1.3:
+    dependencies:
+      fastfall: 1.5.1
+      fastparallel: 2.4.1
+      fastq: 1.20.1
+      fastseries: 1.7.2
+      reusify: 1.1.0
+
+  stream-shift@1.0.3: {}
 
   string-width@4.2.3:
     dependencies:
@@ -2711,6 +4112,10 @@ snapshots:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -2736,6 +4141,10 @@ snapshots:
       glob: 10.5.0
       minimatch: 10.2.5
 
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -2755,9 +4164,18 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  toad-cache@3.7.0: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   turbo@2.9.6:
     optionalDependencies:
@@ -2791,6 +4209,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  util-deprecate@1.0.2: {}
+
   uuid@9.0.1: {}
 
   vite-node@2.1.9(@types/node@22.19.17):
@@ -2811,13 +4231,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.2.4(@types/node@22.19.17):
+  vite-node@3.2.4(@types/node@22.19.17)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@22.19.17)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -2841,7 +4261,7 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
 
-  vite@7.3.2(@types/node@22.19.17):
+  vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2852,6 +4272,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
       fsevents: 2.3.3
+      tsx: 4.21.0
 
   vitest@2.1.9(@types/node@22.19.17):
     dependencies:
@@ -2888,11 +4309,11 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.2.4(@types/node@22.19.17):
+  vitest@3.2.4(@types/node@22.19.17)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@22.19.17)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -2910,8 +4331,8 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@22.19.17)
-      vite-node: 3.2.4(@types/node@22.19.17)
+      vite: 7.3.2(@types/node@22.19.17)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@22.19.17)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
@@ -2933,6 +4354,10 @@ snapshots:
     dependencies:
       isexe: 2.0.0
 
+  which@4.0.0:
+    dependencies:
+      isexe: 3.1.5
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -2952,4 +4377,12 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
+  wrappy@1.0.2: {}
+
+  ws@8.20.0: {}
+
+  xtend@4.0.2: {}
+
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,9 +95,40 @@ importers:
         specifier: ^8.19.1
         version: 8.58.2(eslint@9.39.4)(typescript@5.9.3)
 
+  packages/test-utils:
+    dependencies:
+      '@kinhale/crypto':
+        specifier: workspace:*
+        version: link:../crypto
+      '@kinhale/domain':
+        specifier: workspace:*
+        version: link:../domain
+    devDependencies:
+      '@kinhale/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@kinhale/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.17
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.0.0
+        version: 2.1.9(@types/node@22.19.17)
+
   packages/tsconfig: {}
 
 packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -105,10 +136,22 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.7':
@@ -117,16 +160,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.7':
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.7':
@@ -135,10 +196,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.7':
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.7':
@@ -147,10 +220,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.7':
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.7':
@@ -159,10 +244,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.7':
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.7':
@@ -171,10 +268,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.7':
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.7':
@@ -183,16 +292,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.7':
     resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.7':
@@ -207,6 +334,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.7':
     resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
@@ -217,6 +350,12 @@ packages:
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -231,11 +370,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.7':
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
@@ -243,10 +394,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.7':
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.7':
@@ -562,8 +725,22 @@ packages:
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -576,17 +753,32 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
@@ -681,6 +873,11 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
@@ -909,6 +1106,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1000,8 +1200,16 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -1040,10 +1248,46 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
@@ -1083,6 +1327,31 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@3.2.4:
@@ -1133,52 +1402,103 @@ packages:
 
 snapshots:
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
@@ -1187,10 +1507,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
@@ -1199,13 +1525,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
@@ -1478,6 +1816,13 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -1485,6 +1830,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)
 
   '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@22.19.17))':
     dependencies:
@@ -1494,9 +1847,18 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@22.19.17)
 
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -1504,15 +1866,31 @@ snapshots:
       pathe: 2.0.3
       strip-literal: 3.1.0
 
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -1596,6 +1974,32 @@ snapshots:
   deep-is@0.1.4: {}
 
   es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.27.7:
     optionalDependencies:
@@ -1838,6 +2242,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
@@ -1928,7 +2334,11 @@ snapshots:
 
   tinypool@1.1.1: {}
 
+  tinyrainbow@1.2.0: {}
+
   tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   tinyspy@4.0.4: {}
 
@@ -1968,6 +2378,24 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  vite-node@2.1.9(@types/node@22.19.17):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@3.2.4(@types/node@22.19.17):
     dependencies:
       cac: 6.7.14
@@ -1989,6 +2417,15 @@ snapshots:
       - tsx
       - yaml
 
+  vite@5.4.21(@types/node@22.19.17):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+
   vite@7.3.2(@types/node@22.19.17):
     dependencies:
       esbuild: 0.27.7
@@ -2000,6 +2437,41 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.17
       fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.19.17):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)
+      vite-node: 2.1.9(@types/node@22.19.17)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@3.2.4(@types/node@22.19.17):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@types/node':
         specifier: ^22.10.5
         version: 22.19.17
+      '@vitest/coverage-v8':
+        specifier: ^3.2.4
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.17))
       eslint:
         specifier: ^9.18.0
         version: 9.39.4
@@ -123,6 +126,31 @@ importers:
   packages/tsconfig: {}
 
 packages:
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.2':
+    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -476,8 +504,30 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
@@ -725,6 +775,15 @@ packages:
     resolution: {integrity: sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/coverage-v8@3.2.4':
+    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+    peerDependencies:
+      '@vitest/browser': 3.2.4
+      vitest: 3.2.4
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -796,9 +855,21 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -806,6 +877,9 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@0.3.12:
+    resolution: {integrity: sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -816,6 +890,9 @@ packages:
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@2.1.0:
+    resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -870,6 +947,15 @@ packages:
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -974,6 +1060,10 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -982,6 +1072,11 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -994,6 +1089,9 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1015,12 +1113,38 @@ packages:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
@@ -1061,8 +1185,18 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1070,6 +1204,14 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1094,6 +1236,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -1105,6 +1250,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -1165,6 +1314,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1174,6 +1327,22 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1185,6 +1354,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1396,11 +1569,39 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.2':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -1611,7 +1812,33 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
     optional: true
@@ -1816,6 +2043,25 @@ snapshots:
       '@typescript-eslint/types': 8.58.2
       eslint-visitor-keys: 5.0.1
 
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/node@22.19.17))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 1.0.2
+      ast-v8-to-istanbul: 0.3.12
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.4(@types/node@22.19.17)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -1911,13 +2157,25 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@0.3.12:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   balanced-match@1.0.2: {}
 
@@ -1927,6 +2185,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.1.0:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -1972,6 +2234,12 @@ snapshots:
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
+
+  eastasianwidth@0.2.0: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -2132,6 +2400,11 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   fsevents@2.3.3:
     optional: true
 
@@ -2139,11 +2412,22 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   globals@14.0.0: {}
 
   globals@15.15.0: {}
 
   has-flag@4.0.0: {}
+
+  html-escaper@2.0.2: {}
 
   ignore@5.3.2: {}
 
@@ -2158,11 +2442,42 @@ snapshots:
 
   is-extglob@2.1.1: {}
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
   isexe@2.0.0: {}
+
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
+  js-tokens@10.0.0: {}
 
   js-tokens@9.0.1: {}
 
@@ -2199,9 +2514,21 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
 
   minimatch@10.2.5:
     dependencies:
@@ -2210,6 +2537,12 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.14
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.0
+
+  minipass@7.1.3: {}
 
   ms@2.1.3: {}
 
@@ -2234,6 +2567,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -2241,6 +2576,11 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@1.1.2: {}
 
@@ -2307,11 +2647,33 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-json-comments@3.1.1: {}
 
@@ -2322,6 +2684,12 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   tinybench@2.9.0: {}
 
@@ -2524,5 +2892,17 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   yocto-queue@0.1.0: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,40 @@ importers:
         specifier: ^8.19.1
         version: 8.58.2(eslint@9.39.4)(typescript@5.9.3)
 
+  packages/sync:
+    dependencies:
+      '@automerge/automerge':
+        specifier: ^2.2.0
+        version: 2.2.9
+      '@kinhale/crypto':
+        specifier: workspace:*
+        version: link:../crypto
+    devDependencies:
+      '@kinhale/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@kinhale/test-utils':
+        specifier: workspace:*
+        version: link:../test-utils
+      '@kinhale/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.17
+      '@vitest/coverage-v8':
+        specifier: ^3.0.0
+        version: 3.2.4(vitest@3.2.4(@types/node@22.19.17))
+      eslint:
+        specifier: ^9.18.0
+        version: 9.39.4
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.2
+        version: 3.2.4(@types/node@22.19.17)
+
   packages/test-utils:
     dependencies:
       '@kinhale/crypto':
@@ -130,6 +164,9 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@automerge/automerge@2.2.9':
+    resolution: {integrity: sha512-6HM52Ops79hAQBWMg/t0MNfGOdEiXyenQjO9F1hKZq0RWDsMLpPa1SzRy/C4/4UyX67sTHuA5CwBpH34SpfZlA==}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -1421,6 +1458,10 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
+
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -1587,6 +1628,10 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@automerge/automerge@2.2.9':
+    dependencies:
+      uuid: 9.0.1
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -2745,6 +2790,8 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  uuid@9.0.1: {}
 
   vite-node@2.1.9(@types/node@22.19.17):
     dependencies:


### PR DESCRIPTION
## Résumé

- Squelette complet `apps/api` : Fastify 5, TypeScript strict NodeNext ESM
- Authentification magic link (JWT 15 min) — email/token stockés uniquement en SHA-256
- WebSocket relay E2EE zero-knowledge — blobs opaques (`blobJson`), routing in-memory (Redis Sprint 1)
- Schéma Drizzle ORM : `accounts`, `devices`, `magic_links`, `mailbox_messages` — aucune donnée santé
- Architecture `buildApp(env, overrides?)` testable sans serveur réel

## Sécurité

- Email jamais en clair : SHA-256 uniquement (`emailHash`)
- Token magic link : `randomBytes(32)` → hex → SHA-256 en DB, jamais en clair
- Log magic link conditionnel sur `NODE_ENV=development` uniquement
- Blobs mailbox opaques : le relais ne déchiffre jamais le contenu

## Tests

- 10 tests unitaires (health × 3, auth × 5, relay × 2) via `app.inject()`
- CI racine : 691 tests passés (domain + crypto + sync + api)
- lint + typecheck : 0 erreur

## Plan de test

- [ ] `pnpm test` → 691 tests verts
- [ ] `pnpm lint && pnpm typecheck` → 0 erreur
- [ ] Démarrage local : `docker compose up -d && pnpm dev:api` → health check sur `http://localhost:3000/health`
- [ ] POST `/auth/magic-link` avec email valide → log magic link en console (dev)
- [ ] Vérifier que le magic link loggé n'apparaît pas en `NODE_ENV=production`

## Déféré Sprint 1

- Auth/Authz WebSocket (vérification JWT sur la connexion WS)
- Redis pub/sub (routing multi-node)
- Envoi Resend (magic link par email)
- Race condition SELECT+INSERT sur upsert account → `INSERT ... ON CONFLICT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)