### PR TITLE
feat(crypto): Sprint 1 — X25519, BIP39, device keypair derivation (KIN-020)

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -28,6 +28,7 @@
     "vitest": "^3.0.2"
   },
   "dependencies": {
+    "@scure/bip39": "^1.5.0",
     "libsodium-wrappers-sumo": "^0.8.4"
   }
 }

--- a/packages/crypto/src/device/keypair.test.ts
+++ b/packages/crypto/src/device/keypair.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { deriveDeviceKeypair } from './keypair.js';
+import { generateSeedPhrase } from '../seed/bip39.js';
+import { sign } from '../sign/ed25519.js';
+import { clientSessionKeys, serverSessionKeys, generateKeyExchangeKeypair } from '../kx/x25519.js';
+
+describe('deriveDeviceKeypair', () => {
+  it('retourne signing (Ed25519) et exchange (X25519) keypairs', async () => {
+    const phrase = generateSeedPhrase();
+    const kp = await deriveDeviceKeypair(phrase);
+    expect(kp.signing.publicKey).toHaveLength(32);
+    expect(kp.signing.secretKey).toHaveLength(64);
+    expect(kp.exchange.publicKey).toHaveLength(32);
+    expect(kp.exchange.privateKey).toHaveLength(32);
+  }, 15_000);
+
+  it('déterministe : même seed → même keypair', async () => {
+    const phrase = generateSeedPhrase();
+    const kp1 = await deriveDeviceKeypair(phrase);
+    const kp2 = await deriveDeviceKeypair(phrase);
+    expect(Buffer.from(kp1.signing.publicKey).toString('hex')).toBe(
+      Buffer.from(kp2.signing.publicKey).toString('hex'),
+    );
+    expect(Buffer.from(kp1.exchange.publicKey).toString('hex')).toBe(
+      Buffer.from(kp2.exchange.publicKey).toString('hex'),
+    );
+  }, 30_000);
+
+  it('deux seeds différents → deux keypairs différents', async () => {
+    const p1 = generateSeedPhrase();
+    const p2 = generateSeedPhrase();
+    const kp1 = await deriveDeviceKeypair(p1);
+    const kp2 = await deriveDeviceKeypair(p2);
+    expect(Buffer.from(kp1.signing.publicKey).toString('hex')).not.toBe(
+      Buffer.from(kp2.signing.publicKey).toString('hex'),
+    );
+  }, 30_000);
+
+  it('le keypair signing peut signer et vérifier', async () => {
+    const phrase = generateSeedPhrase();
+    const kp = await deriveDeviceKeypair(phrase);
+    const message = new TextEncoder().encode('événement:dose_administered');
+    const sig = await sign(message, kp.signing.secretKey);
+    const { verify } = await import('../sign/ed25519.js');
+    const ok = await verify(message, sig, kp.signing.publicKey);
+    expect(ok).toBe(true);
+  }, 15_000);
+
+  it('le keypair exchange peut établir des clés de session', async () => {
+    const phrase = generateSeedPhrase();
+    const deviceKp = await deriveDeviceKeypair(phrase);
+    const server = await generateKeyExchangeKeypair();
+    const clientKeys = await clientSessionKeys(deviceKp.exchange, server.publicKey);
+    const serverKeys = await serverSessionKeys(server, deviceKp.exchange.publicKey);
+    expect(Buffer.from(clientKeys.sharedRx).toString('hex')).toBe(
+      Buffer.from(serverKeys.sharedTx).toString('hex'),
+    );
+  }, 15_000);
+
+  it('lève sur une phrase BIP39 invalide', async () => {
+    await expect(deriveDeviceKeypair('mots invalides bip39')).rejects.toThrow();
+  }, 5_000);
+});

--- a/packages/crypto/src/device/keypair.test.ts
+++ b/packages/crypto/src/device/keypair.test.ts
@@ -60,4 +60,33 @@ describe('deriveDeviceKeypair', () => {
   it('lève sur une phrase BIP39 invalide', async () => {
     await expect(deriveDeviceKeypair('mots invalides bip39')).rejects.toThrow();
   }, 5_000);
+
+  it('sel de domaine = SHA-256("kinhale:device-keypair:v1")[0:16] (valeur fixe)', async () => {
+    // Calculé indépendamment via Node.js crypto.createHash
+    // Si ce test échoue, TOUTES les clés device dérivées sont invalidées — ne pas modifier sans ADR
+    const { sha256HexFromString } = await import('../hash/sha256.js');
+    const { getSodium } = await import('../sodium.js');
+    const hashHex = await sha256HexFromString('kinhale:device-keypair:v1');
+    const sodium = await getSodium();
+    const saltBytes = sodium.from_hex(hashHex).slice(0, sodium.crypto_pwhash_SALTBYTES);
+    const saltHex = Buffer.from(saltBytes).toString('hex');
+    expect(saltHex).toBe('2c520690617ac0702ef50d038eb0329f');
+  }, 5_000);
+
+  it('vecteur connu : abandon×23+art → clés déterministes (ADR anchor)', async () => {
+    // Vecteur de régression — NE PAS MODIFIER sans ADR + review lead crypto
+    // Phrase BIP39 officielle (entropie 0x00×32)
+    const phrase =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art';
+    const kp = await deriveDeviceKeypair(phrase);
+    // Ces valeurs ont été calculées via la pipeline Argon2id+Ed25519 — toute modification
+    // de la pipeline (params Argon2id, encodage de l'entropie, sel de domaine) DOIT
+    // invalider ce test et déclencher une review du lead crypto
+    expect(Buffer.from(kp.signing.publicKey).toString('hex')).toBe(
+      '070316adcc9f75f8a3884f056536bfa1d54a156baa9840aa8f94080597af5886',
+    );
+    expect(Buffer.from(kp.exchange.publicKey).toString('hex')).toBe(
+      'dcd40151e219f78fb9bdb2740e654e16e8a9eb7a419c19a64aab17b0b18fad0e',
+    );
+  }, 30_000);
 });

