### PR TITLE
feat(sync): Sprint 1 — SyncCursor, pipeline E2EE, intégration multi-device (KIN-021)

### DIFF
--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -28,3 +28,11 @@ export type { EncryptedBlob } from './mailbox/encrypt.js';
 export { encryptChanges, decryptChanges } from './mailbox/encrypt.js';
 export type { SyncMessage } from './mailbox/message.js';
 export { encodeSyncMessage, decodeSyncMessage } from './mailbox/message.js';
+
+// Pipeline haut-niveau
+export type { SyncMeta } from './mailbox/pipeline.js';
+export { buildSyncMessage, consumeSyncMessage } from './mailbox/pipeline.js';
+
+// Cursor de synchronisation
+export type { SyncCursor } from './sync/cursor.js';
+export { createCursor, recordSent, recordReceived, pendingChanges } from './sync/cursor.js';

--- a/packages/sync/src/integration/multi-device.test.ts
+++ b/packages/sync/src/integration/multi-device.test.ts
@@ -1,0 +1,165 @@
+// packages/sync/src/integration/multi-device.test.ts
+import { describe, it, expect } from 'vitest';
+import {
+  deriveDeviceKeypair,
+  generateSeedPhrase,
+  secretboxKeygen,
+} from '@kinhale/crypto';
+import * as A from '@automerge/automerge';
+import { createDoc, loadDoc, saveDoc } from '../doc/lifecycle.js';
+import { signEvent } from '../events/sign.js';
+import { appendEvent } from '../events/append.js';
+import { buildSyncMessage, consumeSyncMessage } from '../mailbox/pipeline.js';
+import { verifySignedEvent } from '../events/sign.js';
+import type { UnsignedEvent } from '../events/types.js';
+import type { KinhaleDoc } from '../doc/schema.js';
+
+const makeUnsigned = (id: string, deviceId: string): UnsignedEvent => ({
+  id,
+  deviceId,
+  occurredAtMs: 1_700_000_000_000 + parseInt(id.slice(-1), 10),
+  event: {
+    type: 'DoseAdministered',
+    payload: {
+      doseId: id,
+      pumpId: 'pump-1',
+      childId: 'child-1',
+      caregiverId: deviceId,
+      administeredAtMs: 1_700_000_000_000,
+      doseType: 'maintenance',
+      dosesAdministered: 1,
+      symptoms: [],
+      circumstances: [],
+      freeFormTag: null,
+    },
+  },
+});
+
+describe('Multi-device sync (intégration)', () => {
+  it('deux devices convergent via buildSyncMessage / consumeSyncMessage', async () => {
+    // Deux clés de groupe partagées (en production : établies via MLS)
+    const groupKey = await secretboxKeygen();
+
+    // Device Alice : dérive son keypair depuis son seed
+    const aliceSeed = generateSeedPhrase();
+    const aliceKp = await deriveDeviceKeypair(aliceSeed);
+
+    // Device Bob : dérive son keypair depuis son seed
+    const bobSeed = generateSeedPhrase();
+    const bobKp = await deriveDeviceKeypair(bobSeed);
+
+    // Foyer initial : les deux devices partent du même document
+    const householdBase = createDoc('hh-integration-1');
+    let aliceDoc = householdBase;
+    let bobDoc = loadDoc(saveDoc(householdBase));
+
+    // Alice signe et ajoute un événement
+    const aliceEvent = await signEvent(
+      makeUnsigned('evt-alice-1', 'device-alice'),
+      aliceKp.signing.secretKey,
+    );
+    aliceDoc = appendEvent(aliceDoc, aliceEvent);
+
+    // Alice envoie ses changements au relay
+    const msgAliceToBob = await buildSyncMessage(householdBase, aliceDoc, groupKey, {
+      mailboxId: 'mailbox-hh-1',
+      deviceId: 'device-alice',
+      seq: 1,
+    });
+    expect(msgAliceToBob).not.toBeNull();
+
+    // Bob reçoit et applique les changements
+    bobDoc = await consumeSyncMessage(bobDoc, msgAliceToBob!, groupKey);
+    expect(bobDoc.events).toHaveLength(1);
+    expect(bobDoc.events[0]!.id).toBe('evt-alice-1');
+
+    // Bob vérifie la signature d'Alice sur l'événement reçu
+    const valid = await verifySignedEvent(bobDoc.events[0]!);
+    expect(valid).toBe(true);
+
+    // Bob signe et ajoute son propre événement
+    const bobEvent = await signEvent(
+      makeUnsigned('evt-bob-1', 'device-bob'),
+      bobKp.signing.secretKey,
+    );
+    bobDoc = appendEvent(bobDoc, bobEvent);
+
+    // Bob envoie ses changements (delta depuis aliceDoc qui inclut evt-alice-1)
+    const msgBobToAlice = await buildSyncMessage(aliceDoc, bobDoc, groupKey, {
+      mailboxId: 'mailbox-hh-1',
+      deviceId: 'device-bob',
+      seq: 1,
+    });
+    expect(msgBobToAlice).not.toBeNull();
+
+    // Alice reçoit les changements de Bob
+    aliceDoc = await consumeSyncMessage(aliceDoc, msgBobToAlice!, groupKey);
+
+    // Les deux documents convergent
+    expect(aliceDoc.events).toHaveLength(2);
+    expect(bobDoc.events).toHaveLength(2);
+    expect(aliceDoc.events[0]!.id).toBe('evt-alice-1');
+    expect(aliceDoc.events[1]!.id).toBe('evt-bob-1');
+  }, 30_000);
+
+  it('la signature est liée au device (clé différente → signature différente)', async () => {
+    const aliceSeed = generateSeedPhrase();
+    const bobSeed = generateSeedPhrase();
+    const aliceKp = await deriveDeviceKeypair(aliceSeed);
+    const bobKp = await deriveDeviceKeypair(bobSeed);
+
+    const unsigned = makeUnsigned('evt-sign-1', 'device-test');
+    const aliceRecord = await signEvent(unsigned, aliceKp.signing.secretKey);
+    const bobRecord = await signEvent(unsigned, bobKp.signing.secretKey);
+
+    expect(aliceRecord.signatureHex).not.toBe(bobRecord.signatureHex);
+    expect(aliceRecord.signerPublicKeyHex).not.toBe(bobRecord.signerPublicKeyHex);
+
+    // Chaque signature valide avec sa propre clé publique
+    expect(await verifySignedEvent(aliceRecord)).toBe(true);
+    expect(await verifySignedEvent(bobRecord)).toBe(true);
+  }, 30_000);
+
+  it('restauration device : rejouer tous les changements sur un nouveau device', async () => {
+    const groupKey = await secretboxKeygen();
+    const aliceSeed = generateSeedPhrase();
+    const aliceKp = await deriveDeviceKeypair(aliceSeed);
+
+    // Alice construit un historique de 3 événements
+    const base = createDoc('hh-restore-1');
+    let aliceDoc = base;
+    for (let i = 1; i <= 3; i++) {
+      const record = await signEvent(
+        makeUnsigned(`evt-${i}`, 'device-alice'),
+        aliceKp.signing.secretKey,
+      );
+      aliceDoc = appendEvent(aliceDoc, record);
+    }
+
+    // Alice envoie tout depuis l'origine (full sync initial depuis doc vide)
+    // A.init() comme base garantit que TOUS les changements sont inclus,
+    // y compris le premier (createDoc), pour un nouveau device sans historique.
+    const fullSync = await buildSyncMessage(A.init<KinhaleDoc>(), aliceDoc, groupKey, {
+      mailboxId: 'mailbox-restore-1',
+      deviceId: 'device-alice',
+      seq: 1,
+    });
+    expect(fullSync).not.toBeNull();
+
+    // Nouveau device (restauré depuis le même seed BIP39)
+    const aliceKpRestored = await deriveDeviceKeypair(aliceSeed);
+    expect(Buffer.from(aliceKpRestored.signing.publicKey).toString('hex')).toBe(
+      Buffer.from(aliceKp.signing.publicKey).toString('hex'),
+    );
+
+    // Le nouveau device part d'un doc vide et reçoit tout l'historique
+    const newDevice = A.init<KinhaleDoc>();
+    const restored = await consumeSyncMessage(newDevice, fullSync!, groupKey);
+    expect(restored.events).toHaveLength(3);
+
+    // Toutes les signatures sont valides
+    for (const event of restored.events) {
+      expect(await verifySignedEvent(event)).toBe(true);
+    }
+  }, 60_000);
+});

