### PR TITLE
feat(KIN-035-A): chiffrement du stockage local — primitives crypto

### DIFF
--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -18,3 +18,6 @@ export { deriveDeviceKeypair } from './device/keypair.js';
 export type { DeviceKeypair } from './device/keypair.js';
 export { generateInvitationToken } from './invitation/token.js';
 export { generatePin, hashPin, verifyPin } from './invitation/pin.js';
+export { generateStorageKey } from './storage/key.js';
+export type { EncryptedBlob } from './storage/blob.js';
+export { encryptDocBlob, decryptDocBlob } from './storage/blob.js';

--- a/packages/crypto/src/storage/blob.test.ts
+++ b/packages/crypto/src/storage/blob.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { encryptDocBlob, decryptDocBlob } from './blob.js';
+import { generateStorageKey } from './key.js';
+
+describe('encryptDocBlob / decryptDocBlob', () => {
+  it("round-trip rend le plaintext d'origine", async () => {
+    const key = await generateStorageKey();
+    const plaintext = new TextEncoder().encode('hello automerge doc');
+    const blob = await encryptDocBlob(plaintext, key);
+    const decrypted = await decryptDocBlob(blob, key);
+    expect(new TextDecoder().decode(decrypted)).toBe('hello automerge doc');
+  });
+
+  it('produit un blob avec nonceHex 48 chars + version 1', async () => {
+    const key = await generateStorageKey();
+    const blob = await encryptDocBlob(new Uint8Array([1, 2, 3]), key);
+    expect(blob.nonceHex).toMatch(/^[0-9a-f]{48}$/);
+    expect(blob.version).toBe(1);
+    expect(blob.ciphertextHex.length).toBeGreaterThan(0);
+  });
+
+  it('deux chiffrements du même plaintext produisent des ciphertexts différents (nonce aléatoire)', async () => {
+    const key = await generateStorageKey();
+    const plaintext = new Uint8Array([1, 2, 3, 4]);
+    const b1 = await encryptDocBlob(plaintext, key);
+    const b2 = await encryptDocBlob(plaintext, key);
+    expect(b1.ciphertextHex).not.toBe(b2.ciphertextHex);
+    expect(b1.nonceHex).not.toBe(b2.nonceHex);
+  });
+
+  it('throw si la clé est fausse', async () => {
+    const k1 = await generateStorageKey();
+    const k2 = await generateStorageKey();
+    const blob = await encryptDocBlob(new Uint8Array([1, 2, 3]), k1);
+    await expect(decryptDocBlob(blob, k2)).rejects.toThrow();
+  });
+
+  it('throw si le ciphertext est altéré (MAC invalide)', async () => {
+    const key = await generateStorageKey();
+    const blob = await encryptDocBlob(new Uint8Array([1, 2, 3]), key);
+    const tampered = {
+      ...blob,
+      ciphertextHex: blob.ciphertextHex.replace(/^./, (c) => (c === '0' ? '1' : '0')),
+    };
+    await expect(decryptDocBlob(tampered, key)).rejects.toThrow();
+  });
+
+  it("throw si la version n'est pas supportée", async () => {
+    const key = await generateStorageKey();
+    const blob = await encryptDocBlob(new Uint8Array([1]), key);
+    // @ts-expect-error forcer une version invalide pour le test
+    await expect(decryptDocBlob({ ...blob, version: 99 }, key)).rejects.toThrow();
+  });
+});

--- a/packages/crypto/src/storage/blob.ts
+++ b/packages/crypto/src/storage/blob.ts
@@ -1,0 +1,41 @@
+import { secretbox, secretboxOpen, secretboxNonce } from '../box/xchacha20.js';
+import { toHex, fromHex } from '../encode/index.js';
+
+export interface EncryptedBlob {
+  /** nonce hex (24 bytes = 48 chars) */
+  nonceHex: string;
+  /** ciphertext hex (plaintext + 16 bytes Poly1305 MAC) */
+  ciphertextHex: string;
+  /** version format — permet migration future */
+  version: 1;
+}
+
+/**
+ * Chiffre un blob (Automerge doc binary) avec XSalsa20-Poly1305 (AEAD).
+ * Génère un nonce aléatoire 24 bytes à chaque appel (jamais réutilisé).
+ */
+export async function encryptDocBlob(
+  plaintext: Uint8Array,
+  key: Uint8Array,
+): Promise<EncryptedBlob> {
+  const nonce = await secretboxNonce();
+  const ciphertext = await secretbox(plaintext, nonce, key);
+  return {
+    nonceHex: toHex(nonce),
+    ciphertextHex: toHex(ciphertext),
+    version: 1,
+  };
+}
+
+/**
+ * Déchiffre et vérifie le MAC. Throw si la clé est fausse, le blob corrompu,
+ * ou la version non supportée.
+ */
+export async function decryptDocBlob(blob: EncryptedBlob, key: Uint8Array): Promise<Uint8Array> {
+  if (blob.version !== 1) {
+    throw new Error(`storage: version de blob non supportée (${String(blob.version)})`);
+  }
+  const nonce = fromHex(blob.nonceHex);
+  const ciphertext = fromHex(blob.ciphertextHex);
+  return secretboxOpen(ciphertext, nonce, key);
+}