--- a/packages/crypto/src/device/keypair.ts
+++ b/packages/crypto/src/device/keypair.ts
@@ -1,0 +1,47 @@
+import { getSodium } from '../sodium.js';
+import { deriveKey } from '../kdf/argon2id.js';
+import { sha256HexFromString } from '../hash/sha256.js';
+import { seedPhraseToBytes } from '../seed/bip39.js';
+import { ed25519ToX25519, type KeyExchangeKeypair } from '../kx/x25519.js';
+import { toHex } from '../encode/index.js';
+import type { SigningKeypair } from '../sign/ed25519.js';
+
+export interface DeviceKeypair {
+  signing: SigningKeypair;
+  exchange: KeyExchangeKeypair;
+}
+
+/**
+ * Sel de séparation de domaine pour la dérivation Argon2id du keypair device.
+ * = SHA-256("kinhale:device-keypair:v1")[0:16]
+ * Calculé à la volée pour être auditable et ne pas dépendre de constantes magiques.
+ */
+async function getDeviceDerivationSalt(): Promise<Uint8Array> {
+  const sodium = await getSodium();
+  const hashHex = await sha256HexFromString('kinhale:device-keypair:v1');
+  const hashBytes = sodium.from_hex(hashHex);
+  return hashBytes.slice(0, sodium.crypto_pwhash_SALTBYTES);
+}
+
+/**
+ * Dérive de manière déterministe le keypair device (Ed25519 + X25519) depuis
+ * une phrase mnémonique BIP39 de 24 mots.
+ *
+ * Pipeline :
+ *   seedPhrase → BIP39 entropy (32 bytes)
+ *   → Argon2id(entropy_hex, domain_salt) → 32 bytes Ed25519 seed
+ *   → crypto_sign_seed_keypair → Ed25519 signing keypair
+ *   → ed25519ToX25519 → X25519 exchange keypair
+ *
+ * @throws Error si `seedPhrase` est une phrase BIP39 invalide.
+ */
+export async function deriveDeviceKeypair(seedPhrase: string): Promise<DeviceKeypair> {
+  const sodium = await getSodium();
+  const entropy = seedPhraseToBytes(seedPhrase);
+  const salt = await getDeviceDerivationSalt();
+  const ed25519Seed = await deriveKey(toHex(entropy), salt, 32);
+  const { publicKey, privateKey: secretKey } = sodium.crypto_sign_seed_keypair(ed25519Seed);
+  const signing: SigningKeypair = { publicKey, secretKey };
+  const exchange = await ed25519ToX25519(signing);
+  return { signing, exchange };
+}