--- a/packages/sync/src/integration/multi-device.test.ts
+++ b/packages/sync/src/integration/multi-device.test.ts
@@ -1,10 +1,6 @@
 // packages/sync/src/integration/multi-device.test.ts
 import { describe, it, expect } from 'vitest';
-import {
-  deriveDeviceKeypair,
-  generateSeedPhrase,
-  secretboxKeygen,
-} from '@kinhale/crypto';
+import { deriveDeviceKeypair, generateSeedPhrase, secretboxKeygen } from '@kinhale/crypto';
 import * as A from '@automerge/automerge';
 import { createDoc, loadDoc, saveDoc } from '../doc/lifecycle.js';
 import { signEvent } from '../events/sign.js';

--- a/packages/sync/src/mailbox/pipeline.test.ts
+++ b/packages/sync/src/mailbox/pipeline.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { secretboxKeygen } from '@kinhale/crypto';
+import { createDoc, loadDoc, saveDoc } from '../doc/lifecycle.js';
+import { buildSyncMessage, consumeSyncMessage } from './pipeline.js';
+import * as A from '@automerge/automerge';
+import type { SignedEventRecord } from '../doc/schema.js';
+
+const makeRecord = (id: string): SignedEventRecord => ({
+  id,
+  type: 'DoseAdministered',
+  payloadJson: '{}',
+  signerPublicKeyHex: 'a'.repeat(64),
+  signatureHex: 'b'.repeat(128),
+  deviceId: 'dev-1',
+  occurredAtMs: 1_700_000_000_000,
+});
+
+describe('buildSyncMessage', () => {
+  it('retourne null si aucun changement (before === after)', async () => {
+    const key = await secretboxKeygen();
+    const doc = createDoc('hh-pipeline-1');
+    const result = await buildSyncMessage(doc, doc, key, {
+      mailboxId: 'mb-1',
+      deviceId: 'dev-1',
+      seq: 1,
+    });
+    expect(result).toBeNull();
+  });
+
+  it('retourne un SyncMessage JSON encodé si des changements existent', async () => {
+    const key = await secretboxKeygen();
+    const before = createDoc('hh-pipeline-2');
+    const after = A.change(before, (d) => {
+      d.events.push(makeRecord('e1'));
+    });
+    const result = await buildSyncMessage(before, after, key, {
+      mailboxId: 'mb-2',
+      deviceId: 'dev-2',
+      seq: 1,
+    });
+    expect(typeof result).toBe('string');
+    const parsed = JSON.parse(result!);
+    expect(parsed.mailboxId).toBe('mb-2');
+    expect(parsed.deviceId).toBe('dev-2');
+    expect(parsed.seq).toBe(1);
+    expect(typeof parsed.blob.nonce).toBe('string');
+  });
+});
+
+describe('consumeSyncMessage', () => {
+  it('applique les changements et retourne le document mis à jour', async () => {
+    const key = await secretboxKeygen();
+    const base = createDoc('hh-pipeline-3');
+    const sender = A.change(base, (d) => {
+      d.events.push(makeRecord('e1'));
+    });
+    const json = await buildSyncMessage(base, sender, key, {
+      mailboxId: 'mb-3',
+      deviceId: 'dev-3',
+      seq: 1,
+    });
+    expect(json).not.toBeNull();
+
+    const receiver = loadDoc(saveDoc(base));
+    const updated = await consumeSyncMessage(receiver, json!, key);
+    expect(updated.events).toHaveLength(1);
+    expect(updated.events[0]!.id).toBe('e1');
+  });
+
+  it('throw si la clé de déchiffrement est incorrecte', async () => {
+    const key1 = await secretboxKeygen();
+    const key2 = await secretboxKeygen();
+    const base = createDoc('hh-pipeline-4');
+    const after = A.change(base, (d) => {
+      d.events.push(makeRecord('e2'));
+    });
+    const json = await buildSyncMessage(base, after, key1, {
+      mailboxId: 'mb-4',
+      deviceId: 'dev-4',
+      seq: 1,
+    });
+    await expect(consumeSyncMessage(base, json!, key2)).rejects.toThrow();
+  });
+
+  it('round-trip : buildSyncMessage → consumeSyncMessage → document convergé', async () => {
+    const key = await secretboxKeygen();
+    const base = createDoc('hh-pipeline-5');
+    let alice = base;
+    let bob = loadDoc(saveDoc(base));
+
+    // Alice ajoute 2 événements
+    alice = A.change(alice, (d) => {
+      d.events.push(makeRecord('e1'));
+    });
+    alice = A.change(alice, (d) => {
+      d.events.push(makeRecord('e2'));
+    });
+
+    const json = await buildSyncMessage(base, alice, key, {
+      mailboxId: 'mb-5',
+      deviceId: 'alice',
+      seq: 1,
+    });
+    bob = await consumeSyncMessage(bob, json!, key);
+    expect(bob.events).toHaveLength(2);
+    expect(bob.events[0]!.id).toBe('e1');
+    expect(bob.events[1]!.id).toBe('e2');
+  });
+});