--- a/packages/crypto/src/storage/key.test.ts
+++ b/packages/crypto/src/storage/key.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { generateStorageKey } from './key.js';
+
+describe('generateStorageKey', () => {
+  it('retourne 32 bytes', async () => {
+    expect((await generateStorageKey()).length).toBe(32);
+  });
+  it('génère des clés uniques', async () => {
+    const keys = await Promise.all(Array.from({ length: 100 }, () => generateStorageKey()));
+    const set = new Set(keys.map((k) => Buffer.from(k).toString('hex')));
+    expect(set.size).toBe(100);
+  });
+});

--- a/packages/crypto/src/storage/key.ts
+++ b/packages/crypto/src/storage/key.ts
@@ -1,0 +1,10 @@
+import { secretboxKeygen } from '../box/xchacha20.js';
+
+/**
+ * Clé symétrique 32 bytes pour chiffrer le doc Automerge local.
+ * Générée au premier lancement, persistée dans Keychain (mobile) ou
+ * IndexedDB (web). Ne quitte jamais le device.
+ */
+export async function generateStorageKey(): Promise<Uint8Array> {
+  return secretboxKeygen();
+}


### PR DESCRIPTION
## Contexte

Première PR du chantier Sprint 3 — stockage local chiffré. Cette PR pose les fondations crypto ; PR B (mobile) et PR C (web) suivront pour les wrapper dans les doc-stores.

## Motivation

Aujourd'hui le document Automerge est persisté en clair dans \`localStorage\` (web) et \`AsyncStorage\` (mobile). C'est incohérent avec la promesse "local-first + zero-knowledge" du PRD. Cette PR ajoute les primitives nécessaires pour chiffrer le blob au repos avec une clé par device.

## Ce qui est livré

### \`packages/crypto/src/storage/key.ts\`
- \`generateStorageKey()\` : 32 bytes via \`secretboxKeygen()\` (libsodium \`crypto_secretbox_keygen\`)
- La clé sera stockée dans Keychain / Keystore (mobile) ou IndexedDB (web) dans les PRs suivantes

### \`packages/crypto/src/storage/blob.ts\`
- \`EncryptedBlob\` : \`{nonceHex, ciphertextHex, version: 1}\` — JSON-sérialisable
- \`encryptDocBlob(plaintext, key)\` : XSalsa20-Poly1305 AEAD avec nonce 24 bytes aléatoire par appel
- \`decryptDocBlob(blob, key)\` : déchiffre, vérifie MAC, throw sur toute anomalie (mauvaise clé, corruption, version non supportée)
- Champ \`version\` pour migration future (ex: passage à XChaCha20 ou à un autre schéma)

## Tests (8 nouveaux)

- \`key.test.ts\` : 2 tests (longueur 32 bytes, unicité sur 100 tirages)
- \`blob.test.ts\` : 6 tests
  - round-trip
  - format du blob (nonceHex 48 chars, version 1)
  - deux chiffrements du même plaintext → nonces et ciphertexts différents (pas de nonce statique)
  - mauvaise clé → throw
  - ciphertext altéré → throw (MAC invalide)
  - version non supportée → throw

Total : **83 tests crypto**, tous verts. Lint, typecheck, format clean.

## Choix techniques

- **XSalsa20-Poly1305 via \`crypto_secretbox_easy\`** plutôt que XChaCha20 natif : les helpers existent déjà dans \`packages/crypto/src/box/\`, même niveau de sécurité pour nos tailles de nonce (24 bytes), pas de nouvelle dépendance.
- **Nonce aléatoire par chiffrement** : jamais de nonce déterministe, pas de compteur à maintenir.
- **Pas de stockage du nonce avec la clé** : le nonce fait partie du blob, pas du secret.
- **Champ \`version\`** : anticipation de migration (ex. clé wrappée, nouvelle primitive).

## Red flags évités

- Aucun log du plaintext ni de la clé ni du nonce
- Pas de fallback "si clé absente → stocker en clair"
- Pas de comparaison non-const-time (la vérification MAC est faite par libsodium)
- Pas de \`Math.random\`

## Plan de test

- [ ] \`pnpm lint && pnpm typecheck && pnpm test && pnpm format:check\` — vert local ✓
- [ ] PRs suivantes (B mobile, C web) consommeront ces primitives

## Prochaines PRs (hors scope)

- **PR B** : \`apps/mobile/src/stores/doc-store.ts\` — SEK via \`expo-secure-store\`, chiffrement avant AsyncStorage
- **PR C** : \`apps/web/src/stores/doc-store.ts\` — migration \`localStorage\` → IndexedDB (\`idb\`), SEK en IndexedDB, chiffrement du blob

Refs: KIN-035

🤖 Generated with [Claude Code](https://claude.com/claude-code)