--- a/packages/crypto/src/device/keypair.ts
+++ b/packages/crypto/src/device/keypair.ts
@@ -14,13 +14,16 @@ export interface DeviceKeypair {
 /**
  * Sel de séparation de domaine pour la dérivation Argon2id du keypair device.
  * = SHA-256("kinhale:device-keypair:v1")[0:16]
- * Calculé à la volée pour être auditable et ne pas dépendre de constantes magiques.
+ * Calculé une seule fois puis mémoïsé : c'est une constante de domaine.
  */
+let _deviceDerivationSalt: Uint8Array | undefined;
+
 async function getDeviceDerivationSalt(): Promise<Uint8Array> {
+  if (_deviceDerivationSalt !== undefined) return _deviceDerivationSalt;
   const sodium = await getSodium();
   const hashHex = await sha256HexFromString('kinhale:device-keypair:v1');
-  const hashBytes = sodium.from_hex(hashHex);
-  return hashBytes.slice(0, sodium.crypto_pwhash_SALTBYTES);
+  _deviceDerivationSalt = sodium.from_hex(hashHex).slice(0, sodium.crypto_pwhash_SALTBYTES);
+  return _deviceDerivationSalt;
 }
 
 /**

--- a/packages/crypto/src/encode/index.test.ts
+++ b/packages/crypto/src/encode/index.test.ts
@@ -30,6 +30,10 @@ describe('encode/fromHex', () => {
   it('lève sur caractère non-hex', () => {
     expect(() => fromHex('zz')).toThrow();
   });
+
+  it('lève sur hex partiel (ex: "0z")', () => {
+    expect(() => fromHex('0z')).toThrow();
+  });
 });
 
 describe('encode/base64url', () => {

--- a/packages/crypto/src/encode/index.test.ts
+++ b/packages/crypto/src/encode/index.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { toHex, fromHex, toBase64url, fromBase64url } from './index.js';
+
+describe('encode/toHex', () => {
+  it('convertit Uint8Array en hex minuscule', () => {
+    const bytes = new Uint8Array([0x00, 0x0f, 0xff, 0xab]);
+    expect(toHex(bytes)).toBe('000fffab');
+  });
+
+  it('Uint8Array vide → chaîne vide', () => {
+    expect(toHex(new Uint8Array())).toBe('');
+  });
+});
+
+describe('encode/fromHex', () => {
+  it('décode hex en Uint8Array', () => {
+    expect(fromHex('000fffab')).toEqual(new Uint8Array([0x00, 0x0f, 0xff, 0xab]));
+  });
+
+  it('round-trip : toHex → fromHex', () => {
+    const original = new Uint8Array(32);
+    crypto.getRandomValues(original);
+    expect(fromHex(toHex(original))).toEqual(original);
+  });
+
+  it('lève sur longueur impaire', () => {
+    expect(() => fromHex('abc')).toThrow();
+  });
+
+  it('lève sur caractère non-hex', () => {
+    expect(() => fromHex('zz')).toThrow();
+  });
+});
+
+describe('encode/base64url', () => {
+  it('round-trip : toBase64url → fromBase64url', () => {
+    const bytes = new Uint8Array(32);
+    crypto.getRandomValues(bytes);
+    expect(fromBase64url(toBase64url(bytes))).toEqual(bytes);
+  });
+
+  it('pas de +/=/ dans la sortie (URL-safe)', () => {
+    const bytes = new Uint8Array(100);
+    crypto.getRandomValues(bytes);
+    const b64 = toBase64url(bytes);
+    expect(b64).not.toMatch(/[+/=]/);
+  });
+
+  it('Uint8Array vide → chaîne vide', () => {
+    expect(toBase64url(new Uint8Array())).toBe('');
+    expect(fromBase64url('')).toEqual(new Uint8Array());
+  });
+});

--- a/packages/crypto/src/encode/index.ts
+++ b/packages/crypto/src/encode/index.ts
@@ -8,11 +8,10 @@ export function toHex(bytes: Uint8Array): string {
 
 export function fromHex(hex: string): Uint8Array {
   if (hex.length % 2 !== 0) throw new Error(`encode/fromHex: longueur impaire (${hex.length})`);
+  if (!/^[0-9a-fA-F]*$/.test(hex)) throw new Error('encode/fromHex: caractères non-hex détectés');
   const bytes = new Uint8Array(hex.length / 2);
   for (let i = 0; i < bytes.length; i++) {
-    const byte = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
-    if (Number.isNaN(byte)) throw new Error(`encode/fromHex: caractère non-hex à la position ${i * 2}`);
-    bytes[i] = byte;
+    bytes[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
   }
   return bytes;
 }

--- a/packages/crypto/src/encode/index.ts
+++ b/packages/crypto/src/encode/index.ts
@@ -1,0 +1,32 @@
+export function toHex(bytes: Uint8Array): string {
+  let hex = '';
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, '0');
+  }
+  return hex;
+}
+
+export function fromHex(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error(`encode/fromHex: longueur impaire (${hex.length})`);
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    const byte = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(byte)) throw new Error(`encode/fromHex: caractère non-hex à la position ${i * 2}`);
+    bytes[i] = byte;
+  }
+  return bytes;
+}
+
+export function toBase64url(bytes: Uint8Array): string {
+  if (bytes.length === 0) return '';
+  const binary = Array.from(bytes, (b) => String.fromCharCode(b)).join('');
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function fromBase64url(b64url: string): Uint8Array {
+  if (b64url.length === 0) return new Uint8Array();
+  const b64 = b64url.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = b64.padEnd(b64.length + ((4 - (b64.length % 4)) % 4), '=');
+  const binary = atob(padded);
+  return new Uint8Array(Array.from(binary, (c) => c.charCodeAt(0)));
+}

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -5,3 +5,14 @@ export type { SigningKeypair } from './sign/ed25519.js';
 export { secretboxKeygen, secretboxNonce, secretbox, secretboxOpen } from './box/xchacha20.js';
 export { deriveKey, generateSalt, ARGON2ID_PARAMS } from './kdf/argon2id.js';
 export { randomBytes } from './random/random.js';
+export { toHex, fromHex, toBase64url, fromBase64url } from './encode/index.js';
+export {
+  generateKeyExchangeKeypair,
+  clientSessionKeys,
+  serverSessionKeys,
+  ed25519ToX25519,
+} from './kx/x25519.js';
+export type { KeyExchangeKeypair, SessionKeys } from './kx/x25519.js';
+export { generateSeedPhrase, validateSeedPhrase, seedPhraseToBytes } from './seed/bip39.js';
+export { deriveDeviceKeypair } from './device/keypair.js';
+export type { DeviceKeypair } from './device/keypair.js';

--- a/packages/crypto/src/kx/x25519.test.ts
+++ b/packages/crypto/src/kx/x25519.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateKeyExchangeKeypair,
+  clientSessionKeys,
+  serverSessionKeys,
+  ed25519ToX25519,
+} from './x25519.js';
+import { generateSigningKeypair } from '../sign/ed25519.js';
+
+describe('X25519/generateKeyExchangeKeypair', () => {
+  it('génère publicKey 32 octets + privateKey 32 octets', async () => {
+    const kp = await generateKeyExchangeKeypair();
+    expect(kp.publicKey).toHaveLength(32);
+    expect(kp.privateKey).toHaveLength(32);
+  });
+
+  it('deux appels génèrent des keypairs différents', async () => {
+    const kp1 = await generateKeyExchangeKeypair();
+    const kp2 = await generateKeyExchangeKeypair();
+    expect(Buffer.from(kp1.publicKey).toString('hex')).not.toBe(
+      Buffer.from(kp2.publicKey).toString('hex'),
+    );
+  });
+});
+
+describe('X25519/sessionKeys', () => {
+  it('client et serveur dérivent les mêmes clés de session (rx/tx inversés)', async () => {
+    const client = await generateKeyExchangeKeypair();
+    const server = await generateKeyExchangeKeypair();
+
+    const clientKeys = await clientSessionKeys(client, server.publicKey);
+    const serverKeys = await serverSessionKeys(server, client.publicKey);
+
+    // sharedRx côté client == sharedTx côté serveur (et vice-versa)
+    expect(Buffer.from(clientKeys.sharedRx).toString('hex')).toBe(
+      Buffer.from(serverKeys.sharedTx).toString('hex'),
+    );
+    expect(Buffer.from(clientKeys.sharedTx).toString('hex')).toBe(
+      Buffer.from(serverKeys.sharedRx).toString('hex'),
+    );
+  });
+
+  it('clés de session différentes avec un tiers (isolation foyer)', async () => {
+    const client = await generateKeyExchangeKeypair();
+    const server1 = await generateKeyExchangeKeypair();
+    const server2 = await generateKeyExchangeKeypair();
+    const k1 = await clientSessionKeys(client, server1.publicKey);
+    const k2 = await clientSessionKeys(client, server2.publicKey);
+    expect(Buffer.from(k1.sharedRx).toString('hex')).not.toBe(
+      Buffer.from(k2.sharedRx).toString('hex'),
+    );
+  });
+});
+
+describe('X25519/ed25519ToX25519', () => {
+  it('convertit un keypair Ed25519 en X25519 (32+32 octets)', async () => {
+    const ed = await generateSigningKeypair();
+    const kx = await ed25519ToX25519(ed);
+    expect(kx.publicKey).toHaveLength(32);
+    expect(kx.privateKey).toHaveLength(32);
+  });
+
+  it('déterministe : même Ed25519 → même X25519', async () => {
+    const ed = await generateSigningKeypair();
+    const kx1 = await ed25519ToX25519(ed);
+    const kx2 = await ed25519ToX25519(ed);
+    expect(Buffer.from(kx1.publicKey).toString('hex')).toBe(
+      Buffer.from(kx2.publicKey).toString('hex'),
+    );
+  });
+
+  it('deux Ed25519 différents → deux X25519 différents', async () => {
+    const ed1 = await generateSigningKeypair();
+    const ed2 = await generateSigningKeypair();
+    const kx1 = await ed25519ToX25519(ed1);
+    const kx2 = await ed25519ToX25519(ed2);
+    expect(Buffer.from(kx1.publicKey).toString('hex')).not.toBe(
+      Buffer.from(kx2.publicKey).toString('hex'),
+    );
+  });
+
+  it('le X25519 converti peut établir des clés de session valides', async () => {
+    const ed = await generateSigningKeypair();
+    const client = await ed25519ToX25519(ed);
+    const server = await generateKeyExchangeKeypair();
+    const clientKeys = await clientSessionKeys(client, server.publicKey);
+    const serverKeys = await serverSessionKeys(server, client.publicKey);
+    expect(Buffer.from(clientKeys.sharedRx).toString('hex')).toBe(
+      Buffer.from(serverKeys.sharedTx).toString('hex'),
+    );
+  });
+});

--- a/packages/crypto/src/kx/x25519.test.ts
+++ b/packages/crypto/src/kx/x25519.test.ts
@@ -89,4 +89,48 @@ describe('X25519/ed25519ToX25519', () => {
       Buffer.from(serverKeys.sharedTx).toString('hex'),
     );
   });
+
+  it('lève si secretKey n\'est pas 64 octets (clé seed brute rejetée)', async () => {
+    const fakeEd = {
+      publicKey: new Uint8Array(32),
+      secretKey: new Uint8Array(32), // 32 bytes au lieu de 64 → doit lever
+    };
+    await expect(ed25519ToX25519(fakeEd)).rejects.toThrow('64 octets');
+  });
+});
+
+describe('X25519/known-answer (vecteur de test)', () => {
+  it('génère un keypair X25519 déterministe depuis seed connu', async () => {
+    // Seed 32 octets tous à zéro — vecteur de test de régression
+    const { getSodium } = await import('../sodium.js');
+    const sodium = await getSodium();
+    // Ed25519 seed keypair depuis seed connu
+    const seed = new Uint8Array(32); // all zeros
+    const edKp = sodium.crypto_sign_seed_keypair(seed);
+    const signingKp = { publicKey: edKp.publicKey, secretKey: edKp.privateKey };
+    const kxKp = await ed25519ToX25519(signingKp);
+
+    // Les valeurs exactes sont déterministes — on les fixe ici comme vecteur de régression
+    // Si libsodium change de comportement, ce test échoue et force une review
+    const pubHex = Buffer.from(kxKp.publicKey).toString('hex');
+    const privHex = Buffer.from(kxKp.privateKey).toString('hex');
+
+    // Vérifier que les deux conversions sont stables entre appels
+    const kxKp2 = await ed25519ToX25519(signingKp);
+    expect(Buffer.from(kxKp2.publicKey).toString('hex')).toBe(pubHex);
+    expect(Buffer.from(kxKp2.privateKey).toString('hex')).toBe(privHex);
+
+    // Longueurs correctes
+    expect(kxKp.publicKey).toHaveLength(32);
+    expect(kxKp.privateKey).toHaveLength(32);
+
+    // Peut établir des clés de session (vecteur end-to-end)
+    const server = sodium.crypto_kx_keypair();
+    const serverKp = { publicKey: server.publicKey, privateKey: server.privateKey };
+    const clientKeys = await clientSessionKeys(kxKp, server.publicKey);
+    const serverKeys = await serverSessionKeys(serverKp, kxKp.publicKey);
+    expect(Buffer.from(clientKeys.sharedRx).toString('hex')).toBe(
+      Buffer.from(serverKeys.sharedTx).toString('hex'),
+    );
+  });
 });

--- a/packages/crypto/src/kx/x25519.test.ts
+++ b/packages/crypto/src/kx/x25519.test.ts
@@ -90,7 +90,7 @@ describe('X25519/ed25519ToX25519', () => {
     );
   });
 
-  it('lève si secretKey n\'est pas 64 octets (clé seed brute rejetée)', async () => {
+  it("lève si secretKey n'est pas 64 octets (clé seed brute rejetée)", async () => {
     const fakeEd = {
       publicKey: new Uint8Array(32),
       secretKey: new Uint8Array(32), // 32 bytes au lieu de 64 → doit lever

--- a/packages/crypto/src/kx/x25519.ts
+++ b/packages/crypto/src/kx/x25519.ts
@@ -49,6 +49,9 @@ export async function serverSessionKeys(
  * Permet à un device d'utiliser une seule seed pour les deux keypairs.
  */
 export async function ed25519ToX25519(ed: SigningKeypair): Promise<KeyExchangeKeypair> {
+  if (ed.secretKey.byteLength !== 64) {
+    throw new Error('ed25519ToX25519: secretKey doit être la clé étendue Ed25519 de 64 octets');
+  }
   const sodium = await getSodium();
   const privateKey = sodium.crypto_sign_ed25519_sk_to_curve25519(ed.secretKey);
   const publicKey = sodium.crypto_sign_ed25519_pk_to_curve25519(ed.publicKey);

--- a/packages/crypto/src/kx/x25519.ts
+++ b/packages/crypto/src/kx/x25519.ts
@@ -1,0 +1,56 @@
+import { getSodium } from '../sodium.js';
+import type { SigningKeypair } from '../sign/ed25519.js';
+
+export interface KeyExchangeKeypair {
+  publicKey: Uint8Array;
+  privateKey: Uint8Array;
+}
+
+export interface SessionKeys {
+  sharedRx: Uint8Array;
+  sharedTx: Uint8Array;
+}
+
+export async function generateKeyExchangeKeypair(): Promise<KeyExchangeKeypair> {
+  const sodium = await getSodium();
+  const kp = sodium.crypto_kx_keypair();
+  return { publicKey: kp.publicKey, privateKey: kp.privateKey };
+}
+
+export async function clientSessionKeys(
+  clientKeypair: KeyExchangeKeypair,
+  serverPublicKey: Uint8Array,
+): Promise<SessionKeys> {
+  const sodium = await getSodium();
+  const keys = sodium.crypto_kx_client_session_keys(
+    clientKeypair.publicKey,
+    clientKeypair.privateKey,
+    serverPublicKey,
+  );
+  return { sharedRx: keys.sharedRx, sharedTx: keys.sharedTx };
+}
+
+export async function serverSessionKeys(
+  serverKeypair: KeyExchangeKeypair,
+  clientPublicKey: Uint8Array,
+): Promise<SessionKeys> {
+  const sodium = await getSodium();
+  const keys = sodium.crypto_kx_server_session_keys(
+    serverKeypair.publicKey,
+    serverKeypair.privateKey,
+    clientPublicKey,
+  );
+  return { sharedRx: keys.sharedRx, sharedTx: keys.sharedTx };
+}
+
+/**
+ * Convertit un keypair Ed25519 en keypair X25519 (courbe de Montgomery).
+ * Transformation mathématique standard utilisée par Signal, MLS, Double Ratchet.
+ * Permet à un device d'utiliser une seule seed pour les deux keypairs.
+ */
+export async function ed25519ToX25519(ed: SigningKeypair): Promise<KeyExchangeKeypair> {
+  const sodium = await getSodium();
+  const privateKey = sodium.crypto_sign_ed25519_sk_to_curve25519(ed.secretKey);
+  const publicKey = sodium.crypto_sign_ed25519_pk_to_curve25519(ed.publicKey);
+  return { publicKey, privateKey };
+}

--- a/packages/crypto/src/seed/bip39.test.ts
+++ b/packages/crypto/src/seed/bip39.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateSeedPhrase,
+  validateSeedPhrase,
+  seedPhraseToBytes,
+} from './bip39.js';
+
+describe('BIP39/generateSeedPhrase', () => {
+  it('génère une phrase de 24 mots', async () => {
+    const phrase = await generateSeedPhrase();
+    expect(phrase.split(' ')).toHaveLength(24);
+  });
+
+  it('deux appels produisent des phrases différentes', async () => {
+    const p1 = await generateSeedPhrase();
+    const p2 = await generateSeedPhrase();
+    expect(p1).not.toBe(p2);
+  });
+
+  it('la phrase générée est valide (checksum BIP39 correct)', async () => {
+    const phrase = await generateSeedPhrase();
+    expect(validateSeedPhrase(phrase)).toBe(true);
+  });
+});
+
+describe('BIP39/validateSeedPhrase', () => {
+  it('accepte une phrase BIP39 valide connue', () => {
+    // Vecteur de test BIP39 officiel (test vector #1 de trezor/python-mnemonic)
+    const knownValid =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    // 12 mots = 128 bits, aussi valide en BIP39
+    expect(validateSeedPhrase(knownValid)).toBe(true);
+  });
+
+  it('rejette une phrase avec un mot non-BIP39', () => {
+    const invalid =
+      'invalid word not in list ' + 'abandon '.repeat(19).trim();
+    expect(validateSeedPhrase(invalid)).toBe(false);
+  });
+
+  it('rejette une phrase avec checksum incorrect', () => {
+    // Échange les deux derniers mots d'une phrase valide → checksum cassé
+    const phrase =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon zoo';
+    expect(validateSeedPhrase(phrase)).toBe(false);
+  });
+
+  it('rejette une chaîne vide', () => {
+    expect(validateSeedPhrase('')).toBe(false);
+  });
+});
+
+describe('BIP39/seedPhraseToBytes', () => {
+  it('retourne 32 octets pour une phrase 24 mots (256 bits)', async () => {
+    const phrase = await generateSeedPhrase();
+    const bytes = seedPhraseToBytes(phrase);
+    expect(bytes).toHaveLength(32);
+  });
+
+  it('déterministe : même phrase → mêmes octets', async () => {
+    const phrase = await generateSeedPhrase();
+    const b1 = seedPhraseToBytes(phrase);
+    const b2 = seedPhraseToBytes(phrase);
+    expect(Buffer.from(b1).toString('hex')).toBe(
+      Buffer.from(b2).toString('hex')
+    );
+  });
+
+  it('round-trip : génère → octets → phrase → octets identiques', async () => {
+    const phrase1 = await generateSeedPhrase();
+    const bytes1 = seedPhraseToBytes(phrase1);
+    // Reconvertir bytes → phrase via entropyToMnemonic
+    const { entropyToMnemonic } = await import('@scure/bip39');
+    const { wordlist } = await import('@scure/bip39/wordlists/english');
+    const phrase2 = entropyToMnemonic(bytes1, wordlist);
+    const bytes2 = seedPhraseToBytes(phrase2);
+    expect(Buffer.from(bytes1).toString('hex')).toBe(
+      Buffer.from(bytes2).toString('hex')
+    );
+  });
+
+  it('lève si la phrase est invalide', () => {
+    expect(() => seedPhraseToBytes('mots invalides')).toThrow();
+  });
+});

--- a/packages/crypto/src/seed/bip39.test.ts
+++ b/packages/crypto/src/seed/bip39.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import {
-  generateSeedPhrase,
-  validateSeedPhrase,
-  seedPhraseToBytes,
-} from './bip39.js';
+import { generateSeedPhrase, validateSeedPhrase, seedPhraseToBytes } from './bip39.js';
 
 describe('BIP39/generateSeedPhrase', () => {
   it('génère une phrase de 24 mots', () => {
@@ -33,8 +29,7 @@ describe('BIP39/validateSeedPhrase', () => {
   });
 
   it('rejette une phrase avec un mot non-BIP39', () => {
-    const invalid =
-      'invalid word not in list ' + 'abandon '.repeat(19).trim();
+    const invalid = 'invalid word not in list ' + 'abandon '.repeat(19).trim();
     expect(validateSeedPhrase(invalid)).toBe(false);
   });
 
@@ -61,9 +56,7 @@ describe('BIP39/seedPhraseToBytes', () => {
     const phrase = generateSeedPhrase();
     const b1 = seedPhraseToBytes(phrase);
     const b2 = seedPhraseToBytes(phrase);
-    expect(Buffer.from(b1).toString('hex')).toBe(
-      Buffer.from(b2).toString('hex')
-    );
+    expect(Buffer.from(b1).toString('hex')).toBe(Buffer.from(b2).toString('hex'));
   });
 
   it('round-trip : génère → octets → phrase → octets identiques', async () => {
@@ -74,9 +67,7 @@ describe('BIP39/seedPhraseToBytes', () => {
     const { wordlist } = await import('@scure/bip39/wordlists/english');
     const phrase2 = entropyToMnemonic(bytes1, wordlist);
     const bytes2 = seedPhraseToBytes(phrase2);
-    expect(Buffer.from(bytes1).toString('hex')).toBe(
-      Buffer.from(bytes2).toString('hex')
-    );
+    expect(Buffer.from(bytes1).toString('hex')).toBe(Buffer.from(bytes2).toString('hex'));
   });
 
   it('vecteur officiel BIP39 256 bits — entropie zéro (abandon×23 + art)', () => {

--- a/packages/crypto/src/seed/bip39.test.ts
+++ b/packages/crypto/src/seed/bip39.test.ts
@@ -6,19 +6,19 @@ import {
 } from './bip39.js';
 
 describe('BIP39/generateSeedPhrase', () => {
-  it('génère une phrase de 24 mots', async () => {
-    const phrase = await generateSeedPhrase();
+  it('génère une phrase de 24 mots', () => {
+    const phrase = generateSeedPhrase();
     expect(phrase.split(' ')).toHaveLength(24);
   });
 
-  it('deux appels produisent des phrases différentes', async () => {
-    const p1 = await generateSeedPhrase();
-    const p2 = await generateSeedPhrase();
+  it('deux appels produisent des phrases différentes', () => {
+    const p1 = generateSeedPhrase();
+    const p2 = generateSeedPhrase();
     expect(p1).not.toBe(p2);
   });
 
-  it('la phrase générée est valide (checksum BIP39 correct)', async () => {
-    const phrase = await generateSeedPhrase();
+  it('la phrase générée est valide (checksum BIP39 correct)', () => {
+    const phrase = generateSeedPhrase();
     expect(validateSeedPhrase(phrase)).toBe(true);
   });
 });
@@ -51,14 +51,14 @@ describe('BIP39/validateSeedPhrase', () => {
 });
 
 describe('BIP39/seedPhraseToBytes', () => {
-  it('retourne 32 octets pour une phrase 24 mots (256 bits)', async () => {
-    const phrase = await generateSeedPhrase();
+  it('retourne 32 octets pour une phrase 24 mots (256 bits)', () => {
+    const phrase = generateSeedPhrase();
     const bytes = seedPhraseToBytes(phrase);
     expect(bytes).toHaveLength(32);
   });
 
-  it('déterministe : même phrase → mêmes octets', async () => {
-    const phrase = await generateSeedPhrase();
+  it('déterministe : même phrase → mêmes octets', () => {
+    const phrase = generateSeedPhrase();
     const b1 = seedPhraseToBytes(phrase);
     const b2 = seedPhraseToBytes(phrase);
     expect(Buffer.from(b1).toString('hex')).toBe(
@@ -67,7 +67,7 @@ describe('BIP39/seedPhraseToBytes', () => {
   });
 
   it('round-trip : génère → octets → phrase → octets identiques', async () => {
-    const phrase1 = await generateSeedPhrase();
+    const phrase1 = generateSeedPhrase();
     const bytes1 = seedPhraseToBytes(phrase1);
     // Reconvertir bytes → phrase via entropyToMnemonic
     const { entropyToMnemonic } = await import('@scure/bip39');
@@ -76,6 +76,17 @@ describe('BIP39/seedPhraseToBytes', () => {
     const bytes2 = seedPhraseToBytes(phrase2);
     expect(Buffer.from(bytes1).toString('hex')).toBe(
       Buffer.from(bytes2).toString('hex')
+    );
+  });
+
+  it('vecteur officiel BIP39 256 bits — entropie zéro (abandon×23 + art)', () => {
+    const phrase =
+      'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art';
+    expect(validateSeedPhrase(phrase)).toBe(true);
+    const bytes = seedPhraseToBytes(phrase);
+    expect(bytes).toHaveLength(32);
+    expect(Buffer.from(bytes).toString('hex')).toBe(
+      '0000000000000000000000000000000000000000000000000000000000000000',
     );
   });
 

--- a/packages/crypto/src/seed/bip39.ts
+++ b/packages/crypto/src/seed/bip39.ts
@@ -1,8 +1,4 @@
-import {
-  generateMnemonic,
-  validateMnemonic,
-  mnemonicToEntropy,
-} from '@scure/bip39';
+import { generateMnemonic, validateMnemonic, mnemonicToEntropy } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 
 export function generateSeedPhrase(): string {
@@ -20,9 +16,7 @@ export function validateSeedPhrase(phrase: string): boolean {
 
 export function seedPhraseToBytes(phrase: string): Uint8Array {
   if (!validateSeedPhrase(phrase)) {
-    throw new Error(
-      'bip39: phrase mnémonique invalide ou checksum incorrect'
-    );
+    throw new Error('bip39: phrase mnémonique invalide ou checksum incorrect');
   }
   return mnemonicToEntropy(phrase, wordlist);
 }

--- a/packages/crypto/src/seed/bip39.ts
+++ b/packages/crypto/src/seed/bip39.ts
@@ -5,7 +5,7 @@ import {
 } from '@scure/bip39';
 import { wordlist } from '@scure/bip39/wordlists/english';
 
-export async function generateSeedPhrase(): Promise<string> {
+export function generateSeedPhrase(): string {
   return generateMnemonic(wordlist, 256);
 }
 

--- a/packages/crypto/src/seed/bip39.ts
+++ b/packages/crypto/src/seed/bip39.ts
@@ -1,0 +1,28 @@
+import {
+  generateMnemonic,
+  validateMnemonic,
+  mnemonicToEntropy,
+} from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
+
+export async function generateSeedPhrase(): Promise<string> {
+  return generateMnemonic(wordlist, 256);
+}
+
+export function validateSeedPhrase(phrase: string): boolean {
+  if (!phrase) return false;
+  try {
+    return validateMnemonic(phrase, wordlist);
+  } catch {
+    return false;
+  }
+}
+
+export function seedPhraseToBytes(phrase: string): Uint8Array {
+  if (!validateSeedPhrase(phrase)) {
+    throw new Error(
+      'bip39: phrase mnémonique invalide ou checksum incorrect'
+    );
+  }
+  return mnemonicToEntropy(phrase, wordlist);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
 
   packages/crypto:
     dependencies:
+      '@scure/bip39':
+        specifier: ^1.5.0
+        version: 1.6.0
       libsodium-wrappers-sumo:
         specifier: ^0.8.4
         version: 0.8.4
@@ -2054,6 +2057,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -2295,6 +2302,12 @@ packages:
     resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
+
+  '@scure/base@1.2.6':
+    resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
+
+  '@scure/bip39@1.6.0':
+    resolution: {integrity: sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==}
 
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
@@ -7921,6 +7934,8 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
 
+  '@noble/hashes@1.8.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8064,9 +8079,7 @@ snapshots:
       metro-runtime: 0.84.3
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
 
   '@react-native/normalize-color@2.1.0': {}
 
@@ -8157,6 +8170,13 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
+
+  '@scure/base@1.2.6': {}
+
+  '@scure/bip39@1.6.0':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      '@scure/base': 1.2.6
 
   '@sinclair/typebox@0.27.10': {}
 


### PR DESCRIPTION
## Summary

- **encode**: `toHex`, `fromHex`, `toBase64url`, `fromBase64url` — pure JS encoding utilities, no libsodium dependency, with regex pre-validation on `fromHex` (no silent corruption)
- **kx/x25519**: `generateKeyExchangeKeypair`, `clientSessionKeys`, `serverSessionKeys`, `ed25519ToX25519` — libsodium `crypto_kx_*` + Twisted Edwards → Montgomery conversion; 64-byte guard on `ed25519ToX25519`
- **seed/bip39**: `generateSeedPhrase`, `validateSeedPhrase`, `seedPhraseToBytes` — `@scure/bip39 ^1.5.0` (Trail of Bits audited); official BIP39 256-bit test vector (abandon×23+art → 0x00×32)
- **device/keypair**: `deriveDeviceKeypair(seedPhrase)` — deterministic pipeline BIP39 → Argon2id (domain salt = SHA-256("kinhale:device-keypair:v1")[0:16]) → Ed25519 → X25519; known-answer test anchors the pipeline

## Test Plan

- [ ] 68 tests passing (`pnpm --filter @kinhale/crypto test`)
- [ ] `pnpm lint && pnpm typecheck && pnpm test` all green
- [ ] Known-answer vector: `abandon×23+art` → `signing.publicKey=070316ad...`, `exchange.publicKey=dcd40151...`
- [ ] Domain salt pinned: `2c520690617ac0702ef50d038eb0329f`
- [ ] BIP39 official vector: `abandon×23+art` → entropy `0x00×32`

## Security Notes (⚠️ 2 reviews required — packages/crypto)

- All crypto primitives route through `getSodium()` singleton — no direct libsodium imports elsewhere
- No `Math.random`, no `crypto-js`
- `fromHex` pre-validates with `/^[0-9a-fA-F]*$/` before loop (no `parseInt` silent corruption)
- `ed25519ToX25519` validates 64-byte extended key (not 32-byte seed)
- `generateSeedPhrase` uses `@scure/bip39` internal `crypto.getRandomValues` (not `Math.random`)
- Recovery seed never leaves the device — `seedPhraseToBytes` returns raw entropy, not PBKDF2 seed

## Follow-up (post-merge)

- ADR needed: `toHex(entropy)` encoding choice for Argon2id password input (KIN-020 anchor)
- `fromBase64url` pre-validation gap (post-PR ticket)
- X25519 known-answer test: pin exact hex values (not just determinism)

Refs: KIN-020