--- a/packages/sync/src/mailbox/pipeline.ts
+++ b/packages/sync/src/mailbox/pipeline.ts
@@ -1,0 +1,53 @@
+import type { Doc } from '@automerge/automerge';
+import type { KinhaleDoc } from '../doc/schema.js';
+import { getDocChanges, mergeChanges } from '../doc/lifecycle.js';
+import { encryptChanges, decryptChanges } from './encrypt.js';
+import { encodeSyncMessage, decodeSyncMessage } from './message.js';
+
+export interface SyncMeta {
+  mailboxId: string;
+  deviceId: string;
+  seq: number;
+}
+
+/**
+ * Construit un SyncMessage JSON à envoyer au relais depuis les changements entre
+ * `before` et `after`. Retourne `null` si aucun changement (pas d'envoi nécessaire).
+ *
+ * Pipeline : getDocChanges → encryptChanges → encodeSyncMessage
+ */
+export async function buildSyncMessage(
+  before: Doc<KinhaleDoc>,
+  after: Doc<KinhaleDoc>,
+  groupKey: Uint8Array,
+  meta: SyncMeta,
+): Promise<string | null> {
+  const changes = getDocChanges(before, after);
+  if (changes.length === 0) return null;
+  const blob = await encryptChanges(changes, groupKey);
+  return encodeSyncMessage({
+    mailboxId: meta.mailboxId,
+    deviceId: meta.deviceId,
+    blob,
+    seq: meta.seq,
+    sentAtMs: Date.now(),
+  });
+}
+
+/**
+ * Applique un SyncMessage JSON reçu du relais sur un document local.
+ * Déchiffre, merge les changements Automerge et retourne le nouveau document.
+ *
+ * Pipeline : decodeSyncMessage → decryptChanges → mergeChanges
+ *
+ * @throws Error si le JSON est invalide, la clé incorrecte ou le MAC invalide.
+ */
+export async function consumeSyncMessage(
+  doc: Doc<KinhaleDoc>,
+  json: string,
+  groupKey: Uint8Array,
+): Promise<Doc<KinhaleDoc>> {
+  const msg = decodeSyncMessage(json);
+  const changes = await decryptChanges(msg.blob, groupKey);
+  return mergeChanges(doc, changes);
+}

