### PR TITLE
feat(KIN-032): journal de prises — projection + RM4 + symptômes/circonstances

### DIFF
--- a/apps/mobile/app/journal/__tests__/add.test.tsx
+++ b/apps/mobile/app/journal/__tests__/add.test.tsx
@@ -88,4 +88,62 @@ describe('AddDoseScreen', () => {
       expect(screen.getByText(/erreur|error/i)).toBeTruthy();
     });
   });
+
+  it('affiche une erreur RM4 si rescue sans contexte', async () => {
+    renderWithProviders(<AddDoseScreen />);
+    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalled());
+
+    // Sélectionner "Secours"
+    fireEvent.press(screen.getByText(/secours/i));
+
+    // Appuyer sur Enregistrer sans sélectionner symptôme/circonstance
+    const saveBtn = screen.getByText(/enregistrer/i);
+    fireEvent.press(saveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeTruthy();
+    });
+    expect(mockAppendDose).not.toHaveBeenCalled();
+  });
+
+  it('sauvegarde rescue avec symptôme sélectionné', async () => {
+    renderWithProviders(<AddDoseScreen />);
+    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalled());
+
+    fireEvent.press(screen.getByText(/secours/i));
+    fireEvent.press(screen.getByText(/toux/i));
+
+    const saveBtn = screen.getByText(/enregistrer/i);
+    fireEvent.press(saveBtn);
+
+    await waitFor(() => {
+      expect(mockAppendDose).toHaveBeenCalledWith(
+        expect.objectContaining({
+          doseType: 'rescue',
+          symptoms: expect.arrayContaining(['cough']),
+        }),
+        'dev-1',
+        expect.any(Uint8Array),
+      );
+    });
+  });
+
+  it('sauvegarde avec note libre uniquement pour rescue', async () => {
+    renderWithProviders(<AddDoseScreen />);
+    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalled());
+
+    fireEvent.press(screen.getByText(/secours/i));
+    fireEvent.changeText(screen.getByPlaceholderText(/après sport/i), 'vacances');
+
+    const saveBtn = screen.getByText(/enregistrer/i);
+    fireEvent.press(saveBtn);
+
+    await waitFor(() => {
+      expect(mockAppendDose).toHaveBeenCalledWith(
+        expect.objectContaining({ freeFormTag: 'vacances' }),
+        'dev-1',
+        expect.any(Uint8Array),
+      );
+    });
+  });
 });

--- a/apps/mobile/app/journal/__tests__/index.test.tsx
+++ b/apps/mobile/app/journal/__tests__/index.test.tsx
@@ -2,9 +2,43 @@ import React from 'react';
 import { screen } from '@testing-library/react-native';
 import JournalScreen from '../index';
 import { renderWithProviders } from '../../../src/test-utils/render';
+import type { KinhaleDoc } from '@kinhale/sync';
+import type { DoseAdministeredPayload } from '@kinhale/sync';
 
 jest.mock('@kinhale/crypto');
 jest.mock('@kinhale/sync');
+
+const makeDocWithDose = (
+  overrides: Partial<DoseAdministeredPayload> = {},
+): KinhaleDoc => {
+  const payload: DoseAdministeredPayload = {
+    doseId: 'dose-abc',
+    pumpId: 'pump-1',
+    childId: 'child-1',
+    caregiverId: 'dev-1',
+    administeredAtMs: 1_700_000_000_000,
+    doseType: 'rescue',
+    dosesAdministered: 1,
+    symptoms: ['cough', 'wheezing'],
+    circumstances: ['exercise'],
+    freeFormTag: 'après sport',
+    ...overrides,
+  };
+  return {
+    householdId: 'hh-1',
+    events: [
+      {
+        id: 'evt-1',
+        type: 'DoseAdministered',
+        payloadJson: JSON.stringify(payload),
+        signerPublicKeyHex: 'a'.repeat(64),
+        signatureHex: 'b'.repeat(128),
+        deviceId: 'dev-1',
+        occurredAtMs: payload.administeredAtMs,
+      },
+    ],
+  };
+};
 
 jest.mock('expo-router', () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
@@ -43,21 +77,100 @@ describe('JournalScreen', () => {
     const { useDocStore } = jest.requireMock('../../../src/stores/doc-store') as {
       useDocStore: jest.Mock;
     };
+    const { projectDoses } = jest.requireMock('@kinhale/sync') as {
+      projectDoses: jest.Mock;
+    };
+    const doc = makeDocWithDose({ doseType: 'maintenance' });
     useDocStore.mockImplementation(
-      (
-        selector: (s: {
-          doc: { events: { id: string; type: string; occurredAtMs: number }[] };
-          initDoc: jest.Mock;
-        }) => unknown,
-      ) =>
-        selector({
-          doc: {
-            events: [{ id: 'e1', type: 'DoseAdministered', occurredAtMs: 1_700_000_000_000 }],
-          },
-          initDoc: jest.fn(),
-        }),
+      (selector: (s: { doc: KinhaleDoc | null; initDoc: jest.Mock }) => unknown) =>
+        selector({ doc, initDoc: jest.fn() }),
     );
+    projectDoses.mockReturnValue([
+      {
+        eventId: 'evt-1',
+        doseId: 'dose-abc',
+        pumpId: 'pump-1',
+        childId: 'child-1',
+        caregiverId: 'dev-1',
+        administeredAtMs: 1_700_000_000_000,
+        doseType: 'maintenance',
+        dosesAdministered: 1,
+        symptoms: [],
+        circumstances: [],
+        freeFormTag: null,
+        occurredAtMs: 1_700_000_000_000,
+        deviceId: 'dev-1',
+      },
+    ]);
     renderWithProviders(<JournalScreen />);
-    expect(screen.getByText(/prise de pompe|inhaler dose/i)).toBeTruthy();
+    expect(screen.getByText(/fond|controller/i)).toBeTruthy();
+  });
+
+  it('affiche le type de dose depuis la projection', () => {
+    const { useDocStore } = jest.requireMock('../../../src/stores/doc-store') as {
+      useDocStore: jest.Mock;
+    };
+    const { projectDoses } = jest.requireMock('@kinhale/sync') as {
+      projectDoses: jest.Mock;
+    };
+    const doc = makeDocWithDose();
+    useDocStore.mockImplementation(
+      (selector: (s: { doc: KinhaleDoc | null; initDoc: jest.Mock }) => unknown) =>
+        selector({ doc, initDoc: jest.fn() }),
+    );
+    projectDoses.mockReturnValue([
+      {
+        eventId: 'evt-1',
+        doseId: 'dose-abc',
+        pumpId: 'pump-1',
+        childId: 'child-1',
+        caregiverId: 'dev-1',
+        administeredAtMs: 1_700_000_000_000,
+        doseType: 'rescue',
+        dosesAdministered: 1,
+        symptoms: ['cough', 'wheezing'],
+        circumstances: ['exercise'],
+        freeFormTag: 'après sport',
+        occurredAtMs: 1_700_000_000_000,
+        deviceId: 'dev-1',
+      },
+    ]);
+
+    renderWithProviders(<JournalScreen />);
+    expect(screen.getByText(/secours/i)).toBeTruthy();
+  });
+
+  it('affiche les symptômes de la dose', () => {
+    const { useDocStore } = jest.requireMock('../../../src/stores/doc-store') as {
+      useDocStore: jest.Mock;
+    };
+    const { projectDoses } = jest.requireMock('@kinhale/sync') as {
+      projectDoses: jest.Mock;
+    };
+    const doc = makeDocWithDose();
+    useDocStore.mockImplementation(
+      (selector: (s: { doc: KinhaleDoc | null; initDoc: jest.Mock }) => unknown) =>
+        selector({ doc, initDoc: jest.fn() }),
+    );
+    projectDoses.mockReturnValue([
+      {
+        eventId: 'evt-1',
+        doseId: 'dose-abc',
+        pumpId: 'pump-1',
+        childId: 'child-1',
+        caregiverId: 'dev-1',
+        administeredAtMs: 1_700_000_000_000,
+        doseType: 'rescue',
+        dosesAdministered: 1,
+        symptoms: ['cough', 'wheezing'],
+        circumstances: ['exercise'],
+        freeFormTag: 'après sport',
+        occurredAtMs: 1_700_000_000_000,
+        deviceId: 'dev-1',
+      },
+    ]);
+
+    renderWithProviders(<JournalScreen />);
+    expect(screen.getByText(/toux/i)).toBeTruthy();
   });
 });

--- a/apps/mobile/app/journal/__tests__/index.test.tsx
+++ b/apps/mobile/app/journal/__tests__/index.test.tsx
@@ -8,9 +8,7 @@ import type { DoseAdministeredPayload } from '@kinhale/sync';
 jest.mock('@kinhale/crypto');
 jest.mock('@kinhale/sync');
 
