### PR TITLE
feat(KIN-038 PR B): sync E2EE bidirectionnelle via WS côté mobile

### DIFF
--- a/apps/mobile/src/lib/sync/RelaySyncBootstrap.tsx
+++ b/apps/mobile/src/lib/sync/RelaySyncBootstrap.tsx
@@ -1,0 +1,15 @@
+import { useRelaySync } from './useRelaySync';
+
+/**
+ * Composant sans rendu visible qui monte la sync WS bidirectionnelle E2EE
+ * en arrière-plan dès que l'utilisateur est authentifié et que le doc est
+ * initialisé.
+ *
+ * À inclure dans les Providers ou dans le layout racine.
+ * Pas de pragma "use client" côté mobile : React Native n'a pas de distinction
+ * serveur/client comme Next.js.
+ */
+export function RelaySyncBootstrap(): null {
+  useRelaySync();
+  return null;
+}

--- a/apps/mobile/src/lib/sync/__tests__/group-key.test.ts
+++ b/apps/mobile/src/lib/sync/__tests__/group-key.test.ts
@@ -1,0 +1,53 @@
+import { getGroupKey, _resetGroupKeyCache } from '../group-key';
+
+// On mock @kinhale/crypto uniquement pour la fonction deriveKey afin de
+// conserver une dérivation déterministe et rapide dans les tests (l'Argon2id
+// réel serait trop lent et non déterministe).
+jest.mock('@kinhale/crypto', () => ({
+  deriveKey: jest.fn(async (password: string, _salt: Uint8Array, outputLen: number) => {
+    // Retourne un tableau déterministe basé sur le charCode du password.
+    const result = new Uint8Array(outputLen);
+    for (let i = 0; i < outputLen; i++) {
+      result[i] = (password.charCodeAt(i % password.length) ?? 0) & 0xff;
+    }
+    return result;
+  }),
+}));
+
+describe('getGroupKey (mobile)', () => {
+  beforeEach(() => {
+    _resetGroupKeyCache();
+  });
+
+  it('retourne une clé de 32 octets', async () => {
+    const key = await getGroupKey('household-abc');
+    expect(key).toBeInstanceOf(Uint8Array);
+    expect(key).toHaveLength(32);
+  });
+
+  it('retourne la même clé pour le même householdId (déterminisme)', async () => {
+    const key1 = await getGroupKey('household-xyz');
+    _resetGroupKeyCache();
+    const key2 = await getGroupKey('household-xyz');
+    expect(key1).toEqual(key2);
+  });
+
+  it('retourne des clés différentes pour des householdIds différents', async () => {
+    const key1 = await getGroupKey('household-aaa');
+    const key2 = await getGroupKey('household-bbb');
+    expect(key1).not.toEqual(key2);
+  });
+
+  it('utilise le cache : deriveKey appelé une seule fois par householdId', async () => {
+    const { deriveKey } = jest.requireMock('@kinhale/crypto') as {
+      deriveKey: jest.Mock;
+    };
+    deriveKey.mockClear();
+
+    await getGroupKey('household-cached');
+    await getGroupKey('household-cached');
+    await getGroupKey('household-cached');
+
+    expect(deriveKey).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/lib/sync/__tests__/useRelaySync.test.tsx
+++ b/apps/mobile/src/lib/sync/__tests__/useRelaySync.test.tsx
@@ -1,0 +1,235 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useRelaySync } from '../useRelaySync';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+// Mock group-key : dérive instantanément une clé fixe
+jest.mock('../group-key', () => ({
+  getGroupKey: jest.fn(async () => new Uint8Array(32).fill(1)),
+}));
+
+// Mock @kinhale/sync — pipeline E2EE
+// Les types sont explicites pour satisfaire le mode strict TypeScript.
+const mockBuildSyncMessage = jest.fn(
+  async (_before: unknown, _after: unknown, _key: Uint8Array, _meta: unknown) =>
+    '{"mocked":"blob"}',
+);
+const mockConsumeSyncMessage = jest.fn(async (_doc: unknown, _json: string, _key: Uint8Array) => ({
+  __mocked: true,
+}));
+const mockCreateCursor = jest.fn(() => ({
+  lastSentDoc: null,
+  knownHeads: [],
+  receivedCount: 0,
+}));
+const mockRecordSent = jest.fn((cursor: unknown, _doc: unknown) => cursor);
+const mockRecordReceived = jest.fn((cursor: unknown, _changes: unknown) => cursor);
+
+jest.mock('@kinhale/sync', () => ({
+  buildSyncMessage: (before: unknown, after: unknown, key: Uint8Array, meta: unknown) =>
+    mockBuildSyncMessage(before, after, key, meta),
+  consumeSyncMessage: (doc: unknown, json: string, key: Uint8Array) =>
+    mockConsumeSyncMessage(doc, json, key),
+  createCursor: () => mockCreateCursor(),
+  recordSent: (cursor: unknown, doc: unknown) => mockRecordSent(cursor, doc),
+  recordReceived: (cursor: unknown, changes: unknown) => mockRecordReceived(cursor, changes),
+  // getDocChanges retourne un tableau vide — aucun delta à merger
+  getDocChanges: jest.fn(() => [] as Uint8Array[]),
+  // createDoc utilisé pour le type ReturnType<typeof createDoc>
+  createDoc: jest.fn(() => ({})),
+}));
+
+// ---------------------------------------------------------------------------
+// État global mutable pour les stores — modifié par chaque test
+// ---------------------------------------------------------------------------
+
+let mockAuthState = {
+  accessToken: null as string | null,
+  deviceId: null as string | null,
+  householdId: null as string | null,
+};
+
+let mockReceiveChanges = jest.fn();
+let mockDocValue: Record<string, unknown> | null = null;
+
+// Capture du handler onMessage injecté dans createRelayClient (utilisé dans tests futurs)
+let _capturedOnMessage:
+  | ((msg: { blobJson: string; seq: number; sentAtMs: number }) => void)
+  | null = null;
+
+const mockRelayClient = {
+  send: jest.fn(),
+  close: jest.fn(),
+};
+
+const mockCreateRelayClient = jest.fn((_token: string, onMessage: unknown) => {
+  _capturedOnMessage = onMessage as typeof _capturedOnMessage;
+  return mockRelayClient;
+});
+
+jest.mock('../../relay-client', () => ({
+  createRelayClient: (token: string, onMessage: unknown) => mockCreateRelayClient(token, onMessage),
+}));
+
+jest.mock('../../../stores/auth-store', () => ({
+  useAuthStore: (selector: (s: typeof mockAuthState) => unknown) => selector(mockAuthState),
+}));
+
+// Le store doc expose aussi getState() utilisé dans le handler onMessage async.
+jest.mock('../../../stores/doc-store', () => ({
+  useDocStore: Object.assign(
+    (selector: (s: { doc: unknown; receiveChanges: jest.Mock }) => unknown) =>
+      selector({ doc: mockDocValue, receiveChanges: mockReceiveChanges }),
+    {
+      getState: () => ({ doc: mockDocValue, receiveChanges: mockReceiveChanges }),
+    },
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setAuthenticated(): void {
+  mockAuthState = {
+    accessToken: 'tok-test',
+    deviceId: 'device-001',
+    householdId: 'household-001',
+  };
+}
+
+function setDocLoaded(): void {
+  mockDocValue = { householdId: 'household-001', events: [] };
+}
+
+/** Vide la file de microtasks pour laisser les promises async se résoudre. */
+async function flushPromises(rounds = 4): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useRelaySync (mobile)', () => {
+  jest.setTimeout(15000);
+
+  beforeEach(() => {
+    mockAuthState = { accessToken: null, deviceId: null, householdId: null };
+    mockDocValue = null;
+    mockReceiveChanges = jest.fn();
+    _capturedOnMessage = null;
+    mockRelayClient.send.mockClear();
+    mockRelayClient.close.mockClear();
+    mockBuildSyncMessage.mockClear();
+    mockConsumeSyncMessage.mockClear();
+    mockCreateRelayClient.mockClear();
+  });
+
+  it('ne se connecte pas si accessToken est null', async () => {
+    // Le renderHook de @testing-library/react-native doit rester dans la
+    // portée du test (hors act), sinon le test renderer est démonté à la
+    // sortie de act. Divergence mineure vs PR A web (react-dom vs react-test-renderer).
+    renderHook(() => useRelaySync());
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(mockCreateRelayClient).not.toHaveBeenCalled();
+  });
+
+  it('ne se connecte pas si le doc est null même avec token valide', async () => {
+    setAuthenticated();
+    // mockDocValue reste null
+
+    renderHook(() => useRelaySync());
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(mockCreateRelayClient).not.toHaveBeenCalled();
+  });
+
+  it('appelle createRelayClient avec le bon token quand authentifié + doc chargé', async () => {
+    setAuthenticated();
+    setDocLoaded();
+
+    renderHook(() => useRelaySync());
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(mockCreateRelayClient).toHaveBeenCalledWith('tok-test', expect.any(Function));
+  });
+
+  it('retourne connected:true après que la WS est ouverte', async () => {
+    setAuthenticated();
+    setDocLoaded();
+
+    const { result } = renderHook(() => useRelaySync());
+
+    // Initialement non connecté
+    expect(result.current.connected).toBe(false);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(result.current.connected).toBe(true);
+  });
+
+  it('ferme la WS au démontage', async () => {
+    setAuthenticated();
+    setDocLoaded();
+
+    const { unmount } = renderHook(() => useRelaySync());
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    act(() => {
+      unmount();
+    });
+
+    expect(mockRelayClient.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('propage les changes locaux au relai via client.send quand le doc change après connexion', async () => {
+    setAuthenticated();
+    setDocLoaded();
+
+    // On utilise renderHook avec une valeur initiale et on la change après connexion.
+    // Le doc initial sert à établir la connexion.
+    // Une mutation (nouveau objet) déclenche le second effet.
+    // @testing-library/react-native impose de passer des props à rerender,
+    // même vides (signature différente de la version web).
+    const { rerender } = renderHook<{ connected: boolean }, Record<string, never>>(
+      () => useRelaySync(),
+      { initialProps: {} },
+    );
+
+    // Attendre que la connexion WS soit établie (getGroupKey async)
+    await act(async () => {
+      await flushPromises();
+    });
+
+    // La WS est maintenant ouverte (clientRef.current est set).
+    // Simuler un changement de doc : nouvel objet différent.
+    mockDocValue = { householdId: 'household-001', events: [{ id: 'evt-1' }] };
+
+    await act(async () => {
+      rerender({});
+      await flushPromises();
+    });
+
+    // buildSyncMessage doit avoir été appelé avec le doc courant
+    expect(mockBuildSyncMessage).toHaveBeenCalled();
+    // Le résultat non-null est envoyé au relay
+    expect(mockRelayClient.send).toHaveBeenCalledWith('{"mocked":"blob"}');
+  });
+});

--- a/apps/mobile/src/lib/sync/group-key.ts
+++ b/apps/mobile/src/lib/sync/group-key.ts
@@ -1,0 +1,46 @@
+import { deriveKey } from '@kinhale/crypto';
+
+/**
+ * Sel fixe pour la dérivation de la groupKey v1.0.
+ * ASCII : "kinhale-group-v1" suivi de zéros de padding jusqu'à 32 octets.
+ *
+ * AVERTISSEMENT DE SÉCURITÉ (v1.0 simplifié) :
+ * La groupKey est dérivée deterministiquement du householdId. Cela signifie
+ * que quiconque connaît le householdId peut dériver la même clé et déchiffrer
+ * les messages mailbox. Ce compromis est acceptable pour la démo Sprint 4
+ * (deux devices d'un même foyer retrouvent la même clé via leur DB commune),
+ * mais n'est pas production-grade.
+ *
+ * Migration prévue post-v1.0 : utiliser MLS ou une enveloppe key-wrap
+ * transmise via le protocole d'invitation E2EE (ADR à ouvrir, Refs: KIN-038).
+ *
+ * Ce module est une duplication fidèle de apps/web/src/lib/sync/group-key.ts.
+ * Une dette technique est actée pour mutualiser les deux implémentations
+ * dans packages/sync (Refs: KIN-038).
+ */
+const GROUP_KEY_SALT = new Uint8Array([
+  0x6b, 0x69, 0x6e, 0x68, 0x61, 0x6c, 0x65, 0x2d, 0x67, 0x72, 0x6f, 0x75, 0x70, 0x2d, 0x76, 0x31,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+]);
+
+let cache = new Map<string, Uint8Array>();
+
+/**
+ * Retourne la clé de groupe (32 octets) pour un foyer donné.
+ * La clé est mise en cache en mémoire pour éviter le coût Argon2id répété.
+ *
+ * @param householdId - Identifiant du foyer (UUID).
+ * @returns Clé de groupe 32 octets pour XChaCha20-Poly1305.
+ */
+export async function getGroupKey(householdId: string): Promise<Uint8Array> {
+  const cached = cache.get(householdId);
+  if (cached !== undefined) return cached;
+  const key = await deriveKey(householdId, GROUP_KEY_SALT, 32);
+  cache.set(householdId, key);
+  return key;
+}
+
+/** Test helper — vide le cache entre les tests. Ne pas utiliser en production. */
+export function _resetGroupKeyCache(): void {
+  cache = new Map();
+}

--- a/apps/mobile/src/lib/sync/useRelaySync.ts
+++ b/apps/mobile/src/lib/sync/useRelaySync.ts
@@ -7,18 +7,12 @@ import {
   recordReceived,
   getDocChanges,
 } from '@kinhale/sync';
-import type { SyncCursor, createDoc } from '@kinhale/sync';
+import type { SyncCursor } from '@kinhale/sync';
 import { createRelayClient } from '../relay-client';
 import type { RelayClient, RelayMessage } from '../relay-client';
 import { useAuthStore } from '../../stores/auth-store';
 import { useDocStore } from '../../stores/doc-store';
 import { getGroupKey } from './group-key';
-
-/**
- * Type du document Automerge — dérivé de createDoc pour éviter d'importer
- * directement @automerge/automerge qui est une dépendance transitive.
- */
-type KinhaleDocument = ReturnType<typeof createDoc>;
 
 /**
  * Hook qui maintient une connexion WS au relai et synchronise
@@ -51,10 +45,11 @@ export function useRelaySync(): { connected: boolean } {
   const keyRef = React.useRef<Uint8Array | null>(null);
 
   // 1. Ouvre la WS quand l'utilisateur est authentifié et que le doc est chargé.
-  //    Dépendance sur `doc !== null` (valeur booléenne) pour éviter de rouvrir
-  //    la connexion à chaque mutation du doc.
+  //    Dépendance sur `docReady` (valeur booléenne dérivée) pour éviter de
+  //    rouvrir la connexion à chaque mutation du doc.
+  const docReady = doc !== null;
   React.useEffect(() => {
-    if (accessToken === null || deviceId === null || householdId === null || doc === null) {
+    if (accessToken === null || deviceId === null || householdId === null || !docReady) {
       return undefined;
     }
 
@@ -72,11 +67,10 @@ export function useRelaySync(): { connected: boolean } {
         if (currentDoc === null) return;
 
         try {
-          const typedDoc = currentDoc as KinhaleDocument;
-          const newDoc = await consumeSyncMessage(typedDoc, msg.blobJson, keyRef.current);
+          const newDoc = await consumeSyncMessage(currentDoc, msg.blobJson, keyRef.current);
           // Extraire uniquement le delta pour éviter de re-persister des
           // changements déjà présents dans le doc local.
-          const deltaChanges = getDocChanges(typedDoc, newDoc);
+          const deltaChanges = getDocChanges(currentDoc, newDoc);
           if (deltaChanges.length > 0) {
             receiveChanges(deltaChanges);
             cursorRef.current = recordReceived(cursorRef.current, deltaChanges);
@@ -98,7 +92,7 @@ export function useRelaySync(): { connected: boolean } {
       keyRef.current = null;
       setConnected(false);
     };
-  }, [accessToken, deviceId, householdId, doc !== null, receiveChanges]); // doc !== null intentionnel : on ne veut pas rouvrir la WS à chaque mutation du doc
+  }, [accessToken, deviceId, householdId, docReady, receiveChanges]);
 
   // 2. Sur chaque mutation du doc local, construire et pousser le delta au relai.
   React.useEffect(() => {
@@ -113,22 +107,21 @@ export function useRelaySync(): { connected: boolean } {
     }
 
     // Calcule le delta depuis le dernier envoi (ou doc complet si jamais envoyé).
-    const typedDoc = doc as KinhaleDocument;
-    const before = cursorRef.current.lastSentDoc ?? typedDoc;
+    const before = cursorRef.current.lastSentDoc ?? doc;
 
     const localKey = keyRef.current;
     const localClient = clientRef.current;
     const localSeq = ++seqRef.current;
 
     void (async () => {
-      const msg = await buildSyncMessage(before, typedDoc, localKey, {
+      const msg = await buildSyncMessage(before, doc, localKey, {
         mailboxId: householdId,
         deviceId,
         seq: localSeq,
       });
       if (msg !== null) {
         localClient.send(msg);
-        cursorRef.current = recordSent(cursorRef.current, typedDoc);
+        cursorRef.current = recordSent(cursorRef.current, doc);
       }
     })();
   }, [doc, deviceId, householdId]);

--- a/apps/mobile/src/lib/sync/useRelaySync.ts
+++ b/apps/mobile/src/lib/sync/useRelaySync.ts
@@ -1,0 +1,137 @@
+import React from 'react';
+import {
+  buildSyncMessage,
+  consumeSyncMessage,
+  createCursor,
+  recordSent,
+  recordReceived,
+  getDocChanges,
+} from '@kinhale/sync';
+import type { SyncCursor, createDoc } from '@kinhale/sync';
+import { createRelayClient } from '../relay-client';
+import type { RelayClient, RelayMessage } from '../relay-client';
+import { useAuthStore } from '../../stores/auth-store';
+import { useDocStore } from '../../stores/doc-store';
+import { getGroupKey } from './group-key';
+
+/**
+ * Type du document Automerge — dérivé de createDoc pour éviter d'importer
+ * directement @automerge/automerge qui est une dépendance transitive.
+ */
+type KinhaleDocument = ReturnType<typeof createDoc>;
+
+/**
+ * Hook qui maintient une connexion WS au relai et synchronise
+ * bidirectionnellement le doc Automerge local.
+ *
+ * - À chaque change local (doc store update) → buildSyncMessage → ws.send
+ * - À chaque message reçu → consumeSyncMessage → docStore.receiveChanges
+ *
+ * Miroir fidèle de apps/web/src/lib/sync/useRelaySync.ts. Aucune dépendance
+ * DOM : `createRelayClient` mobile s'appuie sur le WebSocket natif React
+ * Native (polyfillé par Expo / Hermes).
+ *
+ * Le groupKey est dérivé deterministiquement du householdId (v1.0 simplifié).
+ * Le cursor garantit l'idempotence (pas de renvoi des mêmes changements).
+ *
+ * Principe zero-knowledge respecté : le relai ne reçoit que des blobs
+ * chiffrés opaques (XChaCha20-Poly1305). Jamais de contenu en clair.
+ */
+export function useRelaySync(): { connected: boolean } {
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const deviceId = useAuthStore((s) => s.deviceId);
+  const householdId = useAuthStore((s) => s.householdId);
+  const doc = useDocStore((s) => s.doc);
+  const receiveChanges = useDocStore((s) => s.receiveChanges);
+
+  const [connected, setConnected] = React.useState(false);
+  const clientRef = React.useRef<RelayClient | null>(null);
+  const cursorRef = React.useRef<SyncCursor>(createCursor());
+  const seqRef = React.useRef(0);
+  const keyRef = React.useRef<Uint8Array | null>(null);
+
+  // 1. Ouvre la WS quand l'utilisateur est authentifié et que le doc est chargé.
+  //    Dépendance sur `doc !== null` (valeur booléenne) pour éviter de rouvrir
+  //    la connexion à chaque mutation du doc.
+  React.useEffect(() => {
+    if (accessToken === null || deviceId === null || householdId === null || doc === null) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    void (async () => {
+      const groupKey = await getGroupKey(householdId);
+      if (cancelled) return;
+
+      keyRef.current = groupKey;
+
+      const client = createRelayClient(accessToken, async (msg: RelayMessage) => {
+        if (keyRef.current === null) return;
+        const currentDoc = useDocStore.getState().doc;
+        if (currentDoc === null) return;
+
+        try {
+          const typedDoc = currentDoc as KinhaleDocument;
+          const newDoc = await consumeSyncMessage(typedDoc, msg.blobJson, keyRef.current);
+          // Extraire uniquement le delta pour éviter de re-persister des
+          // changements déjà présents dans le doc local.
+          const deltaChanges = getDocChanges(typedDoc, newDoc);
+          if (deltaChanges.length > 0) {
+            receiveChanges(deltaChanges);
+            cursorRef.current = recordReceived(cursorRef.current, deltaChanges);
+          }
+        } catch {
+          // Message invalide, corrompu ou clé incorrecte — ignoré silencieusement.
+          // Aucune donnée santé dans les logs (principe zero-knowledge).
+        }
+      });
+
+      clientRef.current = client;
+      setConnected(true);
+    })();
+
+    return () => {
+      cancelled = true;
+      clientRef.current?.close();
+      clientRef.current = null;
+      keyRef.current = null;
+      setConnected(false);
+    };
+  }, [accessToken, deviceId, householdId, doc !== null, receiveChanges]); // doc !== null intentionnel : on ne veut pas rouvrir la WS à chaque mutation du doc
+
+  // 2. Sur chaque mutation du doc local, construire et pousser le delta au relai.
+  React.useEffect(() => {
+    if (
+      doc === null ||
+      clientRef.current === null ||
+      keyRef.current === null ||
+      deviceId === null ||
+      householdId === null
+    ) {
+      return;
+    }
+
+    // Calcule le delta depuis le dernier envoi (ou doc complet si jamais envoyé).
+    const typedDoc = doc as KinhaleDocument;
+    const before = cursorRef.current.lastSentDoc ?? typedDoc;
+
+    const localKey = keyRef.current;
+    const localClient = clientRef.current;
+    const localSeq = ++seqRef.current;
+
+    void (async () => {
+      const msg = await buildSyncMessage(before, typedDoc, localKey, {
+        mailboxId: householdId,
+        deviceId,
+        seq: localSeq,
+      });
+      if (msg !== null) {
+        localClient.send(msg);
+        cursorRef.current = recordSent(cursorRef.current, typedDoc);
+      }
+    })();
+  }, [doc, deviceId, householdId]);
+
+  return { connected };
+}

--- a/apps/mobile/src/providers/index.tsx
+++ b/apps/mobile/src/providers/index.tsx
@@ -3,11 +3,14 @@ import { TamaguiProvider } from 'tamagui';
 import { I18nextProvider } from 'react-i18next';
 import config from '../lib/tamagui.config';
 import i18n from '../lib/i18n';
+import { RelaySyncBootstrap } from '../lib/sync/RelaySyncBootstrap';
 
 export function Providers({ children }: { children: ReactNode }): JSX.Element {
   return (
     <I18nextProvider i18n={i18n}>
       <TamaguiProvider config={config} defaultTheme="light">
+        {/* Monte la sync WS E2EE bidirectionnelle en arrière-plan */}
+        <RelaySyncBootstrap />
         {children}
       </TamaguiProvider>
     </I18nextProvider>

--- a/docs/architecture/adr/ADR-D9-groupkey-deterministe-v1.md
+++ b/docs/architecture/adr/ADR-D9-groupkey-deterministe-v1.md
@@ -1,0 +1,131 @@
+# ADR-D9 — GroupKey E2EE déterministe (compromis v1.0 avant MLS)
+
+**Date** : 2026-04-23
+**Statut** : Accepté (temporaire, à remplacer par ADR-D3 cible)
+**Décideurs** : Martial Kaljob (Kamez Conseils)
+
+## Contexte
+
+L'ADR-D3 fixe la cible du protocole de groupe E2EE de Kinhale : MLS (RFC 9420) via `openmls`, avec fallback Double Ratchet si le PoC Sprint 0 échoue. Cette cible n'est pas encore opérationnelle en avril 2026 : les bindings React Native pour `openmls` (via JSI ou WASM) ne sont pas validés en production mobile, `mls-ts` est encore en développement actif, et le PoC Sprint 0 a été repoussé faute de bindings suffisamment matures pour être intégrés sans risque de régression sur la chaîne de build iOS + Android + Web.
+
+Parallèlement, la roadmap impose une démonstration multi-device fonctionnelle dès le Sprint 4 : un foyer doit pouvoir chiffrer ses deltas Automerge sur un device, les pousser via le relai, et les voir appliqués sur un second device du même foyer — le tout sans que le relai n'ait jamais accès au contenu santé en clair. Cette démonstration est nécessaire pour les tests utilisateurs internes et pour valider l'architecture de sync sur un cas réel avant de complexifier la couche crypto.
+
+La PR A web (#188, mergée le 23 avril) a introduit `apps/web/src/lib/sync/group-key.ts` avec `groupKey = Argon2id(householdId, salt_fixe, 32 bytes)`. La PR B mobile (#189) duplique fidèlement cette approche côté Expo. Les deux PRs documentent le compromis en commentaire d'entête du fichier `group-key.ts`, mais aucun ADR ne formalise la décision, ses limites, ni son plan de remplacement. Le présent document comble ce manque.
+
+Le modèle de menace cible posé par le PRD et l'ADR-D3 est le zero-knowledge strict : même un opérateur Kamez contraint par réquisition, même un relai entièrement compromis, ne doit pas pouvoir déchiffrer une seule donnée santé. La solution actuelle s'écarte de cette cible sur deux points précis (dérivation déterministe depuis le `householdId`, `mailboxId = householdId` en clair côté relai). Il est essentiel que cet écart soit tracé explicitement, avec ses conséquences, et qu'il ne soit pas confondu avec la promesse de sécurité v1.0 telle qu'elle sera communiquée aux utilisateurs à partir du Sprint 7-8.
+
+## Options évaluées
+
+### Option A — Implémenter MLS (ou Double Ratchet) dès Sprint 4
+
+**Description** : Intégrer le protocole cible (MLS via `openmls`, ou fallback Double Ratchet avec Sender Key) dès le Sprint 4, avant toute démonstration multi-device. Aucun compromis transitoire : la sync est construite directement sur la crypto cible.
+
+**Avantages** :
+- Aucune dette cryptographique à rembourser ultérieurement.
+- La promesse zero-knowledge est tenue sans exception dès la v1.0.
+- Pas de migration de clé à orchestrer pour les foyers existants — l'ensemble des blobs du relai est chiffré sous le bon schéma dès le départ.
+- Permet un audit crypto externe continu sur le même code de production, sans artefact transitoire à ignorer.
+
+**Inconvénients** :
+- Les bindings React Native `openmls` ne sont pas stables en avril 2026. Intégrer MLS dès Sprint 4 impose soit de porter soi-même les bindings (plusieurs semaines de travail C++/Rust), soit de basculer immédiatement sur le fallback Double Ratchet avec un Sender Key Protocol custom — ce qui signifie écrire ~500-800 lignes de code crypto custom auditables sans avoir encore la capacité d'audit externe (l'auditeur crypto est prévu Sprint 5-6).
+- Le coût est incompatible avec la fenêtre Sprint 4 : 2-3 semaines-homme de crypto pure retardent l'ensemble de la feature sync et de ses dépendances (persistance partagée, invitation QR, réconciliation CRDT multi-device).
+- Sprint 4 est aussi le sprint où le flux d'invitation QR doit être opérationnel pour les tests utilisateurs. MLS impose un `Welcome` message et un Admin en ligne, ce qui modifie substantiellement l'UX d'onboarding — cette modification doit être mûrie et testée, pas bricolée sous contrainte de temps.
+
+**Risques** :
+- Écrire du code crypto custom (fallback Double Ratchet) sans audit et sous pression de planning est précisément le scénario le plus dangereux pour un projet de santé : risque d'erreur silencieuse de conception, détectée trop tard, avec des données déjà en production à rewrapper.
+- Retarder Sprint 4 par effet domino (sync en retard → pas de données multi-device → pas de validation utilisateur → pas de retour d'usage avant Sprint 6-7) déstabilise l'ensemble du plan v1.0.
+
+### Option B — GroupKey déterministe depuis le householdId (retenue pour v1.0)
+
+**Description** : La clé de groupe est dérivée de façon déterministe depuis le `householdId` par Argon2id avec un salt fixe documenté et 32 octets de sortie. Tous les devices du même foyer qui partagent le `householdId` convergent sur la même `groupKey` sans échange de secret additionnel. Le `mailboxId` transmis au relai est le `householdId` en clair, ce qui permet au relai de router les blobs chiffrés vers la bonne boîte de messages. Le chiffrement symétrique reste XChaCha20-Poly1305 AEAD avec un nonce aléatoire par message — conforme aux invariants `packages/crypto`.
+
+**Avantages** :
+- Débloque la sync multi-device immédiatement : le flux d'invitation QR partage déjà le `householdId` en clair entre les aidants, donc aucun protocole supplémentaire à implémenter pour Sprint 4.
+- Pas de rotation de clé à orchestrer : un foyer = une clé stable, pas d'epoch, pas d'état de groupe à persister en SQLCipher en parallèle du document Automerge.
+- Compatible avec le schéma Automerge + mailbox existant : le wire format reste identique, seule la dérivation de clé change.
+- La surface de code à auditer est réduite (~50 lignes de dérivation + cache) — auditable trivialement par un pair et par l'auditeur externe du Sprint 5-6.
+- Le nonce aléatoire par message préserve l'intégrité AEAD et l'unicité des ciphertexts même avec une clé stable.
+
+**Inconvénients** :
+- **Pas de Post-Compromise Security** : un attaquant qui obtient le `householdId` d'un foyer (fuite DB relai, subpoena, insider Kamez, log accidentel, compromission serveur) peut dériver la `groupKey` et déchiffrer l'intégralité des blobs mailbox du foyer, passés et futurs.
+- **Pas de Forward Secrecy cryptographique** : la clé ne tourne jamais spontanément, la compromission de la clé actuelle compromet tout l'historique chiffré conservé par le relai.
+- **`mailboxId = householdId` en clair** : le relai peut corréler le volume de trafic par foyer, inférer l'activité, et relier deux devices du même foyer par leur `mailboxId` commun. Métadonnées exploitables, même si aucun contenu santé ne transite en clair.
+- **Révocation d'aidant impossible cryptographiquement** : si un aidant (ex : CPE qui quitte le foyer, conjoint révoqué) a conservé le `householdId`, il peut continuer à déchiffrer les blobs futurs tant que le protocole cible MLS n'est pas en place. La révocation métier (suppression de l'accès au relai via révocation de token JWT) n'empêche pas un ancien aidant qui aurait fait une copie des blobs d'en déchiffrer le contenu.
+
+**Risques** :
+- Si l'option est communiquée par erreur aux utilisateurs comme "zero-knowledge strict" avant la bascule MLS, la promesse produit est violée — risque d'image et juridique (Loi 25, RGPD, Consumer Protection).
+- Si un foyer fuit son `householdId` (partage accidentel via capture d'écran, e-mail, message non chiffré), l'exposition est totale et rétroactive.
+
+### Option C — Dériver groupKey via un secret partagé transmis à l'invitation
+
+**Description** : Plutôt que de dériver la clé depuis le `householdId`, générer un secret aléatoire de 32 octets à la création du foyer, et le transmettre aux aidants via le flux d'invitation (QR code, lien signé). Les devices stockent ce secret dans le Keychain / Keystore. Le `mailboxId` reste un identifiant distinct du secret (par exemple un pseudonyme HMAC).
+
+**Avantages** :
+- Découple le `mailboxId` du matériel cryptographique : une fuite du `mailboxId` ne permet pas de déchiffrer les blobs.
+- Pré-curseur propre de MLS : la logique d'invitation avec transport de secret se rapproche du flux `KeyPackage` / `Welcome` MLS, donc le code de l'invitation peut être partiellement réutilisé.
+- Forward Secrecy partielle possible si le secret est rotaté périodiquement ou à la révocation (mais la rotation reste O(N) comme en Signal Sender Key, avec les mêmes limites de simultanéité que documentées dans ADR-D3).
+
+**Inconvénients** :
+- Le coût d'implémentation de l'invitation sécurisée (chiffrement du secret pour le destinataire, signature d'invitation, validité de courte durée, protection contre le rejeu) est proche de celui d'un Welcome MLS simplifié — soit ~1 à 1.5 semaines-homme de crypto auditable, sans apporter les bénéfices structurels de MLS (pas de PCS, pas de TreeKEM, pas de révocation logarithmique).
+- Reste une solution custom : surface d'audit plus grande que MLS standardisé.
+- Dans 2-3 sprints on jette la plus grande partie de ce code pour passer à MLS, ce qui dégrade le ratio coût/valeur.
+
+**Risques** :
+- Investir dans une crypto custom intermédiaire qui sera remplacée sans avoir servi en production réelle — dette de maintenance pour un gain temporaire.
+- Créer une deuxième trajectoire de migration (v1.0 déterministe → v1.0.x secret partagé → v1.1 MLS) au lieu d'une seule (v1.0 déterministe → v1.1 MLS).
+
+## Critères de décision
+
+1. **Déblocage de la démo Sprint 4 multi-device** : la sync doit être fonctionnelle de bout en bout pour les tests utilisateurs, sans attendre la maturité des bindings MLS.
+2. **Non-aggravation de la surface d'attaque par rapport à l'état v0** : le relai ne doit pas recevoir plus de données santé en clair qu'il n'en recevait avant — en l'occurrence aucune, le contenu Automerge reste chiffré AEAD dans tous les scénarios.
+3. **Réversibilité** : la décision doit pouvoir être remplacée par MLS sans migration catastrophique, idéalement sans déconnexion prolongée des foyers ni perte de données.
+4. **Transparence** : le compromis doit être explicite en code (commentaire d'entête de `group-key.ts`), en documentation (présent ADR), et communicable à un auditeur externe ou à un utilisateur averti qui pose la question.
+5. **Proportionnalité du risque** : l'écart au zero-knowledge strict ne doit concerner qu'une fenêtre temporelle bornée (jusqu'à la bascule MLS Sprint 7-8) et ne doit pas être communiqué aux utilisateurs grand public comme une propriété de sécurité finale.
+
+## Décision
+
+**Choix retenu : Option B — GroupKey déterministe via `Argon2id(householdId, salt_fixe, 32 bytes)` pour v1.0, avec remplacement planifié par MLS (ADR-D3) en Sprint 7-8**.
+
+Ce choix est un compromis explicite et temporaire. Il acte qu'en avril 2026, la maturité des bindings MLS React Native n'est pas suffisante pour justifier d'implémenter la cible directement, et qu'aucune solution intermédiaire (Option C) ne présente un ratio coût/valeur supérieur à "tenir bon jusqu'à MLS".
+
+La décision est conditionnée à trois exigences :
+1. Le compromis est documenté en tête de `group-key.ts` côté web et mobile (déjà fait en PR A #188 et PR B #189).
+2. Le présent ADR est publié avant toute communication externe sur la sécurité de la sync v1.0.
+3. La migration MLS est planifiée et tracée (voir plan de migration ci-dessous) comme un livrable obligatoire pour la v1.0 publique — et non pour une v1.1 indéterminée.
+
+Ce qui invaliderait ce choix avant terme : une fuite publique de `householdId` dans un foyer test, une exigence conformité Loi 25 ou RGPD explicitement incompatible avec la configuration actuelle, ou un retour d'audit crypto Sprint 5-6 qui classerait le compromis comme P0 non-acceptable.
+
+## Conséquences
+
+**Positives :**
+- Sync multi-device bidirectionnelle opérationnelle dès Sprint 4, sans bloquer la roadmap produit.
+- Démonstration client et tests utilisateurs internes possibles sur un flux sync réaliste.
+- Aucune régression fonctionnelle par rapport aux règles métier RM1-RM9 : l'application reste journal + rappel + partage, sans aucun impact sur les propriétés observables côté utilisateur.
+- Le relai Kamez ne voit toujours que des blobs chiffrés AEAD (XChaCha20-Poly1305) — le contenu santé ne transite jamais en clair, ce qui reste conforme à la promesse zero-knowledge pour le contenu.
+- Surface de code crypto minimale (~50 lignes) pendant la fenêtre v1.0, facile à auditer, facile à remplacer.
+
+**Négatives / dette acceptée :**
+- Pas de Post-Compromise Security : un attaquant qui obtient le `householdId` d'un foyer peut déchiffrer l'intégralité de l'historique passé et futur stocké côté relai.
+- Pas de Forward Secrecy cryptographique : la clé ne tourne jamais sur la fenêtre v1.0.
+- Le `mailboxId = householdId` en clair côté relai permet la corrélation foyer ↔ volume de trafic et foyer ↔ devices. Métadonnées exploitables, notamment pour l'inférence comportementale.
+- La révocation d'un aidant (cas CPE qui quitte le foyer) ne rote pas la clé : l'aidant révoqué, s'il a conservé le `householdId` ou copié des blobs, peut toujours déchiffrer les blobs futurs tant que MLS n'est pas en place. La révocation métier (retrait du token d'accès au relai) empêche la réception de nouveaux blobs mais pas le déchiffrement de blobs déjà copiés.
+- La communication utilisateur sur la sécurité v1.0 doit être mesurée : on peut affirmer "le relai ne voit jamais le contenu santé en clair", on ne peut pas affirmer "même Kamez ne peut pas déchiffrer" tant que MLS n'est pas en place. La nuance doit être tenue par l'équipe produit et juridique jusqu'à bascule.
+
+**Plan de migration vers MLS (ADR-D3) :**
+- **Sprint 7** : PoC `openmls` mobile (RN, via JSI ou WASM) et web (WASM) validé sur iOS + Android + Chrome + Firefox. Critères de succès identiques au PoC initialement prévu pour Sprint 0 (ADR-D3 section Plan de PoC Sprint 0), avec un test négatif de révocation bloquant.
+- **Sprint 8** : implémentation du flux MLS complet — génération de KeyPackage par device, `Welcome` message porté par le flux d'invitation, `Commit` pour l'Add d'un membre, persistance de l'état MLS en SQLCipher séparée du document Automerge.
+- **Sprint 9** : migration des foyers existants. Pour chaque foyer : génération d'un epoch MLS initial avec tous les devices connus, rewrap du dernier snapshot Automerge sous le nouveau secret d'epoch, purge progressive des blobs mailbox chiffrés avec l'ancienne `groupKey` déterministe une fois que tous les devices ont confirmé la bascule. Les foyers dont un device reste hors ligne > 30 jours conservent l'ancienne clé en fallback jusqu'à reconnexion.
+- **Communication utilisateur** : la migration est silencieuse côté UX courant. Seul l'écran "Paramètres sécurité" affiche l'indicateur "Chiffrement renforcé activé (MLS)" après bascule, avec un lien vers la documentation publique et éventuellement vers cet ADR archivé.
+
+**Points à tracer en télémétrie (ticket KIN-040 à ouvrir) :**
+- Compteur pseudonymisé des échecs de `consumeSyncMessage` (cf. M2 du rapport `kz-securite-KIN-038.md`) pour distinguer les attaques de MITM des bugs de désérialisation côté relai.
+- Champ de version `v` dans le wire format des blobs mailbox, permettant la coexistence de blobs v1 (groupKey déterministe) et v2 (MLS) pendant la fenêtre de migration Sprint 9.
+- Compteur d'entrées en cache de `groupKey` par `householdId` (`_resetGroupKeyCache` exclu en production), pour détecter d'éventuelles dérives de cache entre tests et runtime.
+
+## Statut futur
+
+Cet ADR sera marqué **Superseded by ADR-Dxx** dès que MLS est déployé en production (Sprint 9, objectif avant release publique v1.0). Il reste consulté comme archive du compromis accepté pendant la fenêtre Sprint 4 → Sprint 9, et comme référence auditable pour l'auditeur crypto externe Sprint 5-6 qui doit comprendre l'état transitoire du système au moment où il l'audite.
+
+## Révision prévue
+
+Revue obligatoire au terme de Sprint 7 (validation du PoC MLS), avec décision ferme sur le calendrier Sprint 8-9 de la migration. Revue anticipée si un incident de sécurité (fuite de `householdId`, compromission d'un opérateur relai, évolution réglementaire Loi 25 ou RGPD) impose une accélération de la bascule MLS ou un retrait temporaire de la fonctionnalité de sync multi-device.


### PR DESCRIPTION
## Contexte

Sprint 4 — KIN-038 PR B. Active la propagation E2EE bidirectionnelle des changements Automerge sur mobile (Expo). **Miroir fidèle de la PR A web (#188)** déjà mergée. PR C (rappels + dose manquée) suivra.

## Ce qui est livré

Même architecture que la PR A web, adaptée à React Native :

### `apps/mobile/src/lib/sync/useRelaySync.ts` — hook principal
Quand l'utilisateur est authentifié + doc chargé :
- Ouvre une WS au relais via `createRelayClient(token, onMessage)` (mobile, déjà existant)
- **Envoi** : chaque mutation du doc → `buildSyncMessage(before, after, groupKey, meta)` → `ws.send(blobJson)`
- **Réception** : chaque message reçu → `consumeSyncMessage(doc, json, groupKey)` → `docStore.receiveChanges(delta)`
- Gestion du `SyncCursor` pour éviter les renvois redondants, `seq` monotone pour audit
- Nettoyage propre au démontage (flag `cancelled`, `close()` WS, nettoyage `keyRef`)

### `apps/mobile/src/lib/sync/group-key.ts` — dérivation de la clé de groupe
Duplication fidèle de la version web : `groupKey = Argon2id(householdId, salt_fixe, 32 bytes)`. Cache mémoire.

### `apps/mobile/src/lib/sync/RelaySyncBootstrap.tsx` — composant sans rendu
Monté dans `providers/index.tsx`. Active le hook `useRelaySync()` dès que l'app est chargée (no-op tant que pas authentifié).

## ⚠️ Compromis sécurité (hérités de la PR A, documentés, non aggravés)

- **groupKey déterministe du `householdId`** : compromis acté en commentaire de tête de `group-key.ts`. ADR à ouvrir post-merge. Migration MLS / key-wrap prévue Sprint 7-8.
- **try/catch silencieux** sur `consumeSyncMessage` : échecs de déchiffrement avalés sans compteur/métrique. Acceptable v1.0 (pas de corruption possible, Automerge rejette). Télémétrie à ajouter dans une PR unique web + mobile (ticket de suivi).

## Tests (10 nouveaux, parité stricte avec la PR A web)

- `group-key.test.ts` : 4 tests (longueur 32, déterminisme, householdIds différents produisent clés différentes, cache).
- `useRelaySync.test.tsx` : 6 tests (gating token/doc, ouverture WS, état connected, close au démontage, envoi delta, absence de crash).

Total mobile : **79 tests passent**, aucune régression. 22 suites.

## Divergences design vs PR A web

1. Pas de pragma `"use client"` : React Native n'a pas la distinction serveur/client Next.js.
2. `@testing-library/react-native` : `renderHook` hors de `act()` (sinon test renderer démonté à la sortie). `rerender({})` avec type `Record<string, never>`. Documenté inline.

## Revues préalables

- **Revue qualité** (`kz-review`) : verdict **OK merge après MINEURS** — aucun MAJEUR bloquant. Les 3 MINEURS ont été corrigés dans le commit `30c1dfc` (casts superflus + dépendance `useEffect` extraite en `docReady`).
- **Revue sécurité** (`kz-securite`) : verdict **mergeable, 0 P0/P1 bloquant**. Zero-knowledge respecté, Argon2id OWASP 2024-conforme, pas de `Math.random`, pas de `console.log`, pas de nouvelle dépendance, cycle de vie WS propre.

## Plan de test

- [x] `pnpm --filter @kinhale/mobile typecheck` — vert
- [x] `pnpm --filter @kinhale/mobile lint` — vert
- [x] `pnpm --filter @kinhale/mobile test` — 79/79 passed
- [x] `pnpm format:check` — vert
- [x] `pnpm lint:root` — vert
- [ ] Test manuel démo post-merge : 2 devices (iOS + Android) même compte → ajouter une dose sur l'un → voir apparaître sur l'autre + propagation avec la démo web

## Tickets de suivi à ouvrir post-merge

- ADR sur le compromis groupKey déterministe (migration MLS / key-wrap post-v1.0)
- **KIN-039** : mutualiser `apps/{web,mobile}/src/lib/sync/*` dans `packages/sync/src/client/` (la duplication est une dette crypto)
- **KIN-040** : télémétrie `sync.decrypt_failed` pseudonymisée — web + mobile dans une seule PR

## Prochaine PR

- **PR C** — scheduler rappels de dose + détection dose manquée (règle RM5)

Refs: KIN-038

🤖 Generated with [Claude Code](https://claude.com/claude-code)