--- a/packages/sync/src/sync/cursor.test.ts
+++ b/packages/sync/src/sync/cursor.test.ts
@@ -22,28 +22,28 @@ const makeRecord = (id: string): SignedEventRecord => ({
 describe('SyncCursor', () => {
   it('createCursor initialise un curseur vide', () => {
     const doc = createDoc('hh-cursor-1');
-    const cursor = createCursor(doc);
+    const cursor = createCursor();
     expect(cursor.knownHeads).toHaveLength(0);
   });
 
   it('recordSent met à jour la tête connue', () => {
     const doc = createDoc('hh-cursor-2');
     const updated = A.change(doc, (d) => { d.events.push(makeRecord('e1')); });
-    const cursor = createCursor(doc);
+    const cursor = createCursor();
     const cursor2 = recordSent(cursor, updated);
     expect(cursor2.knownHeads.length).toBeGreaterThan(0);
   });
 
   it('pendingChanges retourne [] si rien de nouveau depuis recordSent', () => {
     const doc = createDoc('hh-cursor-3');
-    const cursor = recordSent(createCursor(doc), doc);
+    const cursor = recordSent(createCursor(), doc);
     const pending = pendingChanges(cursor, doc);
     expect(pending).toHaveLength(0);
   });
 
   it('pendingChanges retourne les changements depuis la dernière tête envoyée', () => {
     const base = createDoc('hh-cursor-4');
-    const cursor = recordSent(createCursor(base), base);
+    const cursor = recordSent(createCursor(), base);
     const updated = A.change(base, (d) => { d.events.push(makeRecord('e1')); });
     const pending = pendingChanges(cursor, updated);
     expect(pending.length).toBeGreaterThan(0);
@@ -52,14 +52,14 @@ describe('SyncCursor', () => {
   it('recordReceived met à jour la tête des changements reçus', () => {
     const doc = createDoc('hh-cursor-5');
     const changes = getAllDocChanges(doc);
-    const cursor = createCursor(doc);
+    const cursor = createCursor();
     const cursor2 = recordReceived(cursor, changes);
     expect(cursor2.receivedCount).toBe(changes.length);
   });
 
   it('enchaîne sent → nouveau commit → pendingChanges → recordSent → 0 pending', () => {
     const base = createDoc('hh-cursor-6');
-    let cursor = recordSent(createCursor(base), base);
+    let cursor = recordSent(createCursor(), base);
     const updated = A.change(base, (d) => { d.events.push(makeRecord('e2')); });
     const pending = pendingChanges(cursor, updated);
     expect(pending.length).toBeGreaterThan(0);

--- a/packages/sync/src/sync/cursor.test.ts
+++ b/packages/sync/src/sync/cursor.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createCursor,
+  recordSent,
+  recordReceived,
+  pendingChanges,
+} from './cursor.js';
+import { createDoc, getAllDocChanges, mergeChanges } from '../doc/lifecycle.js';
+import * as A from '@automerge/automerge';
+import type { KinhaleDoc, SignedEventRecord } from '../doc/schema.js';
+
+const makeRecord = (id: string): SignedEventRecord => ({
+  id,
+  type: 'DoseAdministered',
+  payloadJson: '{}',
+  signerPublicKeyHex: 'a'.repeat(64),
+  signatureHex: 'b'.repeat(128),
+  deviceId: 'dev-1',
+  occurredAtMs: 1_700_000_000_000,
+});
+
+describe('SyncCursor', () => {
+  it('createCursor initialise un curseur vide', () => {
+    const doc = createDoc('hh-cursor-1');
+    const cursor = createCursor(doc);
+    expect(cursor.knownHeads).toHaveLength(0);
+  });
+
+  it('recordSent met à jour la tête connue', () => {
+    const doc = createDoc('hh-cursor-2');
+    const updated = A.change(doc, (d) => { d.events.push(makeRecord('e1')); });
+    const cursor = createCursor(doc);
+    const cursor2 = recordSent(cursor, updated);
+    expect(cursor2.knownHeads.length).toBeGreaterThan(0);
+  });
+
+  it('pendingChanges retourne [] si rien de nouveau depuis recordSent', () => {
+    const doc = createDoc('hh-cursor-3');
+    const cursor = recordSent(createCursor(doc), doc);
+    const pending = pendingChanges(cursor, doc);
+    expect(pending).toHaveLength(0);
+  });
+
+  it('pendingChanges retourne les changements depuis la dernière tête envoyée', () => {
+    const base = createDoc('hh-cursor-4');
+    const cursor = recordSent(createCursor(base), base);
+    const updated = A.change(base, (d) => { d.events.push(makeRecord('e1')); });
+    const pending = pendingChanges(cursor, updated);
+    expect(pending.length).toBeGreaterThan(0);
+  });
+
+  it('recordReceived met à jour la tête des changements reçus', () => {
+    const doc = createDoc('hh-cursor-5');
+    const changes = getAllDocChanges(doc);
+    const cursor = createCursor(doc);
+    const cursor2 = recordReceived(cursor, changes);
+    expect(cursor2.receivedCount).toBe(changes.length);
+  });
+
+  it('enchaîne sent → nouveau commit → pendingChanges → recordSent → 0 pending', () => {
+    const base = createDoc('hh-cursor-6');
+    let cursor = recordSent(createCursor(base), base);
+    const updated = A.change(base, (d) => { d.events.push(makeRecord('e2')); });
+    const pending = pendingChanges(cursor, updated);
+    expect(pending.length).toBeGreaterThan(0);
+    cursor = recordSent(cursor, updated);
+    expect(pendingChanges(cursor, updated)).toHaveLength(0);
+  });
+});

--- a/packages/sync/src/sync/cursor.test.ts
+++ b/packages/sync/src/sync/cursor.test.ts
@@ -1,13 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createCursor,
-  recordSent,
-  recordReceived,
-  pendingChanges,
-} from './cursor.js';
-import { createDoc, getAllDocChanges, mergeChanges } from '../doc/lifecycle.js';
+import { createCursor, recordSent, recordReceived, pendingChanges } from './cursor.js';
+import { createDoc, getAllDocChanges } from '../doc/lifecycle.js';
 import * as A from '@automerge/automerge';
-import type { KinhaleDoc, SignedEventRecord } from '../doc/schema.js';
+import type { SignedEventRecord } from '../doc/schema.js';
 
 const makeRecord = (id: string): SignedEventRecord => ({
   id,
@@ -21,14 +16,15 @@ const makeRecord = (id: string): SignedEventRecord => ({
 
 describe('SyncCursor', () => {
   it('createCursor initialise un curseur vide', () => {
-    const doc = createDoc('hh-cursor-1');
     const cursor = createCursor();
     expect(cursor.knownHeads).toHaveLength(0);
   });
 
   it('recordSent met à jour la tête connue', () => {
-    const doc = createDoc('hh-cursor-2');
-    const updated = A.change(doc, (d) => { d.events.push(makeRecord('e1')); });
+    const baseDoc = createDoc('hh-cursor-2');
+    const updated = A.change(baseDoc, (d) => {
+      d.events.push(makeRecord('e1'));
+    });
     const cursor = createCursor();
     const cursor2 = recordSent(cursor, updated);
     expect(cursor2.knownHeads.length).toBeGreaterThan(0);
@@ -44,7 +40,9 @@ describe('SyncCursor', () => {
   it('pendingChanges retourne les changements depuis la dernière tête envoyée', () => {
     const base = createDoc('hh-cursor-4');
     const cursor = recordSent(createCursor(), base);
-    const updated = A.change(base, (d) => { d.events.push(makeRecord('e1')); });
+    const updated = A.change(base, (d) => {
+      d.events.push(makeRecord('e1'));
+    });
     const pending = pendingChanges(cursor, updated);
     expect(pending.length).toBeGreaterThan(0);
   });
@@ -60,7 +58,9 @@ describe('SyncCursor', () => {
   it('enchaîne sent → nouveau commit → pendingChanges → recordSent → 0 pending', () => {
     const base = createDoc('hh-cursor-6');
     let cursor = recordSent(createCursor(), base);
-    const updated = A.change(base, (d) => { d.events.push(makeRecord('e2')); });
+    const updated = A.change(base, (d) => {
+      d.events.push(makeRecord('e2'));
+    });
     const pending = pendingChanges(cursor, updated);
     expect(pending.length).toBeGreaterThan(0);
     cursor = recordSent(cursor, updated);

--- a/packages/sync/src/sync/cursor.ts
+++ b/packages/sync/src/sync/cursor.ts
@@ -12,7 +12,7 @@ export interface SyncCursor {
 }
 
 /** Crée un cursor initialisé sur le document courant (jamais envoyé). */
-export function createCursor(doc: A.Doc<KinhaleDoc>): SyncCursor {
+export function createCursor(): SyncCursor {
   return {
     lastSentDoc: null,
     knownHeads: [],
@@ -37,6 +37,7 @@ export function recordSent(cursor: SyncCursor, doc: A.Doc<KinhaleDoc>): SyncCurs
  * Incrémente le compteur monotone pour journalisation.
  */
 export function recordReceived(cursor: SyncCursor, changes: Uint8Array[]): SyncCursor {
+  // Changes are applied to the doc outside the cursor (via mergeChanges); only count here.
   return {
     ...cursor,
     receivedCount: cursor.receivedCount + changes.length,

--- a/packages/sync/src/sync/cursor.ts
+++ b/packages/sync/src/sync/cursor.ts
@@ -1,0 +1,55 @@
+import * as A from '@automerge/automerge';
+import type { KinhaleDoc } from '../doc/schema.js';
+import { getDocChanges } from '../doc/lifecycle.js';
+
+export interface SyncCursor {
+  /** Snapshot Automerge après le dernier envoi réussi. Null = jamais envoyé. */
+  readonly lastSentDoc: A.Doc<KinhaleDoc> | null;
+  /** Têtes Automerge connues après le dernier envoi (pour comparaison rapide). */
+  readonly knownHeads: A.Heads;
+  /** Nombre cumulatif de changements reçus (compteur monotone). */
+  readonly receivedCount: number;
+}
+
+/** Crée un cursor initialisé sur le document courant (jamais envoyé). */
+export function createCursor(doc: A.Doc<KinhaleDoc>): SyncCursor {
+  return {
+    lastSentDoc: null,
+    knownHeads: [],
+    receivedCount: 0,
+  };
+}
+
+/**
+ * Enregistre que `doc` a été envoyé avec succès au relay.
+ * Les prochains appels à `pendingChanges` calculeront le delta depuis ce point.
+ */
+export function recordSent(cursor: SyncCursor, doc: A.Doc<KinhaleDoc>): SyncCursor {
+  return {
+    ...cursor,
+    lastSentDoc: doc,
+    knownHeads: A.getHeads(doc),
+  };
+}
+
+/**
+ * Enregistre des changements reçus du relay.
+ * Incrémente le compteur monotone pour journalisation.
+ */
+export function recordReceived(cursor: SyncCursor, changes: Uint8Array[]): SyncCursor {
+  return {
+    ...cursor,
+    receivedCount: cursor.receivedCount + changes.length,
+  };
+}
+
+/**
+ * Retourne les changements Automerge à envoyer depuis la dernière tête connue.
+ * Retourne tous les changements si jamais envoyé (full sync initial).
+ */
+export function pendingChanges(cursor: SyncCursor, current: A.Doc<KinhaleDoc>): Uint8Array[] {
+  if (cursor.lastSentDoc === null) {
+    return A.getAllChanges(current).map((c) => new Uint8Array(c));
+  }
+  return getDocChanges(cursor.lastSentDoc, current);
+}


### PR DESCRIPTION
## Summary

- **SyncCursor** (`src/sync/cursor.ts`) — cursor de delta-sync incrémental par device : `createCursor`, `recordSent`, `recordReceived`, `pendingChanges`
- **Pipeline convenience API** (`src/mailbox/pipeline.ts`) — `buildSyncMessage` + `consumeSyncMessage` composant les primitives encrypt/message existantes en une seule fonction
- **Test d'intégration multi-device** (`src/integration/multi-device.test.ts`) — 3 scénarios bout-en-bout : convergence bidirectionnelle Alice→Bob, binding de signature par device, restauration depuis seed BIP39 sur nouveau device vierge

## Test Plan

- [x] 40 tests passent (`pnpm --filter @kinhale/sync test`) — 26 Sprint 0 + 6 cursor + 5 pipeline + 3 intégration
- [x] Couverture : 97.82% (> 80% requis sur module critique)
- [x] TypeScript strict : 0 erreurs (`pnpm typecheck`)
- [x] Lint + format : 0 warnings (`pnpm lint`, `pnpm format:check`)
- [x] Revue spec compliance + code quality par sous-agents (2 passes par tâche)
- [x] Revue finale : zéro blocker

## Follow-up tickets

- `pendingChanges` full-sync path (cursor vierge) non couvert en unit test
- Renommer le test `recordReceived` pour refléter le comportement réel (compteur uniquement)
- Validation défensive de `SyncMeta` dans `buildSyncMessage`
- Test vector RFC pour le format wire `SyncMessage` (CLAUDE.md §E2EE)
- Documenter la précondition ancêtre dans la JSDoc de `buildSyncMessage`

> ⚠️ **2 reviews obligatoires** — PR touche `packages/sync` (CLAUDE.md)
> `kz-securite` invoqué avant ouverture (zone sensible : enveloppe E2EE + intégration signing)

Refs: KIN-021
🤖 Generated with [Claude Code](https://claude.com/claude-code)