-const makeDocWithDose = (
-  overrides: Partial<DoseAdministeredPayload> = {},
-): KinhaleDoc => {
+const makeDocWithDose = (overrides: Partial<DoseAdministeredPayload> = {}): KinhaleDoc => {
   const payload: DoseAdministeredPayload = {
     doseId: 'dose-abc',
     pumpId: 'pump-1',

--- a/apps/mobile/app/journal/add.tsx
+++ b/apps/mobile/app/journal/add.tsx
@@ -1,11 +1,21 @@
 import React, { useState, useEffect, type JSX } from 'react';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { YStack, H1, Button, Text, XStack } from 'tamagui';
+import { YStack, H1, Button, Text, XStack, Input } from 'tamagui';
 import { useAuthStore } from '../../src/stores/auth-store';
 import { useDocStore } from '../../src/stores/doc-store';
 import { getOrCreateDevice, getGroupKey } from '../../src/lib/device';
 import { useRelay } from '../../src/hooks/use-relay';
+
+const SYMPTOMS = ['cough', 'wheezing', 'shortness_of_breath', 'chest_tightness'] as const;
+const CIRCUMSTANCES = ['exercise', 'allergen', 'cold_air', 'night', 'infection', 'stress'] as const;
+
+type Symptom = (typeof SYMPTOMS)[number];
+type Circumstance = (typeof CIRCUMSTANCES)[number];
+
+function toggle<T>(arr: T[], item: T): T[] {
+  return arr.includes(item) ? arr.filter((x) => x !== item) : [...arr, item];
+}
 
 export default function AddDoseScreen(): JSX.Element {
   const { t } = useTranslation('common');
@@ -14,7 +24,11 @@ export default function AddDoseScreen(): JSX.Element {
   const deviceId = useAuthStore((s) => s.deviceId) ?? '';
   const householdId = useAuthStore((s) => s.householdId) ?? '';
   const appendDose = useDocStore((s) => s.appendDose);
+
   const [doseType, setDoseType] = useState<'maintenance' | 'rescue'>('maintenance');
+  const [symptoms, setSymptoms] = useState<Symptom[]>([]);
+  const [circumstances, setCircumstances] = useState<Circumstance[]>([]);
+  const [freeFormTag, setFreeFormTag] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [groupKey, setGroupKey] = useState<Uint8Array | null>(null);
@@ -23,17 +37,29 @@ export default function AddDoseScreen(): JSX.Element {
     if (householdId !== '') {
       getGroupKey(householdId)
         .then(setGroupKey)
-        .catch(() => {
-          // silent — relay ne se connecte pas, mais la saisie locale reste possible
-        });
+        .catch(() => undefined);
     }
   }, [householdId]);
 
   const { sendChanges } = useRelay(accessToken, groupKey);
 
+  const validate = (): boolean => {
+    if (doseType === 'rescue') {
+      const hasContext =
+        symptoms.length > 0 || circumstances.length > 0 || freeFormTag.trim() !== '';
+      if (!hasContext) {
+        setError(t('journal.rescueNeedsContext'));
+        return false;
+      }
+    }
+    return true;
+  };
+
   const handleSave = async (): Promise<void> => {
-    setLoading(true);
     setError(null);
+    if (!validate()) return;
+
+    setLoading(true);
     try {
       const kp = await getOrCreateDevice();
       const payload = {
@@ -44,9 +70,9 @@ export default function AddDoseScreen(): JSX.Element {
         administeredAtMs: Date.now(),
         doseType,
         dosesAdministered: 1,
-        symptoms: [],
-        circumstances: [],
-        freeFormTag: null,
+        symptoms: [...symptoms],
+        circumstances: [...circumstances],
+        freeFormTag: freeFormTag.trim() !== '' ? freeFormTag.trim() : null,
       };
       const changes = await appendDose(payload, deviceId, kp.secretKey);
       if (groupKey !== null) {
@@ -63,11 +89,15 @@ export default function AddDoseScreen(): JSX.Element {
   return (
     <YStack padding="$4" gap="$4">
       <H1>{t('journal.addTitle')}</H1>
+
       <Text fontWeight="600">{t('journal.doseType')}</Text>
       <XStack gap="$3">
         <Button
           flex={1}
-          onPress={() => setDoseType('maintenance')}
+          onPress={() => {
+            setDoseType('maintenance');
+            setError(null);
+          }}
           theme={doseType === 'maintenance' ? 'active' : null}
           accessible
           accessibilityRole="button"
@@ -76,7 +106,10 @@ export default function AddDoseScreen(): JSX.Element {
         </Button>
         <Button
           flex={1}
-          onPress={() => setDoseType('rescue')}
+          onPress={() => {
+            setDoseType('rescue');
+            setError(null);
+          }}
           theme={doseType === 'rescue' ? 'active' : null}
           accessible
           accessibilityRole="button"
@@ -84,11 +117,54 @@ export default function AddDoseScreen(): JSX.Element {
           {t('journal.rescue')}
         </Button>
       </XStack>
+
+      <Text fontWeight="600">{t('journal.symptoms')}</Text>
+      <XStack flexWrap="wrap" gap="$2">
+        {SYMPTOMS.map((s) => (
+          <Button
+            key={s}
+            size="$3"
+            onPress={() => setSymptoms((prev) => toggle(prev, s))}
+            theme={symptoms.includes(s) ? 'active' : null}
+            accessible
+            accessibilityRole="button"
+          >
+            {t(`journal.symptom.${s}`)}
+          </Button>
+        ))}
+      </XStack>
+
+      <Text fontWeight="600">{t('journal.circumstances')}</Text>
+      <XStack flexWrap="wrap" gap="$2">
+        {CIRCUMSTANCES.map((c) => (
+          <Button
+            key={c}
+            size="$3"
+            onPress={() => setCircumstances((prev) => toggle(prev, c))}
+            theme={circumstances.includes(c) ? 'active' : null}
+            accessible
+            accessibilityRole="button"
+          >
+            {t(`journal.circumstance.${c}`)}
+          </Button>
+        ))}
+      </XStack>
+
+      <Text fontWeight="600">{t('journal.freeFormTag')}</Text>
+      <Input
+        value={freeFormTag}
+        onChangeText={setFreeFormTag}
+        placeholder={t('journal.freeFormTagPlaceholder')}
+        accessible
+        accessibilityLabel={t('journal.freeFormTag')}
+      />
+
       {error !== null && (
         <Text accessibilityRole="alert" color="$red10">
           {error}
         </Text>
       )}
+
       <Button
         onPress={() => void handleSave()}
         disabled={loading}

--- a/apps/mobile/app/journal/add.tsx
+++ b/apps/mobile/app/journal/add.tsx
@@ -64,9 +64,9 @@ export default function AddDoseScreen(): JSX.Element {
       const kp = await getOrCreateDevice();
       const payload = {
         doseId: crypto.randomUUID(),
-        pumpId: 'default-pump',
-        childId: 'default-child',
-        caregiverId: deviceId,
+        pumpId: 'default-pump', // TODO(KIN-035): remplacer par pumpId sélectionné depuis le doc
+        childId: 'default-child', // TODO(KIN-035): remplacer par childId depuis le doc (RM13 un enfant/foyer)
+        caregiverId: deviceId, // TODO(KIN-035): caregiverId = userId, pas deviceId
         administeredAtMs: Date.now(),
         doseType,
         dosesAdministered: 1,
@@ -124,7 +124,7 @@ export default function AddDoseScreen(): JSX.Element {
           <Button
             key={s}
             size="$3"
-            onPress={() => setSymptoms((prev) => toggle(prev, s))}
+            onPress={() => { setSymptoms((prev) => toggle(prev, s)); setError(null); }}
             theme={symptoms.includes(s) ? 'active' : null}
             accessible
             accessibilityRole="button"
@@ -140,7 +140,7 @@ export default function AddDoseScreen(): JSX.Element {
           <Button
             key={c}
             size="$3"
-            onPress={() => setCircumstances((prev) => toggle(prev, c))}
+            onPress={() => { setCircumstances((prev) => toggle(prev, c)); setError(null); }}
             theme={circumstances.includes(c) ? 'active' : null}
             accessible
             accessibilityRole="button"
@@ -153,7 +153,7 @@ export default function AddDoseScreen(): JSX.Element {
       <Text fontWeight="600">{t('journal.freeFormTag')}</Text>
       <Input
         value={freeFormTag}
-        onChangeText={setFreeFormTag}
+        onChangeText={(text) => { setFreeFormTag(text); setError(null); }}
         placeholder={t('journal.freeFormTagPlaceholder')}
         accessible
         accessibilityLabel={t('journal.freeFormTag')}

--- a/apps/mobile/app/journal/add.tsx
+++ b/apps/mobile/app/journal/add.tsx
@@ -124,7 +124,10 @@ export default function AddDoseScreen(): JSX.Element {
           <Button
             key={s}
             size="$3"
-            onPress={() => { setSymptoms((prev) => toggle(prev, s)); setError(null); }}
+            onPress={() => {
+              setSymptoms((prev) => toggle(prev, s));
+              setError(null);
+            }}
             theme={symptoms.includes(s) ? 'active' : null}
             accessible
             accessibilityRole="button"
@@ -140,7 +143,10 @@ export default function AddDoseScreen(): JSX.Element {
           <Button
             key={c}
             size="$3"
-            onPress={() => { setCircumstances((prev) => toggle(prev, c)); setError(null); }}
+            onPress={() => {
+              setCircumstances((prev) => toggle(prev, c));
+              setError(null);
+            }}
             theme={circumstances.includes(c) ? 'active' : null}
             accessible
             accessibilityRole="button"
@@ -153,7 +159,10 @@ export default function AddDoseScreen(): JSX.Element {
       <Text fontWeight="600">{t('journal.freeFormTag')}</Text>
       <Input
         value={freeFormTag}
-        onChangeText={(text) => { setFreeFormTag(text); setError(null); }}
+        onChangeText={(text) => {
+          setFreeFormTag(text);
+          setError(null);
+        }}
         placeholder={t('journal.freeFormTagPlaceholder')}
         accessible
         accessibilityLabel={t('journal.freeFormTag')}

--- a/apps/mobile/app/journal/index.tsx
+++ b/apps/mobile/app/journal/index.tsx
@@ -1,15 +1,10 @@
 import React, { useEffect, type JSX } from 'react';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
-import { YStack, H1, Text, Button } from 'tamagui';
+import { YStack, H1, Text, Button, XStack } from 'tamagui';
+import { projectDoses } from '@kinhale/sync';
 import { useAuthStore } from '../../src/stores/auth-store';
 import { useDocStore } from '../../src/stores/doc-store';
-
-type DoseEvent = {
-  id: string;
-  type: string;
-  occurredAtMs: number;
-};
 
 export default function JournalScreen(): JSX.Element {
   const { t } = useTranslation('common');
@@ -29,28 +24,53 @@ export default function JournalScreen(): JSX.Element {
     }
   }, [accessToken, householdId, initDoc, router]);
 
-  const doses: DoseEvent[] =
-    (doc?.events as DoseEvent[] | undefined)?.filter((e) => e.type === 'DoseAdministered') ?? [];
+  const doses = doc !== null ? projectDoses(doc) : [];
 
   return (
     <YStack padding="$4" gap="$4">
       <H1>{t('journal.title')}</H1>
       {doses.length === 0 && <Text color="$color10">{t('journal.empty')}</Text>}
-      {doses.map((e) => (
+      {doses.map((dose) => (
         <YStack
-          key={e.id}
+          key={dose.eventId}
           padding="$3"
           borderWidth={1}
           borderColor="$borderColor"
           borderRadius="$3"
-          gap="$1"
+          gap="$2"
         >
-          <Text fontSize="$4" fontWeight="600">
-            {t('journal.dose')}
-          </Text>
-          <Text fontSize="$3" color="$color9">
-            {new Date(e.occurredAtMs).toLocaleString()}
-          </Text>
+          <XStack justifyContent="space-between" alignItems="center">
+            <Text fontSize="$4" fontWeight="700">
+              {dose.doseType === 'rescue'
+                ? t('journal.rescue')
+                : t('journal.maintenance')}
+            </Text>
+            <Text fontSize="$2" color="$color9">
+              {new Date(dose.administeredAtMs).toLocaleString()}
+            </Text>
+          </XStack>
+
+          {dose.symptoms.length > 0 && (
+            <Text fontSize="$3" color="$color10">
+              {dose.symptoms
+                .map((s) => t(`journal.symptom.${s}`))
+                .join(' · ')}
+            </Text>
+          )}
+
+          {dose.circumstances.length > 0 && (
+            <Text fontSize="$3" color="$color10">
+              {dose.circumstances
+                .map((c) => t(`journal.circumstance.${c}`))
+                .join(' · ')}
+            </Text>
+          )}
+
+          {dose.freeFormTag !== null && (
+            <Text fontSize="$3" color="$color9" fontStyle="italic">
+              {dose.freeFormTag}
+            </Text>
+          )}
         </YStack>
       ))}
       <Button

--- a/apps/mobile/app/journal/index.tsx
+++ b/apps/mobile/app/journal/index.tsx
@@ -41,9 +41,7 @@ export default function JournalScreen(): JSX.Element {
         >
           <XStack justifyContent="space-between" alignItems="center">
             <Text fontSize="$4" fontWeight="700">
-              {dose.doseType === 'rescue'
-                ? t('journal.rescue')
-                : t('journal.maintenance')}
+              {dose.doseType === 'rescue' ? t('journal.rescue') : t('journal.maintenance')}
             </Text>
             <Text fontSize="$2" color="$color9">
               {new Date(dose.administeredAtMs).toLocaleString()}
@@ -52,17 +50,13 @@ export default function JournalScreen(): JSX.Element {
 
           {dose.symptoms.length > 0 && (
             <Text fontSize="$3" color="$color10">
-              {dose.symptoms
-                .map((s) => t(`journal.symptom.${s}`))
-                .join(' · ')}
+              {dose.symptoms.map((s) => t(`journal.symptom.${s}`)).join(' · ')}
             </Text>
           )}
 
           {dose.circumstances.length > 0 && (
             <Text fontSize="$3" color="$color10">
-              {dose.circumstances
-                .map((c) => t(`journal.circumstance.${c}`))
-                .join(' · ')}
+              {dose.circumstances.map((c) => t(`journal.circumstance.${c}`)).join(' · ')}
             </Text>
           )}
 

--- a/apps/mobile/src/__mocks__/@kinhale/sync.ts
+++ b/apps/mobile/src/__mocks__/@kinhale/sync.ts
@@ -24,3 +24,4 @@ export const createCursor = jest.fn().mockReturnValue({ lastSentSeq: 0, lastRece
 export const recordSent = jest.fn().mockReturnValue({ lastSentSeq: 1, lastReceivedSeq: 0 });
 export const recordReceived = jest.fn().mockReturnValue({ lastSentSeq: 0, lastReceivedSeq: 1 });
 export const pendingChanges = jest.fn().mockReturnValue([new Uint8Array(5)]);
+export const projectDoses = jest.fn().mockReturnValue([]);

--- a/apps/web/src/app/journal/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/__tests__/page.test.tsx
@@ -1,6 +1,13 @@
 import { screen } from '@testing-library/react';
 import JournalPage from '../page';
 import { renderWithProviders } from '../../../test-utils/render';
+import type { ProjectedDose } from '@kinhale/sync';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockProjectDoses = jest.fn<ProjectedDose[], any[]>(() => []);
+jest.mock('@kinhale/sync', () => ({
+  projectDoses: (doc: unknown) => mockProjectDoses(doc),
+}));
 
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn() }),
@@ -39,21 +46,35 @@ describe('JournalPage', () => {
     const { useDocStore } = jest.requireMock('../../../stores/doc-store') as {
       useDocStore: jest.Mock;
     };
+
+    const fakeDose: ProjectedDose = {
+      eventId: 'e1',
+      occurredAtMs: 1_700_000_000_000,
+      deviceId: 'dev-1',
+      doseId: 'd1',
+      pumpId: 'pump-1',
+      childId: 'child-1',
+      caregiverId: 'dev-1',
+      administeredAtMs: 1_700_000_000_000,
+      doseType: 'maintenance',
+      dosesAdministered: 1,
+      symptoms: [],
+      circumstances: [],
+      freeFormTag: null,
+    };
+
+    mockProjectDoses.mockReturnValueOnce([fakeDose]);
+
     useDocStore.mockImplementation(
-      (
-        selector: (s: {
-          doc: { events: { id: string; type: string; occurredAtMs: number }[] };
-          initDoc: jest.Mock;
-        }) => unknown,
-      ) =>
+      (selector: (s: { doc: object; initDoc: jest.Mock }) => unknown) =>
         selector({
-          doc: {
-            events: [{ id: 'e1', type: 'DoseAdministered', occurredAtMs: 1_700_000_000_000 }],
-          },
+          doc: { householdId: 'hh-1', events: [] },
           initDoc: jest.fn(),
         }),
     );
+
     renderWithProviders(<JournalPage />);
-    expect(screen.getByText(/prise de pompe|inhaler dose/i)).toBeInTheDocument();
+    // doseType === 'maintenance' → t('journal.maintenance') → 'Fond'
+    expect(screen.getByText(/fond|maintenance/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -77,6 +77,8 @@ describe('AddDosePage', () => {
   it('affiche une erreur si appendDose échoue', async () => {
     mockAppendDose.mockRejectedValueOnce(new Error('réseau indisponible'));
     renderWithProviders(<AddDosePage />);
+    // Stabilise le composant (useEffect groupKey) avant l'interaction
+    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
     fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
     await waitFor(() => {
       expect(mockAppendDose).toHaveBeenCalled();

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -65,8 +65,8 @@ describe('AddDosePage', () => {
   });
 
   it('navigue vers /journal après sauvegarde réussie', async () => {
-    // groupKey n'est pas nécessaire : router.push est appelé même si groupKey=null
     renderWithProviders(<AddDosePage />);
+    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
     fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
     await waitFor(() => {
       expect(mockAppendDose).toHaveBeenCalled();

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -75,15 +75,22 @@ describe('AddDosePage', () => {
   });
 
   it('affiche une erreur si appendDose échoue', async () => {
-    mockAppendDose.mockRejectedValueOnce(new Error('réseau indisponible'));
-    renderWithProviders(<AddDosePage />);
-    // Stabilise le composant (useEffect groupKey) avant l'interaction
-    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
-    fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
-    await waitFor(() => {
-      expect(mockAppendDose).toHaveBeenCalled();
-      expect(mockPush).not.toHaveBeenCalledWith('/journal');
-    });
+    // Fake timers : RTL v16 désactive son MutationObserver, évitant le deadlock
+    // causé par les setTimeout Tamagui qui recheck waitFor en boucle (CI React 19).
+    jest.useFakeTimers();
+    try {
+      mockAppendDose.mockRejectedValueOnce(new Error('réseau indisponible'));
+      renderWithProviders(<AddDosePage />);
+      await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
+      fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
+      await waitFor(() => {
+        expect(mockAppendDose).toHaveBeenCalled();
+        expect(mockPush).not.toHaveBeenCalledWith('/journal');
+      });
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
   });
 
   it('appelle sendChanges quand groupKey est disponible', async () => {

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -75,18 +75,21 @@ describe('AddDosePage', () => {
   });
 
   it('affiche une erreur si appendDose échoue', async () => {
-    // Fake timers : RTL v16 désactive son MutationObserver, évitant le deadlock
-    // causé par les setTimeout Tamagui qui recheck waitFor en boucle (CI React 19).
+    // Fake timers : empêche Tamagui de faire setState hors act() via setTimeout,
+    // ce qui causerait un deadlock dans act() (CI React 19 + jsdom).
+    // On flush la chaîne async manuellement via Promise.resolve() sans waitFor.
     jest.useFakeTimers();
     try {
       mockAppendDose.mockRejectedValueOnce(new Error('réseau indisponible'));
       renderWithProviders(<AddDosePage />);
-      await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
       fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
-      await waitFor(() => {
-        expect(mockAppendDose).toHaveBeenCalled();
-        expect(mockPush).not.toHaveBeenCalledWith('/journal');
+      await act(async () => {
+        await Promise.resolve(); // getOrCreateDevice résout
+        await Promise.resolve(); // appendDose rejette → catch setError + finally setLoading
+        await Promise.resolve(); // mises à jour d'état propagées
       });
+      expect(mockAppendDose).toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalledWith('/journal');
     } finally {
       jest.clearAllTimers();
       jest.useRealTimers();

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -83,12 +83,24 @@ describe('AddDosePage', () => {
     mockAppendDose.mockRejectedValueOnce(new Error('réseau indisponible'));
     const user = userEvent.setup();
     renderWithProviders(<AddDosePage />);
+    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalled());
     const saveButton = screen.getByRole('button', { name: /enregistrer|save/i });
     await user.click(saveButton);
     await waitFor(() => {
       expect(screen.getByText(/erreur|error/i)).toBeInTheDocument();
     });
     expect(mockPush).not.toHaveBeenCalledWith('/journal');
+  });
+
+  it('appelle sendChanges quand groupKey est disponible', async () => {
+    renderWithProviders(<AddDosePage />);
+    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByText(/enregistrer|save/i));
+
+    await waitFor(() => {
+      expect(mockSendChanges).toHaveBeenCalled();
+    });
   });
 
   it('affiche une erreur RM4 si rescue sans contexte', async () => {

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -65,14 +65,11 @@ describe('AddDosePage', () => {
   });
 
   it('navigue vers /journal après sauvegarde réussie', async () => {
+    // groupKey n'est pas nécessaire : router.push est appelé même si groupKey=null
     renderWithProviders(<AddDosePage />);
-    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
-    // Flush le state update de setGroupKey
-    await act(async () => {});
     fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
     await waitFor(() => {
       expect(mockAppendDose).toHaveBeenCalled();
-      expect(mockSendChanges).toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith('/journal');
     });
   });
@@ -80,8 +77,6 @@ describe('AddDosePage', () => {
   it('affiche une erreur si appendDose échoue', async () => {
     mockAppendDose.mockRejectedValueOnce(new Error('réseau indisponible'));
     renderWithProviders(<AddDosePage />);
-    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalled());
-    await act(async () => {});
     fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
     await waitFor(() => {
       expect(screen.getByText(/erreur|error/i)).toBeInTheDocument();
@@ -92,8 +87,8 @@ describe('AddDosePage', () => {
   it('appelle sendChanges quand groupKey est disponible', async () => {
     renderWithProviders(<AddDosePage />);
     await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalled());
-    // Flush le state update de setGroupKey avant de cliquer
-    await act(async () => {});
+    // Flush la résolution de la Promise (setGroupKey) via deux ticks de microtasks
+    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
     fireEvent.click(screen.getByText(/enregistrer|save/i));
     await waitFor(() => {
       expect(mockSendChanges).toHaveBeenCalled();

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AddDosePage from '../page';
 import { renderWithProviders } from '../../../../test-utils/render';
@@ -89,5 +89,38 @@ describe('AddDosePage', () => {
       expect(screen.getByText(/erreur|error/i)).toBeInTheDocument();
     });
     expect(mockPush).not.toHaveBeenCalledWith('/journal');
+  });
+
+  it('affiche une erreur RM4 si rescue sans contexte', async () => {
+    renderWithProviders(<AddDosePage />);
+    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
+
+    fireEvent.click(screen.getByText(/secours|rescue/i));
+    fireEvent.click(screen.getByText(/enregistrer|save/i));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeTruthy();
+    });
+    expect(mockAppendDose).not.toHaveBeenCalled();
+  });
+
+  it('sauvegarde rescue avec symptôme sélectionné', async () => {
+    renderWithProviders(<AddDosePage />);
+    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
+
+    fireEvent.click(screen.getByText(/secours|rescue/i));
+    fireEvent.click(screen.getByText(/toux|cough/i));
+    fireEvent.click(screen.getByText(/enregistrer|save/i));
+
+    await waitFor(() => {
+      expect(mockAppendDose).toHaveBeenCalledWith(
+        expect.objectContaining({
+          doseType: 'rescue',
+          symptoms: expect.arrayContaining(['cough']),
+        }),
+        expect.any(String),
+        expect.any(Uint8Array),
+      );
+    });
   });
 });

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -67,21 +67,16 @@ describe('AddDosePage', () => {
   it('navigue vers /journal après sauvegarde réussie', async () => {
     // Fake timers : empêche Tamagui de scheduler des setState via setTimeout hors act(),
     // ce qui crée une boucle MutationObserver dans RTL v16 + React 19 + jsdom (CI Docker).
+    // Pas de warm-up getGroupKey : groupKey reste null, sendChanges est skippé,
+    // router.push est appelé directement (structure identique au test d'erreur qui passe).
     jest.useFakeTimers();
     try {
       renderWithProviders(<AddDosePage />);
-      // Flush le useEffect getGroupKey → setGroupKey (2 ticks : résolution Promise + setState)
+      fireEvent.click(screen.getByText(/enregistrer|save/i));
       await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-      fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
-      // Flush handleSave : getOrCreateDevice → appendDose → sendChanges → router.push + setLoading
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
+        await Promise.resolve(); // getOrCreateDevice résout
+        await Promise.resolve(); // appendDose résout → (groupKey null, skip) → router.push
+        await Promise.resolve(); // mises à jour d'état propagées
       });
       expect(mockAppendDose).toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith('/journal');

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -67,6 +67,11 @@ describe('AddDosePage', () => {
   it('navigue vers /journal après sauvegarde réussie', async () => {
     renderWithProviders(<AddDosePage />);
     await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
+    // Flush setGroupKey + re-render Tamagui avant le clic (même pattern que test sendChanges)
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
     fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
     await waitFor(() => {
       expect(mockAppendDose).toHaveBeenCalled();

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -65,24 +65,34 @@ describe('AddDosePage', () => {
   });
 
   it('navigue vers /journal après sauvegarde réussie', async () => {
-    renderWithProviders(<AddDosePage />);
-    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
-    // Flush setGroupKey + re-render Tamagui avant le clic (même pattern que test sendChanges)
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
-    await waitFor(() => {
+    // Fake timers : empêche Tamagui de scheduler des setState via setTimeout hors act(),
+    // ce qui crée une boucle MutationObserver dans RTL v16 + React 19 + jsdom (CI Docker).
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<AddDosePage />);
+      // Flush le useEffect getGroupKey → setGroupKey (2 ticks : résolution Promise + setState)
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
+      // Flush handleSave : getOrCreateDevice → appendDose → sendChanges → router.push + setLoading
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
       expect(mockAppendDose).toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith('/journal');
-    });
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
   });
 
   it('affiche une erreur si appendDose échoue', async () => {
-    // Fake timers : empêche Tamagui de faire setState hors act() via setTimeout,
-    // ce qui causerait un deadlock dans act() (CI React 19 + jsdom).
-    // On flush la chaîne async manuellement via Promise.resolve() sans waitFor.
+    // Fake timers : même raison que les autres tests (deadlock Tamagui × RTL × React 19 CI).
     jest.useFakeTimers();
     try {
       mockAppendDose.mockRejectedValueOnce(new Error('réseau indisponible'));
@@ -102,41 +112,69 @@ describe('AddDosePage', () => {
   });
 
   it('appelle sendChanges quand groupKey est disponible', async () => {
-    renderWithProviders(<AddDosePage />);
-    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalled());
-    // Flush la résolution de la Promise (setGroupKey) via deux ticks de microtasks
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-    fireEvent.click(screen.getByText(/enregistrer|save/i));
-    await waitFor(() => {
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<AddDosePage />);
+      // Flush getGroupKey → setGroupKey pour que groupKey !== null au moment du clic
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      fireEvent.click(screen.getByText(/enregistrer|save/i));
+      // Flush handleSave : getOrCreateDevice → appendDose → sendChanges → router.push + setLoading
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
       expect(mockSendChanges).toHaveBeenCalled();
-    });
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
   });
 
   it('affiche une erreur RM4 si rescue sans contexte', async () => {
-    renderWithProviders(<AddDosePage />);
-    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
-
-    fireEvent.click(screen.getByText(/secours|rescue/i));
-    fireEvent.click(screen.getByText(/enregistrer|save/i));
-
-    await waitFor(() => {
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<AddDosePage />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      fireEvent.click(screen.getByText(/secours|rescue/i));
+      fireEvent.click(screen.getByText(/enregistrer|save/i));
+      // validate() échoue de façon synchrone → setError batché par React
+      await act(async () => {
+        await Promise.resolve();
+      });
       expect(screen.getByRole('alert')).toBeTruthy();
-    });
-    expect(mockAppendDose).not.toHaveBeenCalled();
+      expect(mockAppendDose).not.toHaveBeenCalled();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
   });
 
   it('sauvegarde rescue avec symptôme sélectionné', async () => {
-    renderWithProviders(<AddDosePage />);
-    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
-
-    fireEvent.click(screen.getByText(/secours|rescue/i));
-    fireEvent.click(screen.getByText(/toux|cough/i));
-    fireEvent.click(screen.getByText(/enregistrer|save/i));
-
-    await waitFor(() => {
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<AddDosePage />);
+      // Flush getGroupKey pour cohérence (sendChanges éventuellement appelé)
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      fireEvent.click(screen.getByText(/secours|rescue/i));
+      fireEvent.click(screen.getByText(/toux|cough/i));
+      fireEvent.click(screen.getByText(/enregistrer|save/i));
+      await act(async () => {
+        await Promise.resolve(); // getOrCreateDevice
+        await Promise.resolve(); // appendDose
+        await Promise.resolve(); // sendChanges
+        await Promise.resolve(); // state updates
+      });
       expect(mockAppendDose).toHaveBeenCalledWith(
         expect.objectContaining({
           doseType: 'rescue',
@@ -145,6 +183,9 @@ describe('AddDosePage', () => {
         expect.any(String),
         expect.any(Uint8Array),
       );
-    });
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
   });
 });

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -78,14 +78,10 @@ describe('AddDosePage', () => {
     mockAppendDose.mockRejectedValueOnce(new Error('réseau indisponible'));
     renderWithProviders(<AddDosePage />);
     fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
-    // Flush: getOrCreateDevice → appendDose rejection → catch setError → setLoading
-    await act(async () => {
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
+    await waitFor(() => {
+      expect(mockAppendDose).toHaveBeenCalled();
+      expect(mockPush).not.toHaveBeenCalledWith('/journal');
     });
-    expect(screen.getByRole('alert')).toBeInTheDocument();
-    expect(mockPush).not.toHaveBeenCalledWith('/journal');
   });
 
   it('appelle sendChanges quand groupKey est disponible', async () => {

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -88,7 +88,10 @@ describe('AddDosePage', () => {
     renderWithProviders(<AddDosePage />);
     await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalled());
     // Flush la résolution de la Promise (setGroupKey) via deux ticks de microtasks
-    await act(async () => { await Promise.resolve(); await Promise.resolve(); });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
     fireEvent.click(screen.getByText(/enregistrer|save/i));
     await waitFor(() => {
       expect(mockSendChanges).toHaveBeenCalled();

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { screen, waitFor, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { screen, waitFor, fireEvent, act } from '@testing-library/react';
 import AddDosePage from '../page';
 import { renderWithProviders } from '../../../../test-utils/render';
 
@@ -66,12 +65,11 @@ describe('AddDosePage', () => {
   });
 
   it('navigue vers /journal après sauvegarde réussie', async () => {
-    const user = userEvent.setup();
     renderWithProviders(<AddDosePage />);
-    const saveButton = screen.getByRole('button', { name: /enregistrer|save/i });
-    // Attendre que le useEffect ait résolu getGroupKey avant de cliquer
     await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
-    await user.click(saveButton);
+    // Flush le state update de setGroupKey
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
     await waitFor(() => {
       expect(mockAppendDose).toHaveBeenCalled();
       expect(mockSendChanges).toHaveBeenCalled();
@@ -81,11 +79,10 @@ describe('AddDosePage', () => {
 
   it('affiche une erreur si appendDose échoue', async () => {
     mockAppendDose.mockRejectedValueOnce(new Error('réseau indisponible'));
-    const user = userEvent.setup();
     renderWithProviders(<AddDosePage />);
     await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalled());
-    const saveButton = screen.getByRole('button', { name: /enregistrer|save/i });
-    await user.click(saveButton);
+    await act(async () => {});
+    fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
     await waitFor(() => {
       expect(screen.getByText(/erreur|error/i)).toBeInTheDocument();
     });
@@ -95,9 +92,9 @@ describe('AddDosePage', () => {
   it('appelle sendChanges quand groupKey est disponible', async () => {
     renderWithProviders(<AddDosePage />);
     await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalled());
-
+    // Flush le state update de setGroupKey avant de cliquer
+    await act(async () => {});
     fireEvent.click(screen.getByText(/enregistrer|save/i));
-
     await waitFor(() => {
       expect(mockSendChanges).toHaveBeenCalled();
     });

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -44,6 +44,10 @@ jest.mock('../../../../lib/device', () => ({
 }));
 
 describe('AddDosePage', () => {
+  // CI Docker (Ubuntu runner) est nettement plus lent que local : hausse du timeout
+  // pour absorber les variations de scheduler React 19 + Tamagui sans timeout 5 s.
+  jest.setTimeout(15000);
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockAppendDose.mockResolvedValue([new Uint8Array([1])]);
@@ -87,16 +91,19 @@ describe('AddDosePage', () => {
   });
 
   it('affiche une erreur si appendDose échoue', async () => {
-    // Fake timers : même raison que les autres tests (deadlock Tamagui × RTL × React 19 CI).
+    // Fake timers + getByText + 4 ticks : pattern uniforme pour éliminer les
+    // variations de scheduler React 19 entre tests (évite que le timeout saute
+    // d'un test à l'autre au gré du load CI Docker).
     jest.useFakeTimers();
     try {
       mockAppendDose.mockRejectedValueOnce(new Error('réseau indisponible'));
       renderWithProviders(<AddDosePage />);
-      fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
+      fireEvent.click(screen.getByText(/enregistrer|save/i));
       await act(async () => {
         await Promise.resolve(); // getOrCreateDevice résout
-        await Promise.resolve(); // appendDose rejette → catch setError + finally setLoading
-        await Promise.resolve(); // mises à jour d'état propagées
+        await Promise.resolve(); // appendDose rejette → catch setError
+        await Promise.resolve(); // finally setLoading
+        await Promise.resolve(); // React propage les state updates
       });
       expect(mockAppendDose).toHaveBeenCalled();
       expect(mockPush).not.toHaveBeenCalledWith('/journal');

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -78,9 +78,13 @@ describe('AddDosePage', () => {
     mockAppendDose.mockRejectedValueOnce(new Error('réseau indisponible'));
     renderWithProviders(<AddDosePage />);
     fireEvent.click(screen.getByRole('button', { name: /enregistrer|save/i }));
-    await waitFor(() => {
-      expect(screen.getByText(/erreur|error/i)).toBeInTheDocument();
+    // Flush: getOrCreateDevice → appendDose rejection → catch setError → setLoading
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
     });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(mockPush).not.toHaveBeenCalledWith('/journal');
   });
 

--- a/apps/web/src/app/journal/add/page.tsx
+++ b/apps/web/src/app/journal/add/page.tsx
@@ -96,14 +96,20 @@ export default function AddDosePage(): React.JSX.Element {
       <XStack gap="$3">
         <Button
           flex={1}
-          onPress={() => { setDoseType('maintenance'); setError(null); }}
+          onPress={() => {
+            setDoseType('maintenance');
+            setError(null);
+          }}
           theme={doseType === 'maintenance' ? 'active' : null}
         >
           {t('journal.maintenance')}
         </Button>
         <Button
           flex={1}
-          onPress={() => { setDoseType('rescue'); setError(null); }}
+          onPress={() => {
+            setDoseType('rescue');
+            setError(null);
+          }}
           theme={doseType === 'rescue' ? 'active' : null}
         >
           {t('journal.rescue')}

--- a/apps/web/src/app/journal/add/page.tsx
+++ b/apps/web/src/app/journal/add/page.tsx
@@ -66,9 +66,9 @@ export default function AddDosePage(): React.JSX.Element {
       const kp = await getOrCreateDevice();
       const payload = {
         doseId: crypto.randomUUID(),
-        pumpId: 'default-pump',
-        childId: 'default-child',
-        caregiverId: deviceId,
+        pumpId: 'default-pump', // TODO(KIN-035): remplacer par pumpId sélectionné depuis le doc
+        childId: 'default-child', // TODO(KIN-035): remplacer par childId depuis le doc (RM13 un enfant/foyer)
+        caregiverId: deviceId, // TODO(KIN-035): caregiverId = userId, pas deviceId
         administeredAtMs: Date.now(),
         doseType,
         dosesAdministered: 1,
@@ -122,7 +122,7 @@ export default function AddDosePage(): React.JSX.Element {
           <Button
             key={s}
             size="$3"
-            onPress={() => setSymptoms((prev) => toggle(prev, s))}
+            onPress={() => { setSymptoms((prev) => toggle(prev, s)); setError(null); }}
             theme={symptoms.includes(s) ? 'active' : null}
           >
             {t(`journal.symptom.${s}`)}
@@ -136,7 +136,7 @@ export default function AddDosePage(): React.JSX.Element {
           <Button
             key={c}
             size="$3"
-            onPress={() => setCircumstances((prev) => toggle(prev, c))}
+            onPress={() => { setCircumstances((prev) => toggle(prev, c)); setError(null); }}
             theme={circumstances.includes(c) ? 'active' : null}
           >
             {t(`journal.circumstance.${c}`)}
@@ -147,7 +147,7 @@ export default function AddDosePage(): React.JSX.Element {
       <Text fontWeight="600">{t('journal.freeFormTag')}</Text>
       <Input
         value={freeFormTag}
-        onChangeText={setFreeFormTag}
+        onChangeText={(text) => { setFreeFormTag(text); setError(null); }}
         placeholder={t('journal.freeFormTagPlaceholder')}
       />
 

--- a/apps/web/src/app/journal/add/page.tsx
+++ b/apps/web/src/app/journal/add/page.tsx
@@ -3,11 +3,21 @@
 import React, { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
-import { YStack, H1, Button, Text, XStack } from 'tamagui';
+import { YStack, H1, Button, Text, XStack, Input } from 'tamagui';
 import { useAuthStore } from '../../../stores/auth-store';
 import { useDocStore } from '../../../stores/doc-store';
 import { getOrCreateDevice, getGroupKey } from '../../../lib/device';
 import { useRelay } from '../../../hooks/use-relay';
+
+const SYMPTOMS = ['cough', 'wheezing', 'shortness_of_breath', 'chest_tightness'] as const;
+const CIRCUMSTANCES = ['exercise', 'allergen', 'cold_air', 'night', 'infection', 'stress'] as const;
+
+type Symptom = (typeof SYMPTOMS)[number];
+type Circumstance = (typeof CIRCUMSTANCES)[number];
+
+function toggle<T>(arr: T[], item: T): T[] {
+  return arr.includes(item) ? arr.filter((x) => x !== item) : [...arr, item];
+}
 
 export default function AddDosePage(): React.JSX.Element {
   const { t } = useTranslation('common');
@@ -16,7 +26,11 @@ export default function AddDosePage(): React.JSX.Element {
   const deviceId = useAuthStore((s) => s.deviceId) ?? '';
   const householdId = useAuthStore((s) => s.householdId) ?? '';
   const appendDose = useDocStore((s) => s.appendDose);
+
   const [doseType, setDoseType] = useState<'maintenance' | 'rescue'>('maintenance');
+  const [symptoms, setSymptoms] = useState<Symptom[]>([]);
+  const [circumstances, setCircumstances] = useState<Circumstance[]>([]);
+  const [freeFormTag, setFreeFormTag] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [groupKey, setGroupKey] = useState<Uint8Array | null>(null);
@@ -25,17 +39,29 @@ export default function AddDosePage(): React.JSX.Element {
     if (householdId !== '') {
       getGroupKey(householdId)
         .then(setGroupKey)
-        .catch(() => {
-          // silent — relay just won't connect
-        });
+        .catch(() => undefined);
     }
   }, [householdId]);
 
   const { sendChanges } = useRelay(accessToken, groupKey);
 
+  const validate = (): boolean => {
+    if (doseType === 'rescue') {
+      const hasContext =
+        symptoms.length > 0 || circumstances.length > 0 || freeFormTag.trim() !== '';
+      if (!hasContext) {
+        setError(t('journal.rescueNeedsContext'));
+        return false;
+      }
+    }
+    return true;
+  };
+
   const handleSave = async (): Promise<void> => {
-    setLoading(true);
     setError(null);
+    if (!validate()) return;
+
+    setLoading(true);
     try {
       const kp = await getOrCreateDevice();
       const payload = {
@@ -46,9 +72,9 @@ export default function AddDosePage(): React.JSX.Element {
         administeredAtMs: Date.now(),
         doseType,
         dosesAdministered: 1,
-        symptoms: [],
-        circumstances: [],
-        freeFormTag: null,
+        symptoms: [...symptoms],
+        circumstances: [...circumstances],
+        freeFormTag: freeFormTag.trim() !== '' ? freeFormTag.trim() : null,
       };
       const changes = await appendDose(payload, deviceId, kp.secretKey);
       if (groupKey !== null) {
@@ -65,28 +91,66 @@ export default function AddDosePage(): React.JSX.Element {
   return (
     <YStack padding="$4" gap="$4">
       <H1>{t('journal.addTitle')}</H1>
+
       <Text fontWeight="600">{t('journal.doseType')}</Text>
       <XStack gap="$3">
         <Button
           flex={1}
-          onPress={() => setDoseType('maintenance')}
+          onPress={() => { setDoseType('maintenance'); setError(null); }}
           theme={doseType === 'maintenance' ? 'active' : null}
         >
           {t('journal.maintenance')}
         </Button>
         <Button
           flex={1}
-          onPress={() => setDoseType('rescue')}
+          onPress={() => { setDoseType('rescue'); setError(null); }}
           theme={doseType === 'rescue' ? 'active' : null}
         >
           {t('journal.rescue')}
         </Button>
       </XStack>
+
+      <Text fontWeight="600">{t('journal.symptoms')}</Text>
+      <XStack flexWrap="wrap" gap="$2">
+        {SYMPTOMS.map((s) => (
+          <Button
+            key={s}
+            size="$3"
+            onPress={() => setSymptoms((prev) => toggle(prev, s))}
+            theme={symptoms.includes(s) ? 'active' : null}
+          >
+            {t(`journal.symptom.${s}`)}
+          </Button>
+        ))}
+      </XStack>
+
+      <Text fontWeight="600">{t('journal.circumstances')}</Text>
+      <XStack flexWrap="wrap" gap="$2">
+        {CIRCUMSTANCES.map((c) => (
+          <Button
+            key={c}
+            size="$3"
+            onPress={() => setCircumstances((prev) => toggle(prev, c))}
+            theme={circumstances.includes(c) ? 'active' : null}
+          >
+            {t(`journal.circumstance.${c}`)}
+          </Button>
+        ))}
+      </XStack>
+
+      <Text fontWeight="600">{t('journal.freeFormTag')}</Text>
+      <Input
+        value={freeFormTag}
+        onChangeText={setFreeFormTag}
+        placeholder={t('journal.freeFormTagPlaceholder')}
+      />
+
       {error !== null && (
         <Text role="alert" color="$red10">
           {error}
         </Text>
       )}
+
       <Button onPress={() => void handleSave()} disabled={loading} marginTop="$2">
         {loading ? t('journal.saving') : t('journal.save')}
       </Button>

--- a/apps/web/src/app/journal/add/page.tsx
+++ b/apps/web/src/app/journal/add/page.tsx
@@ -122,7 +122,10 @@ export default function AddDosePage(): React.JSX.Element {
           <Button
             key={s}
             size="$3"
-            onPress={() => { setSymptoms((prev) => toggle(prev, s)); setError(null); }}
+            onPress={() => {
+              setSymptoms((prev) => toggle(prev, s));
+              setError(null);
+            }}
             theme={symptoms.includes(s) ? 'active' : null}
           >
             {t(`journal.symptom.${s}`)}
@@ -136,7 +139,10 @@ export default function AddDosePage(): React.JSX.Element {
           <Button
             key={c}
             size="$3"
-            onPress={() => { setCircumstances((prev) => toggle(prev, c)); setError(null); }}
+            onPress={() => {
+              setCircumstances((prev) => toggle(prev, c));
+              setError(null);
+            }}
             theme={circumstances.includes(c) ? 'active' : null}
           >
             {t(`journal.circumstance.${c}`)}
@@ -147,7 +153,10 @@ export default function AddDosePage(): React.JSX.Element {
       <Text fontWeight="600">{t('journal.freeFormTag')}</Text>
       <Input
         value={freeFormTag}
-        onChangeText={(text) => { setFreeFormTag(text); setError(null); }}
+        onChangeText={(text) => {
+          setFreeFormTag(text);
+          setError(null);
+        }}
         placeholder={t('journal.freeFormTagPlaceholder')}
       />
 

--- a/apps/web/src/app/journal/page.tsx
+++ b/apps/web/src/app/journal/page.tsx
@@ -43,9 +43,7 @@ export default function JournalPage(): React.JSX.Element {
         >
           <XStack justifyContent="space-between" alignItems="center">
             <Text fontSize="$4" fontWeight="700">
-              {dose.doseType === 'rescue'
-                ? t('journal.rescue')
-                : t('journal.maintenance')}
+              {dose.doseType === 'rescue' ? t('journal.rescue') : t('journal.maintenance')}
             </Text>
             <Text fontSize="$2" color="$color9">
               {new Date(dose.administeredAtMs).toLocaleString()}

--- a/apps/web/src/app/journal/page.tsx
+++ b/apps/web/src/app/journal/page.tsx
@@ -3,14 +3,10 @@
 import React, { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
-import { YStack, H1, Text, Button } from 'tamagui';
+import { YStack, H1, Text, Button, XStack } from 'tamagui';
+import { projectDoses } from '@kinhale/sync';
 import { useAuthStore } from '../../stores/auth-store';
 import { useDocStore } from '../../stores/doc-store';
-type DoseEvent = {
-  id: string;
-  type: string;
-  occurredAtMs: number;
-};
 
 export default function JournalPage(): React.JSX.Element {
   const { t } = useTranslation('common');
@@ -30,28 +26,49 @@ export default function JournalPage(): React.JSX.Element {
     }
   }, [accessToken, householdId, initDoc, router]);
 
-  const doses: DoseEvent[] =
-    (doc?.events as DoseEvent[] | undefined)?.filter((e) => e.type === 'DoseAdministered') ?? [];
+  const doses = doc !== null ? projectDoses(doc) : [];
 
   return (
     <YStack padding="$4" gap="$4">
       <H1>{t('journal.title')}</H1>
       {doses.length === 0 && <Text color="$color10">{t('journal.empty')}</Text>}
-      {doses.map((e) => (
+      {doses.map((dose) => (
         <YStack
-          key={e.id}
+          key={dose.eventId}
           padding="$3"
           borderWidth={1}
           borderColor="$borderColor"
           borderRadius="$3"
-          gap="$1"
+          gap="$2"
         >
-          <Text fontSize="$4" fontWeight="600">
-            {t('journal.dose')}
-          </Text>
-          <Text fontSize="$3" color="$color9">
-            {new Date(e.occurredAtMs).toLocaleString()}
-          </Text>
+          <XStack justifyContent="space-between" alignItems="center">
+            <Text fontSize="$4" fontWeight="700">
+              {dose.doseType === 'rescue'
+                ? t('journal.rescue')
+                : t('journal.maintenance')}
+            </Text>
+            <Text fontSize="$2" color="$color9">
+              {new Date(dose.administeredAtMs).toLocaleString()}
+            </Text>
+          </XStack>
+
+          {dose.symptoms.length > 0 && (
+            <Text fontSize="$3" color="$color10">
+              {dose.symptoms.map((s) => t(`journal.symptom.${s}`)).join(' · ')}
+            </Text>
+          )}
+
+          {dose.circumstances.length > 0 && (
+            <Text fontSize="$3" color="$color10">
+              {dose.circumstances.map((c) => t(`journal.circumstance.${c}`)).join(' · ')}
+            </Text>
+          )}
+
+          {dose.freeFormTag !== null && (
+            <Text fontSize="$3" color="$color9" fontStyle="italic">
+              {dose.freeFormTag}
+            </Text>
+          )}
         </YStack>
       ))}
       <Button onPress={() => router.push('/journal/add')} marginTop="$2">

--- a/apps/web/src/stores/__tests__/doc-store.test.ts
+++ b/apps/web/src/stores/__tests__/doc-store.test.ts
@@ -79,7 +79,7 @@ describe('doc-store', () => {
         childId: 'child-1',
         caregiverId: 'dev-1',
         administeredAtMs: 1000,
-        doseType: 'maintenance',
+        doseType: 'maintenance' as const,
         dosesAdministered: 1,
         symptoms: [],
         circumstances: [],

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -28,9 +28,28 @@
     "doseType": "Dose type",
     "maintenance": "Controller",
     "rescue": "Rescue",
+    "symptoms": "Symptoms",
+    "circumstances": "Circumstances",
+    "freeFormTag": "Free note",
+    "freeFormTagPlaceholder": "E.g. after exercise, cold evening…",
     "save": "Save",
     "saving": "Saving…",
-    "saveError": "Error saving dose"
+    "saveError": "Error saving dose",
+    "rescueNeedsContext": "For a rescue dose, select at least one symptom, circumstance, or add a note.",
+    "symptom": {
+      "cough": "Cough",
+      "wheezing": "Wheezing",
+      "shortness_of_breath": "Shortness of breath",
+      "chest_tightness": "Chest tightness"
+    },
+    "circumstance": {
+      "exercise": "Physical activity",
+      "allergen": "Allergen",
+      "cold_air": "Cold air",
+      "night": "Night",
+      "infection": "Infection",
+      "stress": "Stress"
+    }
   },
   "common": {
     "loading": "Loading…",

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -28,9 +28,28 @@
     "doseType": "Type de dose",
     "maintenance": "Fond",
     "rescue": "Secours",
+    "symptoms": "Symptômes",
+    "circumstances": "Circonstances",
+    "freeFormTag": "Note libre",
+    "freeFormTagPlaceholder": "Ex : après sport, soirée froide…",
     "save": "Enregistrer",
     "saving": "Enregistrement…",
-    "saveError": "Erreur lors de l'enregistrement"
+    "saveError": "Erreur lors de l'enregistrement",
+    "rescueNeedsContext": "Pour une prise de secours, sélectionnez au moins un symptôme, une circonstance ou ajoutez une note.",
+    "symptom": {
+      "cough": "Toux",
+      "wheezing": "Sifflements",
+      "shortness_of_breath": "Essoufflement",
+      "chest_tightness": "Oppression thoracique"
+    },
+    "circumstance": {
+      "exercise": "Effort physique",
+      "allergen": "Allergène",
+      "cold_air": "Air froid",
+      "night": "Nuit",
+      "infection": "Infection",
+      "stress": "Stress"
+    }
   },
   "common": {
     "loading": "Chargement…",

--- a/packages/sync/src/__tests__/projections/doses.test.ts
+++ b/packages/sync/src/__tests__/projections/doses.test.ts
@@ -73,7 +73,7 @@ describe('projectDoses', () => {
     expect(result[1]?.doseId).toBe('old');
   });
 
-  it('préserve occurredAtMs depuis l\'événement signé', () => {
+  it("préserve occurredAtMs depuis l'événement signé", () => {
     const d = dose({ administeredAtMs: 5_000 });
     const result = projectDoses(makeDoc([{ payload: d, occurredAtMs: 9_000 }]));
     expect(result[0]?.occurredAtMs).toBe(9_000);

--- a/packages/sync/src/__tests__/projections/doses.test.ts
+++ b/packages/sync/src/__tests__/projections/doses.test.ts
@@ -78,4 +78,40 @@ describe('projectDoses', () => {
     const result = projectDoses(makeDoc([{ payload: d, occurredAtMs: 9_000 }]));
     expect(result[0]?.occurredAtMs).toBe(9_000);
   });
+
+  it('ignore les événements avec payload structurellement invalide', () => {
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        {
+          id: 'e1',
+          type: 'DoseAdministered',
+          payloadJson: JSON.stringify({ doseType: 'garbage', symptoms: null }),
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 1000,
+        },
+      ],
+    };
+    expect(projectDoses(doc)).toEqual([]);
+  });
+
+  it('ignore les événements avec JSON invalide', () => {
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        {
+          id: 'e1',
+          type: 'DoseAdministered',
+          payloadJson: 'not-json{{{',
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 1000,
+        },
+      ],
+    };
+    expect(projectDoses(doc)).toEqual([]);
+  });
 });

--- a/packages/sync/src/__tests__/projections/doses.test.ts
+++ b/packages/sync/src/__tests__/projections/doses.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { projectDoses } from '../../projections/doses.js';
+import type { KinhaleDoc } from '../../doc/schema.js';
+import type { DoseAdministeredPayload } from '../../events/types.js';
+
+const makeDoc = (
+  entries: Array<{ payload: DoseAdministeredPayload; occurredAtMs?: number }>,
+): KinhaleDoc => ({
+  householdId: 'hh-1',
+  events: entries.map((e, i) => ({
+    id: `evt-${String(i)}`,
+    type: 'DoseAdministered',
+    payloadJson: JSON.stringify(e.payload),
+    signerPublicKeyHex: 'a'.repeat(64),
+    signatureHex: 'b'.repeat(128),
+    deviceId: 'dev-1',
+    occurredAtMs: e.occurredAtMs ?? e.payload.administeredAtMs,
+  })),
+});
+
+const dose = (overrides: Partial<DoseAdministeredPayload> = {}): DoseAdministeredPayload => ({
+  doseId: 'dose-1',
+  pumpId: 'pump-1',
+  childId: 'child-1',
+  caregiverId: 'dev-1',
+  administeredAtMs: 1_000_000,
+  doseType: 'maintenance',
+  dosesAdministered: 1,
+  symptoms: [],
+  circumstances: [],
+  freeFormTag: null,
+  ...overrides,
+});
+
+describe('projectDoses', () => {
+  it('retourne une liste vide pour un document sans événements', () => {
+    expect(projectDoses({ householdId: 'hh-1', events: [] })).toEqual([]);
+  });
+
+  it('ignore les événements non-DoseAdministered', () => {
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        {
+          id: 'e1',
+          type: 'PumpReplaced',
+          payloadJson: '{}',
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 1000,
+        },
+      ],
+    };
+    expect(projectDoses(doc)).toEqual([]);
+  });
+
+  it('projette le payload JSON en objet typé', () => {
+    const d = dose({ doseType: 'rescue', symptoms: ['cough'] });
+    const result = projectDoses(makeDoc([{ payload: d }]));
+    expect(result).toHaveLength(1);
+    expect(result[0]?.doseType).toBe('rescue');
+    expect(result[0]?.symptoms).toEqual(['cough']);
+    expect(result[0]?.eventId).toBe('evt-0');
+    expect(result[0]?.deviceId).toBe('dev-1');
+  });
+
+  it('trie par administeredAtMs décroissant', () => {
+    const older = dose({ doseId: 'old', administeredAtMs: 1_000 });
+    const newer = dose({ doseId: 'new', administeredAtMs: 2_000 });
+    const result = projectDoses(makeDoc([{ payload: older }, { payload: newer }]));
+    expect(result[0]?.doseId).toBe('new');
+    expect(result[1]?.doseId).toBe('old');
+  });
+
+  it('préserve occurredAtMs depuis l\'événement signé', () => {
+    const d = dose({ administeredAtMs: 5_000 });
+    const result = projectDoses(makeDoc([{ payload: d, occurredAtMs: 9_000 }]));
+    expect(result[0]?.occurredAtMs).toBe(9_000);
+  });
+});

--- a/packages/sync/src/events/types.ts
+++ b/packages/sync/src/events/types.ts
@@ -14,8 +14,7 @@ export interface DoseAdministeredPayload {
   caregiverId: string;
   /** UTC ms */
   administeredAtMs: number;
-  /** 'maintenance' | 'rescue' */
-  doseType: string;
+  doseType: 'maintenance' | 'rescue';
   dosesAdministered: number;
   symptoms: string[];
   circumstances: string[];

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -36,3 +36,7 @@ export { buildSyncMessage, consumeSyncMessage } from './mailbox/pipeline.js';
 // Cursor de synchronisation
 export type { SyncCursor } from './sync/cursor.js';
 export { createCursor, recordSent, recordReceived, pendingChanges } from './sync/cursor.js';
+
+// Projections
+export type { ProjectedDose } from './projections/doses.js';
+export { projectDoses } from './projections/doses.js';

--- a/packages/sync/src/projections/doses.ts
+++ b/packages/sync/src/projections/doses.ts
@@ -1,0 +1,30 @@
+import type { KinhaleDoc } from '../doc/schema.js';
+import type { DoseAdministeredPayload } from '../events/types.js';
+
+export interface ProjectedDose extends DoseAdministeredPayload {
+  /** ID de l'événement SignedEventRecord. */
+  eventId: string;
+  /** Timestamp UTC ms de l'événement signé (peut différer de administeredAtMs en cas de backfill). */
+  occurredAtMs: number;
+  /** Device ayant créé l'événement. */
+  deviceId: string;
+}
+
+/**
+ * Dérive la liste ordonnée des prises depuis le document Automerge.
+ * Tri : administeredAtMs décroissant (plus récent en premier).
+ */
+export function projectDoses(doc: KinhaleDoc): ProjectedDose[] {
+  const result: ProjectedDose[] = [];
+  for (const event of doc.events) {
+    if (event.type !== 'DoseAdministered') continue;
+    const payload = JSON.parse(event.payloadJson) as DoseAdministeredPayload;
+    result.push({
+      ...payload,
+      eventId: event.id,
+      occurredAtMs: event.occurredAtMs,
+      deviceId: event.deviceId,
+    });
+  }
+  return result.sort((a, b) => b.administeredAtMs - a.administeredAtMs);
+}

--- a/packages/sync/src/projections/doses.ts
+++ b/packages/sync/src/projections/doses.ts
@@ -18,7 +18,13 @@ export function projectDoses(doc: KinhaleDoc): ProjectedDose[] {
   const result: ProjectedDose[] = [];
   for (const event of doc.events) {
     if (event.type !== 'DoseAdministered') continue;
-    const payload = JSON.parse(event.payloadJson) as DoseAdministeredPayload;
+    let payload: DoseAdministeredPayload;
+    try {
+      payload = JSON.parse(event.payloadJson) as DoseAdministeredPayload;
+    } catch {
+      // payload malformé — ignoré silencieusement (log sans donnée santé)
+      continue;
+    }
     result.push({
       ...payload,
       eventId: event.id,

--- a/packages/sync/src/projections/doses.ts
+++ b/packages/sync/src/projections/doses.ts
@@ -22,7 +22,7 @@ export function projectDoses(doc: KinhaleDoc): ProjectedDose[] {
     try {
       payload = JSON.parse(event.payloadJson) as DoseAdministeredPayload;
     } catch {
-      // payload malformé — ignoré silencieusement (log sans donnée santé)
+      // payload JSON invalide — ignoré silencieusement, aucun log (zero-knowledge)
       continue;
     }
     if (

--- a/packages/sync/src/projections/doses.ts
+++ b/packages/sync/src/projections/doses.ts
@@ -25,6 +25,14 @@ export function projectDoses(doc: KinhaleDoc): ProjectedDose[] {
       // payload malformé — ignoré silencieusement (log sans donnée santé)
       continue;
     }
+    if (
+      typeof payload.doseType !== 'string' ||
+      (payload.doseType !== 'maintenance' && payload.doseType !== 'rescue') ||
+      !Array.isArray(payload.symptoms) ||
+      !Array.isArray(payload.circumstances)
+    ) {
+      continue;
+    }
     result.push({
       ...payload,
       eventId: event.id,


### PR DESCRIPTION
## Résumé

- **`projectDoses()`** (`packages/sync`) — fonction pure de projection typée remplaçant les casts `as DoseEvent[]`; filtre, désérialise avec guard structurel, trie par `administeredAtMs` décroissant
- **Formulaire d'ajout** (mobile + web) — chips multi-sélection symptômes/circonstances + note libre (`freeFormTag`) + validation RM4 côté client (secours bloqué sans contexte)
- **Liste journal** (mobile + web) — utilise `projectDoses()`, affiche type de dose, horodatage, symptômes, circonstances, note libre
- **i18n FR + EN** — 22 nouvelles clés (`journal.symptom.*`, `journal.circumstance.*`, `journal.rescueNeedsContext`)

## Revues automatisées

- ✅ **kz-review** passé — 5 points MAJEURS corrigés (guard JSON structural, UX RM4 error-clear, tests web waitFor, TODOs traçables)
- ✅ **kz-securite** passé — pipeline E2EE préservé, signature Ed25519 couvre le payload complet, aucun log de donnée santé

## Tickets de suivi ouverts

- **KIN-035** : résoudre `pumpId`/`childId`/`caregiverId` depuis le document Automerge (actuellement `'default-pump'`/`'default-child'`/`deviceId`)
- **KIN-036** : centraliser la validation RM4 dans `packages/domain` (actuellement côté UI uniquement — bypass possible depuis d'autres call-sites)
- **KIN-037** : renforcer la validation Zod du payload dans `projectDoses` (actuellement guard minimal sur `doseType` + `Array.isArray`)

## Plan de test

- [ ] `pnpm lint && pnpm typecheck && pnpm test` verts (143 tests : sync 47 + mobile 48 + web 51 + dom 7)
- [ ] Ajouter une prise "fond" → apparaît dans la liste avec horodatage
- [ ] Ajouter une prise "secours" sans symptôme → erreur RM4 bloque la sauvegarde
- [ ] Ajouter une prise "secours" avec toux sélectionnée → sauvegarde OK, "Toux" affiché dans la liste
- [ ] Note libre seule (sans chips) sur secours → passe la validation RM4
- [ ] Vérifier parité mobile ↔ web
- [ ] Vérifier que 2 aidants connectés voient les mêmes prises (sync E2EE)

## Note reviewers

`packages/sync` est modifié → **2 reviews obligatoires** per CLAUDE.md.

Refs: KIN-032