### PR TITLE
feat(KIN-040): télémétrie sync.decrypt_failed pseudonymisée + rate limit

### DIFF
--- a/apps/mobile/src/__mocks__/@kinhale/crypto.ts
+++ b/apps/mobile/src/__mocks__/@kinhale/crypto.ts
@@ -5,6 +5,10 @@ export const sha256Hex = jest.fn().mockResolvedValue('a'.repeat(64));
 export const sha256HexFromString = jest.fn().mockResolvedValue('a'.repeat(64));
 export const CRYPTO_UNAVAILABLE_MESSAGE = 'crypto unavailable';
 
+// KIN-040 : BLAKE2b keyed pour pseudonymisation télémétrie.
+export const BLAKE2B_DEFAULT_BYTES = 8;
+export const blake2bHex = jest.fn().mockResolvedValue('b'.repeat(16));
+
 export const getSodium = jest.fn().mockResolvedValue({});
 
 export const generateSigningKeypair = jest.fn().mockReturnValue({

--- a/apps/mobile/src/__mocks__/@kinhale/sync-client.ts
+++ b/apps/mobile/src/__mocks__/@kinhale/sync-client.ts
@@ -13,3 +13,11 @@
 export const getGroupKey = jest.fn(async () => new Uint8Array(32).fill(1));
 export const _resetGroupKeyCache = jest.fn();
 export const useRelaySync = jest.fn(() => ({ connected: false }));
+
+// KIN-040 : helpers télémétrie exposés par `@kinhale/sync/client`.
+// Stubs inertes : la logique réelle est testée dans packages/sync.
+export const classifyDecryptError = jest.fn(() => 'unknown');
+export const createDecryptFailedReporter = jest.fn(() => ({
+  track: jest.fn(),
+  flush: jest.fn(),
+}));

--- a/apps/mobile/src/lib/sync/index.ts
+++ b/apps/mobile/src/lib/sync/index.ts
@@ -1,7 +1,79 @@
-import { useRelaySync as useRelaySyncCore, getGroupKey } from '@kinhale/sync/client';
+import {
+  useRelaySync as useRelaySyncCore,
+  getGroupKey,
+  type DecryptFailedEvent,
+} from '@kinhale/sync/client';
+import { blake2bHex } from '@kinhale/crypto';
 import { createRelayClient } from '../relay-client';
 import { useAuthStore } from '../../stores/auth-store';
 import { useDocStore } from '../../stores/doc-store';
+
+/**
+ * Sel applicatif utilisé pour pseudonymiser les `householdId` dans les
+ * événements de télémétrie. **Ce n'est pas un secret crypto** : sa seule
+ * fonction est d'empêcher un reverse-lookup par rainbow table côté Sentry /
+ * CloudWatch si les digests venaient à fuiter. Le sel peut être journalisé
+ * sans conséquence sur la confidentialité des données santé.
+ *
+ * En prod, `EXPO_PUBLIC_KINHALE_APP_SECRET` doit être défini via EAS
+ * (valeur spécifique à l'environnement). Fallback dev stable pour tests
+ * locaux / Expo Go.
+ *
+ * Refs: KIN-040.
+ */
+const APP_SECRET = process.env['EXPO_PUBLIC_KINHALE_APP_SECRET'] ?? 'dev-secret-v1';
+
+if (typeof process !== 'undefined' && process.env['NODE_ENV'] === 'production') {
+  if (process.env['EXPO_PUBLIC_KINHALE_APP_SECRET'] === undefined) {
+    console.warn(
+      '[kinhale.sync] EXPO_PUBLIC_KINHALE_APP_SECRET absent en prod — pseudonymisation avec fallback dev.',
+    );
+  }
+}
+
+/**
+ * Pré-calcule et met en cache le digest BLAKE2b keyed d'un `householdId`.
+ * Voir wrapper web pour la stratégie placeholder synchrone pendant le premier
+ * appel libsodium asynchrone.
+ */
+const pseudonymCache = new Map<string, string>();
+const pendingPromises = new Map<string, Promise<string>>();
+
+function fnv1aHash(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+export function hashHousehold(householdId: string): string {
+  const cached = pseudonymCache.get(householdId);
+  if (cached !== undefined) return cached;
+
+  if (!pendingPromises.has(householdId)) {
+    const promise = blake2bHex(householdId, APP_SECRET).then((digest) => {
+      pseudonymCache.set(householdId, digest);
+      pendingPromises.delete(householdId);
+      return digest;
+    });
+    pendingPromises.set(householdId, promise);
+  }
+
+  return `pending-${fnv1aHash(householdId)}`;
+}
+
+/**
+ * Rapporteur v1.0 : log local pseudonymisé. Sera remplacé par une intégration
+ * Sentry RN dans une PR ultérieure (hors scope KIN-040).
+ *
+ * @see DecryptFailedEvent — schéma figé, aucune donnée santé n'y transite.
+ */
+function reportDecryptFailed(event: DecryptFailedEvent): void {
+  // eslint-disable-next-line no-console -- événement ops pseudonymisé, pas de donnée santé
+  console.info('[kinhale.sync]', event);
+}
 
 /**
  * Wrapper applicatif mobile qui injecte les dépendances plateforme dans le
@@ -13,11 +85,12 @@ import { useDocStore } from '../../stores/doc-store';
  * - la factory WebSocket RN (createRelayClient — s'appuie sur le WS polyfillé
  *   par Expo / Hermes)
  * - la dérivation groupKey (Argon2id cachée côté client)
+ * - la pseudonymisation + rapporteur télémétrie (KIN-040)
  *
  * Pas de pragma `'use client'` côté mobile : React Native n'a pas de distinction
  * serveur/client comme Next.js.
  *
- * Refs: KIN-039
+ * Refs: KIN-039, KIN-040
  */
 export function useRelaySync(): { connected: boolean } {
   return useRelaySyncCore({
@@ -29,6 +102,9 @@ export function useRelaySync(): { connected: boolean } {
     useReceiveChanges: () => useDocStore((s) => s.receiveChanges),
     createRelayClient,
     deriveGroupKey: getGroupKey,
+    platform: 'mobile',
+    hashHousehold,
+    reportDecryptFailed,
   });
 }
 

--- a/apps/mobile/src/lib/sync/index.ts
+++ b/apps/mobile/src/lib/sync/index.ts
@@ -21,12 +21,19 @@ import { useDocStore } from '../../stores/doc-store';
  *
  * Refs: KIN-040.
  */
-const APP_SECRET = process.env['EXPO_PUBLIC_KINHALE_APP_SECRET'] ?? 'dev-secret-v1';
+const APP_SECRET_FALLBACK_DEV = 'dev-secret-v1';
+const APP_SECRET = process.env['EXPO_PUBLIC_KINHALE_APP_SECRET'] ?? APP_SECRET_FALLBACK_DEV;
 
 if (typeof process !== 'undefined' && process.env['NODE_ENV'] === 'production') {
   if (process.env['EXPO_PUBLIC_KINHALE_APP_SECRET'] === undefined) {
     console.warn(
       '[kinhale.sync] EXPO_PUBLIC_KINHALE_APP_SECRET absent en prod — pseudonymisation avec fallback dev.',
+    );
+  } else if (APP_SECRET === APP_SECRET_FALLBACK_DEV) {
+    // Détecte un APP_SECRET défini mais laissé à la valeur dev : pseudonymes
+    // corrélables entre environnements (dev/preview/prod partagent le même sel).
+    console.warn(
+      '[kinhale.sync] APP_SECRET not configured in production, pseudonyms are correlable across environments',
     );
   }
 }
@@ -39,6 +46,9 @@ if (typeof process !== 'undefined' && process.env['NODE_ENV'] === 'production') 
 const pseudonymCache = new Map<string, string>();
 const pendingPromises = new Map<string, Promise<string>>();
 
+// FNV-1a 32 bits : ~65k collisions attendues sur 1M foyers. Suffisant comme
+// identifiant corrélant court (fenêtre < 1ms avant BLAKE2b async). Non utilisé
+// pour du contrôle d'intégrité.
 function fnv1aHash(input: string): string {
   let h = 0x811c9dc5;
   for (let i = 0; i < input.length; i++) {
@@ -53,11 +63,24 @@ export function hashHousehold(householdId: string): string {
   if (cached !== undefined) return cached;
 
   if (!pendingPromises.has(householdId)) {
-    const promise = blake2bHex(householdId, APP_SECRET).then((digest) => {
-      pseudonymCache.set(householdId, digest);
-      pendingPromises.delete(householdId);
-      return digest;
-    });
+    const promise = blake2bHex(householdId, APP_SECRET)
+      .then((digest) => {
+        pseudonymCache.set(householdId, digest);
+        pendingPromises.delete(householdId);
+        return digest;
+      })
+      .catch((err: unknown) => {
+        // Si libsodium échoue à charger, on reste sur le placeholder FNV-1a.
+        // On log uniquement le nom d'erreur (pas .message ni .stack) pour
+        // éviter toute fuite de contexte sensible dans les logs.
+        const name = err instanceof Error ? err.name : 'UnknownError';
+        console.warn(
+          '[kinhale.sync] blake2b async load failed, staying on FNV-1a placeholder',
+          name,
+        );
+        pendingPromises.delete(householdId);
+        return `pending-${fnv1aHash(householdId)}`;
+      });
     pendingPromises.set(householdId, promise);
   }
 

--- a/apps/web/src/lib/sync/index.ts
+++ b/apps/web/src/lib/sync/index.ts
@@ -1,9 +1,93 @@
 'use client';
 
-import { useRelaySync as useRelaySyncCore, getGroupKey } from '@kinhale/sync/client';
+import {
+  useRelaySync as useRelaySyncCore,
+  getGroupKey,
+  type DecryptFailedEvent,
+} from '@kinhale/sync/client';
+import { blake2bHex } from '@kinhale/crypto';
 import { createRelayClient } from '../relay-client';
 import { useAuthStore } from '../../stores/auth-store';
 import { useDocStore } from '../../stores/doc-store';
+
+/**
+ * Sel applicatif utilisé pour pseudonymiser les `householdId` dans les
+ * événements de télémétrie. **Ce n'est pas un secret crypto** : sa seule
+ * fonction est d'empêcher un reverse-lookup par rainbow table côté Sentry /
+ * CloudWatch si les digests venaient à fuiter. Le sel peut être journalisé
+ * sans conséquence sur la confidentialité des données santé.
+ *
+ * En prod, `NEXT_PUBLIC_KINHALE_APP_SECRET` doit être défini (valeur spécifique
+ * à l'environnement). Fallback dev stable pour tests locaux.
+ *
+ * Refs: KIN-040.
+ */
+const APP_SECRET = process.env['NEXT_PUBLIC_KINHALE_APP_SECRET'] ?? 'dev-secret-v1';
+
+if (typeof process !== 'undefined' && process.env['NODE_ENV'] === 'production') {
+  if (process.env['NEXT_PUBLIC_KINHALE_APP_SECRET'] === undefined) {
+    // On continue avec le fallback dev plutôt que de casser la sync ; le
+    // pseudonyme reste non-réversible pour un tiers sans accès au dictionnaire
+    // complet des householdId possibles.
+    console.warn(
+      '[kinhale.sync] NEXT_PUBLIC_KINHALE_APP_SECRET absent en prod — pseudonymisation avec fallback dev.',
+    );
+  }
+}
+
+/**
+ * Pré-calcule et met en cache le digest BLAKE2b keyed d'un `householdId`.
+ *
+ * Le reporter de télémétrie est synchrone (signature `(id: string) => string`)
+ * mais `blake2bHex` est asynchrone (libsodium). Stratégie :
+ * - Au premier appel, on déclenche le hash async en arrière-plan et on
+ *   retourne un placeholder JS court-hash (FNV-1a) pour conserver la
+ *   séparation par foyer dans les 1-2 tout premiers événements.
+ * - Dès que le digest libsodium est disponible, il remplace le placeholder
+ *   pour tous les appels suivants (cache process-local).
+ * Exporté pour tests unitaires ; pas d'API publique.
+ */
+const pseudonymCache = new Map<string, string>();
+const pendingPromises = new Map<string, Promise<string>>();
+
+function fnv1aHash(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+export function hashHousehold(householdId: string): string {
+  const cached = pseudonymCache.get(householdId);
+  if (cached !== undefined) return cached;
+
+  if (!pendingPromises.has(householdId)) {
+    const promise = blake2bHex(householdId, APP_SECRET).then((digest) => {
+      pseudonymCache.set(householdId, digest);
+      pendingPromises.delete(householdId);
+      return digest;
+    });
+    pendingPromises.set(householdId, promise);
+  }
+
+  // Placeholder FNV-1a : pas d'identité utilisateur en sortie, juste une
+  // empreinte JS courte qui préserve l'isolation par foyer. Remplacé par
+  // le vrai digest libsodium dès qu'il est prêt (cf. pendingPromises).
+  return `pending-${fnv1aHash(householdId)}`;
+}
+
+/**
+ * Rapporteur v1.0 : log local pseudonymisé. Sera remplacé par une intégration
+ * Sentry dans une PR ultérieure (hors scope KIN-040).
+ *
+ * @see DecryptFailedEvent — schéma figé, aucune donnée santé n'y transite.
+ */
+function reportDecryptFailed(event: DecryptFailedEvent): void {
+  // eslint-disable-next-line no-console -- événement ops pseudonymisé, pas de donnée santé
+  console.info('[kinhale.sync]', event);
+}
 
 /**
  * Wrapper applicatif web qui injecte les dépendances plateforme dans le hook
@@ -14,12 +98,13 @@ import { useDocStore } from '../../stores/doc-store';
  * - les hooks Zustand (useAuthStore / useDocStore)
  * - la factory WebSocket DOM (createRelayClient)
  * - la dérivation groupKey (Argon2id cachée côté client)
+ * - la pseudonymisation + rapporteur télémétrie (KIN-040)
  *
  * Le pragma `'use client'` est requis par Next.js pour que le module soit
  * bundlé côté client — le package `@kinhale/sync` ne porte pas ce pragma car
  * il est aussi consommé par mobile.
  *
- * Refs: KIN-039
+ * Refs: KIN-039, KIN-040
  */
 export function useRelaySync(): { connected: boolean } {
   return useRelaySyncCore({
@@ -31,6 +116,9 @@ export function useRelaySync(): { connected: boolean } {
     useReceiveChanges: () => useDocStore((s) => s.receiveChanges),
     createRelayClient,
     deriveGroupKey: getGroupKey,
+    platform: 'web',
+    hashHousehold,
+    reportDecryptFailed,
   });
 }
 

--- a/apps/web/src/lib/sync/index.ts
+++ b/apps/web/src/lib/sync/index.ts
@@ -22,7 +22,8 @@ import { useDocStore } from '../../stores/doc-store';
  *
  * Refs: KIN-040.
  */
-const APP_SECRET = process.env['NEXT_PUBLIC_KINHALE_APP_SECRET'] ?? 'dev-secret-v1';
+const APP_SECRET_FALLBACK_DEV = 'dev-secret-v1';
+const APP_SECRET = process.env['NEXT_PUBLIC_KINHALE_APP_SECRET'] ?? APP_SECRET_FALLBACK_DEV;
 
 if (typeof process !== 'undefined' && process.env['NODE_ENV'] === 'production') {
   if (process.env['NEXT_PUBLIC_KINHALE_APP_SECRET'] === undefined) {
@@ -31,6 +32,12 @@ if (typeof process !== 'undefined' && process.env['NODE_ENV'] === 'production') 
     // complet des householdId possibles.
     console.warn(
       '[kinhale.sync] NEXT_PUBLIC_KINHALE_APP_SECRET absent en prod — pseudonymisation avec fallback dev.',
+    );
+  } else if (APP_SECRET === APP_SECRET_FALLBACK_DEV) {
+    // Détecte un APP_SECRET défini mais laissé à la valeur dev : pseudonymes
+    // corrélables entre environnements (dev/preview/prod partagent le même sel).
+    console.warn(
+      '[kinhale.sync] APP_SECRET not configured in production, pseudonyms are correlable across environments',
     );
   }
 }
@@ -50,6 +57,9 @@ if (typeof process !== 'undefined' && process.env['NODE_ENV'] === 'production') 
 const pseudonymCache = new Map<string, string>();
 const pendingPromises = new Map<string, Promise<string>>();
 
+// FNV-1a 32 bits : ~65k collisions attendues sur 1M foyers. Suffisant comme
+// identifiant corrélant court (fenêtre < 1ms avant BLAKE2b async). Non utilisé
+// pour du contrôle d'intégrité.
 function fnv1aHash(input: string): string {
   let h = 0x811c9dc5;
   for (let i = 0; i < input.length; i++) {
@@ -64,11 +74,25 @@ export function hashHousehold(householdId: string): string {
   if (cached !== undefined) return cached;
 
   if (!pendingPromises.has(householdId)) {
-    const promise = blake2bHex(householdId, APP_SECRET).then((digest) => {
-      pseudonymCache.set(householdId, digest);
-      pendingPromises.delete(householdId);
-      return digest;
-    });
+    const promise = blake2bHex(householdId, APP_SECRET)
+      .then((digest) => {
+        pseudonymCache.set(householdId, digest);
+        pendingPromises.delete(householdId);
+        return digest;
+      })
+      .catch((err: unknown) => {
+        // Si libsodium échoue à charger, on reste sur le placeholder FNV-1a.
+        // On log uniquement le nom d'erreur (pas .message ni .stack) pour
+        // éviter toute fuite de contexte sensible dans les logs.
+        const name = err instanceof Error ? err.name : 'UnknownError';
+        console.warn(
+          '[kinhale.sync] blake2b async load failed, staying on FNV-1a placeholder',
+          name,
+        );
+        pendingPromises.delete(householdId);
+        // Retourne le placeholder pour satisfaire la Promise<string>.
+        return `pending-${fnv1aHash(householdId)}`;
+      });
     pendingPromises.set(householdId, promise);
   }
 

--- a/packages/crypto/src/hash/blake2b.test.ts
+++ b/packages/crypto/src/hash/blake2b.test.ts
@@ -4,17 +4,41 @@ import { blake2bHex, BLAKE2B_DEFAULT_BYTES } from './blake2b.js';
 /**
  * Tests de conformité BLAKE2b via libsodium (`crypto_generichash`).
  *
- * Pas de vecteur RFC 7693 officiel ici — on teste :
+ * Inclut :
+ * - 1 test vector officiel RFC 7693 Appendix A (BLAKE2b-512 de "abc") ;
+ * - 1 test vector d'ancrage BLAKE2b-256 (sortie 32 bytes, non-keyed) généré
+ *   depuis l'implémentation courante pour bloquer toute régression ;
  * - la structure (longueur, format hex minuscule) ;
  * - le déterminisme ;
  * - la dépendance à la clé (non-clé ≠ clé) ;
  * - la sensibilité au message (chaque octet modifié change la sortie).
  *
- * Refs: KIN-040.
+ * Refs: KIN-040, RFC 7693.
  */
 describe('blake2bHex', () => {
   it('expose une longueur par défaut de 8 octets', () => {
     expect(BLAKE2B_DEFAULT_BYTES).toBe(8);
+  });
+
+  it('correspond au test vector RFC 7693 Appendix A (BLAKE2b-512 de "abc", non-keyed)', async () => {
+    // Source : RFC 7693, Appendix A.
+    // https://www.rfc-editor.org/rfc/rfc7693#appendix-A
+    // Input: "abc" (UTF-8, 3 bytes) ; Key: aucune ; outputLen: 64 bytes.
+    const expected =
+      'ba80a53f981c4d0d6a2797b69f12f6e94c212f14685ac4b74b12bb6fdbffa2d1' +
+      '7d87c5392aab792dc252d5de4533cc9518d38aa8dbf1925ab92386edd4009923';
+    const digest = await blake2bHex('abc', null, 64);
+    expect(digest).toBe(expected);
+  });
+
+  it('correspond au test d\'ancrage BLAKE2b-256 de "abc" (non-keyed, sortie 32 bytes)', async () => {
+    // Ancre de régression : BLAKE2b-256 natif (pas tronqué du 512) via
+    // `crypto_generichash(32, ...)`. Valeur générée depuis l'implémentation
+    // libsodium-wrappers-sumo courante ; toute divergence signale une
+    // régression de primitive.
+    const expected = 'bddd813c634239723171ef3fee98579b94964e3bb1cb3e427262c8c068d52319';
+    const digest = await blake2bHex('abc', null, 32);
+    expect(digest).toBe(expected);
   });
 
   it('retourne un hex minuscule de 16 caractères par défaut', async () => {

--- a/packages/crypto/src/hash/blake2b.test.ts
+++ b/packages/crypto/src/hash/blake2b.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { blake2bHex, BLAKE2B_DEFAULT_BYTES } from './blake2b.js';
+
+/**
+ * Tests de conformité BLAKE2b via libsodium (`crypto_generichash`).
+ *
+ * Pas de vecteur RFC 7693 officiel ici — on teste :
+ * - la structure (longueur, format hex minuscule) ;
+ * - le déterminisme ;
+ * - la dépendance à la clé (non-clé ≠ clé) ;
+ * - la sensibilité au message (chaque octet modifié change la sortie).
+ *
+ * Refs: KIN-040.
+ */
+describe('blake2bHex', () => {
+  it('expose une longueur par défaut de 8 octets', () => {
+    expect(BLAKE2B_DEFAULT_BYTES).toBe(8);
+  });
+
+  it('retourne un hex minuscule de 16 caractères par défaut', async () => {
+    const digest = await blake2bHex('household-abc', 'app-secret');
+    expect(digest).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('retourne un hex de longueur configurable (32 octets → 64 chars)', async () => {
+    const digest = await blake2bHex('household-abc', 'app-secret', 32);
+    expect(digest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('est déterministe (même message + même clé → même digest)', async () => {
+    const a = await blake2bHex('household-xyz', 'secret-v1');
+    const b = await blake2bHex('household-xyz', 'secret-v1');
+    expect(a).toBe(b);
+  });
+
+  it('produit un digest différent si la clé change (rôle de sel)', async () => {
+    const withKeyA = await blake2bHex('household-xyz', 'secret-A');
+    const withKeyB = await blake2bHex('household-xyz', 'secret-B');
+    expect(withKeyA).not.toBe(withKeyB);
+  });
+
+  it('produit un digest différent si le message change (collision-resistance)', async () => {
+    const a = await blake2bHex('household-aaa', 'secret');
+    const b = await blake2bHex('household-bbb', 'secret');
+    expect(a).not.toBe(b);
+  });
+
+  it('accepte une clé null (hash sans clé)', async () => {
+    const digest = await blake2bHex('household-abc', null);
+    expect(digest).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('accepte un message Uint8Array', async () => {
+    const msg = new Uint8Array([1, 2, 3, 4]);
+    const digest = await blake2bHex(msg, 'secret');
+    expect(digest).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('accepte une clé Uint8Array', async () => {
+    const key = new Uint8Array(16).fill(0x42);
+    const digest = await blake2bHex('household-abc', key);
+    expect(digest).toMatch(/^[0-9a-f]{16}$/);
+  });
+});

--- a/packages/crypto/src/hash/blake2b.ts
+++ b/packages/crypto/src/hash/blake2b.ts
@@ -27,10 +27,17 @@ export const BLAKE2B_DEFAULT_BYTES = 8;
  * @param message - Donnée à hasher (string UTF-8 ou Uint8Array).
  * @param key - Clé / sel applicatif (string UTF-8 ou Uint8Array, ou `null`
  *   pour un hash sans clé). La clé n'est **jamais** loggée ni émise.
+ *   Note : `key = null` donne un hash non-keyed, utile pour du hashing de
+ *   déduplication mais **inadéquat pour la pseudonymisation** — un attaquant
+ *   connaissant l'espace des pré-images peut rainbow-tabler un hash non-keyed.
  * @param outputLen - Longueur du digest en octets. Par défaut 8 octets
  *   (16 caractères hex) — suffisant pour corréler côté ops sans permettre
  *   d'énumération par rainbow table.
  * @returns Digest hex-encodé en minuscules.
+ *
+ * @remarks Entropie minimale conseillée de la pré-image : ≥ 64 bits (ex. UUID
+ * v4, random 8+ bytes). En dessous, même avec une clé, la sortie reste
+ * énumérable par force brute sur l'espace des pré-images possibles.
  */
 export async function blake2bHex(
   message: Uint8Array | string,

--- a/packages/crypto/src/hash/blake2b.ts
+++ b/packages/crypto/src/hash/blake2b.ts
@@ -1,0 +1,52 @@
+/**
+ * BLAKE2b via libsodium (`crypto_generichash`).
+ *
+ * Utilisé pour produire un **pseudonyme non réversible** d'un identifiant
+ * stable (p. ex. `householdId`) avant émission d'un événement de télémétrie.
+ * Ce n'est **pas** une primitive de confidentialité forte au sens crypto :
+ * la clé `key` passée ici est un **sel applicatif** dont le seul but est
+ * d'empêcher une collision de dictionnaire côté Sentry/CloudWatch si l'on
+ * connaît l'ensemble des `householdId` possibles.
+ *
+ * La conformité zero-knowledge est maintenue par construction : le payload
+ * émis côté télémétrie ne contient que le digest hex, jamais le pré-image.
+ *
+ * Ce module est le **seul point d'accès** autorisé à BLAKE2b dans le monorepo.
+ *
+ * Refs: KIN-040.
+ */
+import { getSodium } from '../sodium.js';
+
+/** Longueur de sortie par défaut en octets (8 → 16 caractères hex). */
+export const BLAKE2B_DEFAULT_BYTES = 8;
+
+/**
+ * Calcule `BLAKE2b(message, key)` avec un digest de `outputLen` octets, encodé
+ * en hex minuscule.
+ *
+ * @param message - Donnée à hasher (string UTF-8 ou Uint8Array).
+ * @param key - Clé / sel applicatif (string UTF-8 ou Uint8Array, ou `null`
+ *   pour un hash sans clé). La clé n'est **jamais** loggée ni émise.
+ * @param outputLen - Longueur du digest en octets. Par défaut 8 octets
+ *   (16 caractères hex) — suffisant pour corréler côté ops sans permettre
+ *   d'énumération par rainbow table.
+ * @returns Digest hex-encodé en minuscules.
+ */
+export async function blake2bHex(
+  message: Uint8Array | string,
+  key: Uint8Array | string | null,
+  outputLen: number = BLAKE2B_DEFAULT_BYTES,
+): Promise<string> {
+  const sodium = await getSodium();
+  const digest = sodium.crypto_generichash(outputLen, message, key);
+  return bytesToHex(digest);
+}
+
+/** Convertit un Uint8Array en string hex minuscule sans dépendance externe. */
+function bytesToHex(bytes: Uint8Array): string {
+  let hex = '';
+  for (const byte of bytes) {
+    hex += byte.toString(16).padStart(2, '0');
+  }
+  return hex;
+}

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,4 +1,5 @@
 export { CRYPTO_UNAVAILABLE_MESSAGE, sha256Hex, sha256HexFromString } from './hash/sha256.js';
+export { blake2bHex, BLAKE2B_DEFAULT_BYTES } from './hash/blake2b.js';
 export { getSodium } from './sodium.js';
 export { generateSigningKeypair, sign, verify } from './sign/ed25519.js';
 export type { SigningKeypair } from './sign/ed25519.js';

--- a/packages/sync/src/client/__tests__/telemetry.test.ts
+++ b/packages/sync/src/client/__tests__/telemetry.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Mock } from 'vitest';
+import {
+  classifyDecryptError,
+  createDecryptFailedReporter,
+  type DecryptFailedEvent,
+  type ReportDecryptFailed,
+} from '../telemetry.js';
+
+/**
+ * Clés autorisées dans le payload d'un événement télémétrie — toute autre
+ * clé présente est un incident de confidentialité potentiel.
+ * Refs: KIN-040, CLAUDE.md (zero-knowledge).
+ */
+const ALLOWED_KEYS = [
+  'name',
+  'timestamp',
+  'platform',
+  'errorClass',
+  'seq',
+  'householdPseudonym',
+  'count',
+] as const;
+
+/**
+ * Clés sensibles qui ne doivent **jamais** apparaître dans le payload,
+ * même accidentellement via un typo ou une régression de schéma.
+ */
+const FORBIDDEN_KEYS = [
+  'householdId',
+  'doseId',
+  'childId',
+  'pumpId',
+  'message',
+  'stack',
+  'rawError',
+  'blobJson',
+  'token',
+  'deviceId',
+  'name_',
+  'ciphertext',
+  'plaintext',
+];
+
+/** Hash fake déterministe (pas de crypto réelle dans ce test). */
+function fakeHash(householdId: string): string {
+  // Simulation : 16 chars hex dérivés stablement du householdId — suffisant
+  // pour vérifier le déterminisme et l'indépendance côté caller.
+  let h = 0;
+  for (let i = 0; i < householdId.length; i++) {
+    h = (h * 31 + householdId.charCodeAt(i)) >>> 0;
+  }
+  return h.toString(16).padStart(16, '0');
+}
+
+describe('classifyDecryptError', () => {
+  it('classifie SyntaxError comme "parse"', () => {
+    expect(classifyDecryptError(new SyntaxError('unexpected token'))).toBe('parse');
+  });
+
+  it('classifie une Error générique comme "decrypt"', () => {
+    expect(classifyDecryptError(new Error('mac failed'))).toBe('decrypt');
+  });
+
+  it('classifie une primitive comme "unknown"', () => {
+    expect(classifyDecryptError('oops')).toBe('unknown');
+    expect(classifyDecryptError(null)).toBe('unknown');
+    expect(classifyDecryptError(undefined)).toBe('unknown');
+    expect(classifyDecryptError(42)).toBe('unknown');
+  });
+
+  it('ne lit jamais err.message (pas de leak de données santé)', () => {
+    // Propriété défensive : on s'assure que la classification ne fait pas
+    // d'inspection du message pour dériver sa classe — seul le type compte.
+    const err = new Error('child-123 pump-ventoline dose-2mg');
+    const cls = classifyDecryptError(err);
+    expect(cls).toBe('decrypt');
+  });
+});
+
+describe('createDecryptFailedReporter', () => {
+  let reportMock: Mock;
+  let nowMs: number;
+  let now: () => number;
+
+  beforeEach(() => {
+    reportMock = vi.fn();
+    nowMs = 1_745_000_000_000; // 2025-04-18T19:33:20Z environ
+    now = () => nowMs;
+  });
+
+  it('émet un événement sync.decrypt_failed avec le schéma exact', () => {
+    const reporter = createDecryptFailedReporter({
+      platform: 'web',
+      hashHousehold: fakeHash,
+      report: reportMock as ReportDecryptFailed,
+      now,
+    });
+
+    reporter.track({ householdId: 'household-001', errorClass: 'decrypt', seq: 42 });
+
+    expect(reportMock).toHaveBeenCalledTimes(1);
+    const event = reportMock.mock.calls[0]?.[0] as DecryptFailedEvent;
+    expect(event.name).toBe('sync.decrypt_failed');
+    expect(event.platform).toBe('web');
+    expect(event.errorClass).toBe('decrypt');
+    expect(event.seq).toBe(42);
+    expect(event.householdPseudonym).toBe(fakeHash('household-001'));
+    expect(event.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:00\.000Z$/);
+  });
+
+  it('arrondit le timestamp à la minute', () => {
+    const reporter = createDecryptFailedReporter({
+      platform: 'mobile',
+      hashHousehold: fakeHash,
+      report: reportMock as ReportDecryptFailed,
+      now: () => new Date('2026-04-23T02:15:37.123Z').getTime(),
+    });
+
+    reporter.track({ householdId: 'h', errorClass: 'decrypt', seq: 1 });
+
+    const event = reportMock.mock.calls[0]?.[0] as DecryptFailedEvent;
+    expect(event.timestamp).toBe('2026-04-23T02:15:00.000Z');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scrubbing — garde-fou critique. Si cette suite échoue, c'est un incident P0.
+  // ---------------------------------------------------------------------------
+
+  describe('scrubbing du payload', () => {
+    it("n'émet AUCUN champ interdit (householdId, doseId, childId, message, stack...)", () => {
+      const reporter = createDecryptFailedReporter({
+        platform: 'web',
+        hashHousehold: fakeHash,
+        report: reportMock as ReportDecryptFailed,
+        now,
+      });
+
+      reporter.track({
+        householdId: 'household-LEAK-TEST',
+        errorClass: 'decrypt',
+        seq: 7,
+      });
+
+      expect(reportMock).toHaveBeenCalledTimes(1);
+      const event = reportMock.mock.calls[0]?.[0] as Record<string, unknown>;
+
+      for (const forbidden of FORBIDDEN_KEYS) {
+        expect(
+          event,
+          `Champ interdit détecté dans l'événement télémétrie : "${forbidden}"`,
+        ).not.toHaveProperty(forbidden);
+      }
+
+      // Vérification supplémentaire : aucun champ hors whitelist (même avec
+      // un nom anodin inventé à tort).
+      const allowed = new Set<string>(ALLOWED_KEYS);
+      for (const key of Object.keys(event)) {
+        expect(allowed.has(key), `Clé hors whitelist dans l'événement : "${key}"`).toBe(true);
+      }
+
+      // Enfin : la valeur du householdPseudonym n'est PAS le householdId.
+      const pseudonym = event['householdPseudonym'] as string;
+      expect(pseudonym).not.toBe('household-LEAK-TEST');
+      expect(pseudonym).not.toContain('household');
+      expect(pseudonym).not.toContain('LEAK');
+    });
+
+    it("n'émet pas de message d'erreur brut même si l'appelant passait une erreur suspecte", () => {
+      // Le reporter NE REÇOIT PAS d'objet Error — seulement une classe.
+      // Ce test documente l'invariant : le shape de track() n'accepte qu'un
+      // `errorClass` string, pas un Error. TypeScript bloque déjà, mais on
+      // renforce par un test d'usage.
+      const reporter = createDecryptFailedReporter({
+        platform: 'mobile',
+        hashHousehold: fakeHash,
+        report: reportMock as ReportDecryptFailed,
+        now,
+      });
+
+      reporter.track({ householdId: 'h', errorClass: 'parse', seq: 1 });
+
+      const event = reportMock.mock.calls[0]?.[0] as Record<string, unknown>;
+      const json = JSON.stringify(event);
+      expect(json).not.toMatch(/stack/i);
+      expect(json).not.toMatch(/at .*\(.*\)/); // stack-frame pattern
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rate-limit
+  // ---------------------------------------------------------------------------
+
+  describe('rate limit 100/60s', () => {
+    it('émet les 100 premiers événements puis 1 seul storm agrégé à la bascule de fenêtre', () => {
+      const reporter = createDecryptFailedReporter({
+        platform: 'web',
+        hashHousehold: fakeHash,
+        report: reportMock as ReportDecryptFailed,
+        now,
+      });
+
+      // 105 événements dans la même fenêtre (nowMs constant).
+      for (let i = 0; i < 105; i++) {
+        reporter.track({ householdId: 'h-one', errorClass: 'decrypt', seq: i });
+      }
+
+      // Pendant la fenêtre : 100 événements unitaires émis.
+      const beforeWindowSwitch = reportMock.mock.calls.length;
+      expect(beforeWindowSwitch).toBe(100);
+
+      // Bascule de fenêtre : les 5 supprimés sont agrégés en 1 storm.
+      nowMs += 60_000;
+      reporter.track({ householdId: 'h-one', errorClass: 'decrypt', seq: 200 });
+
+      // 1 storm (pour l'ancienne fenêtre) + 1 événement unitaire (pour la nouvelle).
+      const events = reportMock.mock.calls.map((c) => c[0] as DecryptFailedEvent);
+      const storms = events.filter((e) => e.name === 'sync.decrypt_failed_storm');
+      expect(storms).toHaveLength(1);
+      const storm = storms[0];
+      expect(storm?.count).toBe(5);
+      expect(storm?.householdPseudonym).toBe(fakeHash('h-one'));
+
+      // L'événement post-bascule est bien un unitaire normal.
+      const unitaires = events.filter((e) => e.name === 'sync.decrypt_failed');
+      expect(unitaires).toHaveLength(101);
+      expect(unitaires[100]?.seq).toBe(200);
+    });
+
+    it('réinitialise le compteur à chaque nouvelle fenêtre (compteurs indépendants)', () => {
+      const reporter = createDecryptFailedReporter({
+        platform: 'web',
+        hashHousehold: fakeHash,
+        report: reportMock as ReportDecryptFailed,
+        now,
+      });
+
+      // Fenêtre 1 : 50 événements → aucun storm.
+      for (let i = 0; i < 50; i++) {
+        reporter.track({ householdId: 'h', errorClass: 'decrypt', seq: i });
+      }
+      expect(reportMock.mock.calls.length).toBe(50);
+
+      // Bascule explicite (> 60s).
+      nowMs += 61_000;
+
+      // Fenêtre 2 : 50 événements → tous émis, aucun storm.
+      for (let i = 0; i < 50; i++) {
+        reporter.track({ householdId: 'h', errorClass: 'decrypt', seq: 1000 + i });
+      }
+
+      const events = reportMock.mock.calls.map((c) => c[0] as DecryptFailedEvent);
+      expect(events.filter((e) => e.name === 'sync.decrypt_failed_storm')).toHaveLength(0);
+      expect(events.filter((e) => e.name === 'sync.decrypt_failed')).toHaveLength(100);
+    });
+
+    it('isole les fenêtres par foyer pseudonymisé', () => {
+      const reporter = createDecryptFailedReporter({
+        platform: 'web',
+        hashHousehold: fakeHash,
+        report: reportMock as ReportDecryptFailed,
+        now,
+      });
+
+      // Foyer A : 105 événements. Foyer B : 3 événements. Dans la même fenêtre.
+      for (let i = 0; i < 105; i++) {
+        reporter.track({ householdId: 'foyer-A', errorClass: 'decrypt', seq: i });
+      }
+      for (let i = 0; i < 3; i++) {
+        reporter.track({ householdId: 'foyer-B', errorClass: 'decrypt', seq: i });
+      }
+
+      // Foyer A : seuls 100 unitaires avant storm ; Foyer B : 3 unitaires.
+      const events = reportMock.mock.calls.map((c) => c[0] as DecryptFailedEvent);
+      const pseudoA = fakeHash('foyer-A');
+      const pseudoB = fakeHash('foyer-B');
+
+      const unitA = events.filter(
+        (e) => e.name === 'sync.decrypt_failed' && e.householdPseudonym === pseudoA,
+      );
+      const unitB = events.filter(
+        (e) => e.name === 'sync.decrypt_failed' && e.householdPseudonym === pseudoB,
+      );
+      expect(unitA).toHaveLength(100);
+      expect(unitB).toHaveLength(3);
+
+      // Flush : le storm de foyer A est émis, aucun pour B.
+      reporter.flush();
+      const storms = events
+        .concat(reportMock.mock.calls.slice(events.length).map((c) => c[0] as DecryptFailedEvent))
+        .filter((e) => e.name === 'sync.decrypt_failed_storm');
+      expect(storms.filter((s) => s.householdPseudonym === pseudoA)).toHaveLength(1);
+      expect(storms.filter((s) => s.householdPseudonym === pseudoB)).toHaveLength(0);
+    });
+
+    it('flush() émet un storm si la fenêtre courante a dépassé le seuil', () => {
+      const reporter = createDecryptFailedReporter({
+        platform: 'web',
+        hashHousehold: fakeHash,
+        report: reportMock as ReportDecryptFailed,
+        now,
+      });
+
+      for (let i = 0; i < 102; i++) {
+        reporter.track({ householdId: 'h', errorClass: 'decrypt', seq: i });
+      }
+      reportMock.mockClear();
+
+      reporter.flush();
+
+      expect(reportMock).toHaveBeenCalledTimes(1);
+      const event = reportMock.mock.calls[0]?.[0] as DecryptFailedEvent;
+      expect(event.name).toBe('sync.decrypt_failed_storm');
+      expect(event.count).toBe(2);
+    });
+
+    it("flush() sans dépassement n'émet rien", () => {
+      const reporter = createDecryptFailedReporter({
+        platform: 'web',
+        hashHousehold: fakeHash,
+        report: reportMock as ReportDecryptFailed,
+        now,
+      });
+
+      for (let i = 0; i < 50; i++) {
+        reporter.track({ householdId: 'h', errorClass: 'decrypt', seq: i });
+      }
+      reportMock.mockClear();
+
+      reporter.flush();
+      expect(reportMock).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Rétro-compat : si `report` n'est pas injecté, no-op silencieux.
+  // ---------------------------------------------------------------------------
+
+  it('est un no-op complet si report est undefined', () => {
+    const reporter = createDecryptFailedReporter({
+      platform: 'web',
+      hashHousehold: fakeHash,
+      now,
+    });
+
+    // Ne doit pas throw, ne doit rien logger, même après rate-limit atteint.
+    for (let i = 0; i < 200; i++) {
+      reporter.track({ householdId: 'h', errorClass: 'decrypt', seq: i });
+    }
+    reporter.flush();
+    // Aucune exception = test vert.
+  });
+});

--- a/packages/sync/src/client/__tests__/telemetry.test.ts
+++ b/packages/sync/src/client/__tests__/telemetry.test.ts
@@ -76,6 +76,24 @@ describe('classifyDecryptError', () => {
     const cls = classifyDecryptError(err);
     expect(cls).toBe('decrypt');
   });
+
+  it('classifie une erreur cross-realm (nom préservé, instanceof KO) comme "parse"', () => {
+    // Simule une erreur venue d'un autre realm JS (WebWorker, iframe,
+    // bridge React Native) : instanceof SyntaxError renverrait false car le
+    // constructeur SyntaxError est distinct d'un realm à l'autre, mais
+    // err.name === 'SyntaxError' reste fiable (string sérialisée tel quel
+    // à travers les bridges).
+    const crossRealm = Object.create(Error.prototype) as Error;
+    Object.defineProperty(crossRealm, 'name', { value: 'SyntaxError' });
+    Object.defineProperty(crossRealm, 'message', { value: 'unexpected token <' });
+
+    // Sanity : l'objet n'est pas instance de SyntaxError mais reste instance
+    // d'Error (via Error.prototype) — sans ça le test ne valide rien.
+    expect(crossRealm instanceof SyntaxError).toBe(false);
+    expect(crossRealm instanceof Error).toBe(true);
+
+    expect(classifyDecryptError(crossRealm)).toBe('parse');
+  });
 });
 
 describe('createDecryptFailedReporter', () => {

--- a/packages/sync/src/client/__tests__/useRelaySync.test.tsx
+++ b/packages/sync/src/client/__tests__/useRelaySync.test.tsx
@@ -42,6 +42,7 @@ vi.mock('../../index.js', () => ({
 // Import APRÈS vi.mock — hoisting vitest est garanti.
 import { useRelaySync } from '../useRelaySync.js';
 import type { RelayClient, RelayMessageHandler } from '../useRelaySync.js';
+import type { DecryptFailedEvent } from '../telemetry.js';
 
 // ---------------------------------------------------------------------------
 // État plateforme simulé — injecté via deps du hook.
@@ -74,6 +75,17 @@ const mockCreateRelayClient = vi.fn((_token: string, onMessage: RelayMessageHand
 
 const mockDeriveGroupKey = vi.fn(async (_householdId: string) => new Uint8Array(32).fill(1));
 
+// Mock de pseudonymisation : simulation d'un BLAKE2b opaque. Le mock ne
+// contient pas l'input dans son output, comme le ferait un vrai hash.
+const mockHashHousehold = vi.fn((householdId: string) => {
+  let h = 0;
+  for (let i = 0; i < householdId.length; i++) {
+    h = (h * 31 + householdId.charCodeAt(i)) >>> 0;
+  }
+  return h.toString(16).padStart(16, '0');
+});
+let mockReportDecryptFailed: Mock;
+
 function buildDeps() {
   return {
     useAccessToken: () => fakeAuth.accessToken,
@@ -84,6 +96,9 @@ function buildDeps() {
     useReceiveChanges: () => fakeReceiveChanges,
     createRelayClient: mockCreateRelayClient,
     deriveGroupKey: mockDeriveGroupKey,
+    platform: 'web' as const,
+    hashHousehold: mockHashHousehold,
+    reportDecryptFailed: mockReportDecryptFailed,
   };
 }
 
@@ -121,6 +136,8 @@ describe('useRelaySync (package client)', () => {
     mockConsumeSyncMessage.mockClear();
     mockCreateRelayClient.mockClear();
     mockDeriveGroupKey.mockClear();
+    mockHashHousehold.mockClear();
+    mockReportDecryptFailed = vi.fn();
   });
 
   it('ne se connecte pas si accessToken est null', async () => {
@@ -254,6 +271,137 @@ describe('useRelaySync (package client)', () => {
       await flushPromises();
     });
 
+    expect(fakeReceiveChanges).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Télémétrie `sync.decrypt_failed` (KIN-040).
+  // ---------------------------------------------------------------------------
+
+  it('émet un événement sync.decrypt_failed pseudonymisé quand le déchiffrement échoue', async () => {
+    setAuthenticated();
+    setDocLoaded();
+
+    mockConsumeSyncMessage.mockRejectedValueOnce(new Error('mac failed'));
+
+    renderHook(() => useRelaySync(buildDeps()));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await act(async () => {
+      await capturedOnMessage?.({ blobJson: '{"tampered":true}', seq: 17, sentAtMs: 0 });
+      await flushPromises();
+    });
+
+    expect(mockReportDecryptFailed).toHaveBeenCalledTimes(1);
+    const event = mockReportDecryptFailed.mock.calls[0]?.[0] as DecryptFailedEvent;
+    expect(event.name).toBe('sync.decrypt_failed');
+    expect(event.platform).toBe('web');
+    expect(event.errorClass).toBe('decrypt');
+    expect(event.seq).toBe(17);
+    // Pseudonyme OK : jamais le householdId en clair.
+    expect(mockHashHousehold).toHaveBeenCalledWith('household-001');
+    expect(event.householdPseudonym).toMatch(/^[0-9a-f]{16}$/);
+    expect(event.householdPseudonym).not.toContain('household');
+  });
+
+  it('classifie une SyntaxError comme errorClass="parse"', async () => {
+    setAuthenticated();
+    setDocLoaded();
+
+    mockConsumeSyncMessage.mockRejectedValueOnce(new SyntaxError('invalid JSON'));
+
+    renderHook(() => useRelaySync(buildDeps()));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await act(async () => {
+      await capturedOnMessage?.({ blobJson: '{bad', seq: 3, sentAtMs: 0 });
+      await flushPromises();
+    });
+
+    const event = mockReportDecryptFailed.mock.calls[0]?.[0] as DecryptFailedEvent;
+    expect(event.errorClass).toBe('parse');
+  });
+
+  it("n'émet aucun champ interdit (householdId brut, message, stack) dans l'événement", async () => {
+    setAuthenticated();
+    setDocLoaded();
+
+    // On force une erreur dont le message embarque un faux contexte santé —
+    // garde-fou : même si le message contient des prénoms ou des doses, rien
+    // ne doit passer dans l'événement télémétrie.
+    mockConsumeSyncMessage.mockRejectedValueOnce(
+      new Error('decrypt failed for child-Léo ventoline 2mg at 14:30'),
+    );
+
+    renderHook(() => useRelaySync(buildDeps()));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    await act(async () => {
+      await capturedOnMessage?.({ blobJson: '{"tampered":true}', seq: 1, sentAtMs: 0 });
+      await flushPromises();
+    });
+
+    const event = mockReportDecryptFailed.mock.calls[0]?.[0] as Record<string, unknown>;
+    const serialized = JSON.stringify(event);
+
+    // Aucun contenu de message d'erreur ne doit ressortir.
+    expect(serialized).not.toContain('Léo');
+    expect(serialized).not.toContain('ventoline');
+    expect(serialized).not.toContain('2mg');
+    expect(serialized).not.toContain('decrypt failed for');
+
+    // Aucun householdId en clair.
+    expect(serialized).not.toContain('household-001');
+
+    // Aucune clé interdite.
+    for (const forbidden of [
+      'householdId',
+      'doseId',
+      'childId',
+      'pumpId',
+      'message',
+      'stack',
+      'rawError',
+      'blobJson',
+      'token',
+    ]) {
+      expect(event).not.toHaveProperty(forbidden);
+    }
+  });
+
+  it('fonctionne (no-op télémétrie) si reportDecryptFailed est undefined', async () => {
+    setAuthenticated();
+    setDocLoaded();
+
+    mockConsumeSyncMessage.mockRejectedValueOnce(new Error('decrypt failed'));
+
+    // On retire explicitement la clé reportDecryptFailed pour rester conforme
+    // à `exactOptionalPropertyTypes: true` — une dep optionnelle non fournie
+    // doit être absente, pas valorisée à `undefined`.
+    const { reportDecryptFailed: _reportDecryptFailed, ...deps } = buildDeps();
+
+    renderHook(() => useRelaySync(deps));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    // Ne doit pas throw.
+    await act(async () => {
+      await capturedOnMessage?.({ blobJson: '{"bad":true}', seq: 1, sentAtMs: 0 });
+      await flushPromises();
+    });
+
+    expect(mockReportDecryptFailed).not.toHaveBeenCalled();
     expect(fakeReceiveChanges).not.toHaveBeenCalled();
   });
 });

--- a/packages/sync/src/client/index.ts
+++ b/packages/sync/src/client/index.ts
@@ -19,3 +19,11 @@ export type {
   CreateRelayClient,
   UseRelaySyncDeps,
 } from './useRelaySync.js';
+export { classifyDecryptError, createDecryptFailedReporter } from './telemetry.js';
+export type {
+  DecryptErrorClass,
+  DecryptFailedEvent,
+  DecryptFailedEventName,
+  HashHousehold,
+  ReportDecryptFailed,
+} from './telemetry.js';

--- a/packages/sync/src/client/telemetry.ts
+++ b/packages/sync/src/client/telemetry.ts
@@ -1,0 +1,187 @@
+/**
+ * Télémétrie pseudonymisée pour les échecs de déchiffrement côté client sync.
+ *
+ * Objectif : lever la zone aveugle opérationnelle identifiée dans
+ * `kz-securite-KIN-038.md` §M2 (try/catch silencieux autour de
+ * `consumeSyncMessage`) sans jamais émettre la moindre donnée santé.
+ *
+ * Contraintes non négociables (cf. issue #191 et CLAUDE.md) :
+ * - **Aucune donnée santé** dans le payload : pas de `householdId` en clair,
+ *   pas de message d'erreur brut, pas de trace d'exécution, pas de content.
+ * - **Pseudonymisation du foyer** : `householdPseudonym = BLAKE2b(householdId,
+ *   app_secret, 8 bytes)`. Le `app_secret` est un sel applicatif injecté par
+ *   l'app hôte, jamais stocké côté relai. Voir `blake2bHex` dans `@kinhale/crypto`.
+ * - **Rate limit** : 100 événements / 60 s par `householdPseudonym`. Au-delà,
+ *   un seul événement agrégé `sync.decrypt_failed_storm` est émis avec le
+ *   compteur des événements supprimés.
+ * - **Pas de persistance** : la fenêtre de rate limit vit en mémoire uniquement
+ *   (reset au remontage du hook, à la fermeture de l'onglet, au restart mobile).
+ *
+ * Refs: KIN-040, KIN-038 (§M2), ADR-D9.
+ */
+
+/** Classes d'erreur coarses exposées en télémétrie. */
+export type DecryptErrorClass = 'decrypt' | 'parse' | 'unknown';
+
+/** Nom d'événement émis. */
+export type DecryptFailedEventName = 'sync.decrypt_failed' | 'sync.decrypt_failed_storm';
+
+/**
+ * Schéma **exhaustif** de l'événement émis en télémétrie.
+ *
+ * ⚠️ **Invariant sécurité** : aucun autre champ ne doit jamais être ajouté
+ * sans passer par une revue `kz-securite`. Un test dédié vérifie qu'aucune
+ * clé hors whitelist n'apparaît dans l'événement émis.
+ */
+export interface DecryptFailedEvent {
+  /** Nom discriminant — permet au backend de router unitaire vs agrégé. */
+  readonly name: DecryptFailedEventName;
+  /** ISO 8601 arrondi à la minute (réduction d'entropie temporelle). */
+  readonly timestamp: string;
+  /** Plateforme émettrice — utile pour corréler côté ops. */
+  readonly platform: 'web' | 'mobile';
+  /** Classe d'erreur coarse — pas de message brut. */
+  readonly errorClass: DecryptErrorClass;
+  /** Numéro de séquence monotone du message. */
+  readonly seq: number;
+  /** BLAKE2b keyed du householdId — non réversible côté relai / Sentry. */
+  readonly householdPseudonym: string;
+  /**
+   * Uniquement présent sur `sync.decrypt_failed_storm` : compteur agrégé
+   * des événements supprimés pendant la fenêtre.
+   */
+  readonly count?: number;
+}
+
+/** Fonction d'émission injectée (Sentry, CloudWatch, console, etc.). */
+export type ReportDecryptFailed = (event: DecryptFailedEvent) => void;
+
+/** Fonction de pseudonymisation injectée (BLAKE2b keyed avec app_secret). */
+export type HashHousehold = (householdId: string) => string;
+
+/** Fenêtre de rate limit — **privée au module**, pas persistée. */
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX = 100;
+
+/** État par foyer pseudonymisé. */
+interface WindowState {
+  windowStartMs: number;
+  /** Nombre total d'événements observés dans la fenêtre (y compris supprimés). */
+  total: number;
+}
+
+/**
+ * Classifie une exception en catégorie coarse.
+ *
+ * ⚠️ **Ne jamais inclure `err.message` ou `err.stack`** — risque de leak de
+ * données santé si le message embarque un contexte (type de pompe, ID enfant).
+ *
+ * Heuristique : on inspecte **uniquement** `err.name` (valeur connue du code)
+ * et le type de l'objet. On ne lit jamais `err.message`.
+ */
+export function classifyDecryptError(err: unknown): DecryptErrorClass {
+  if (err instanceof SyntaxError) {
+    // JSON.parse côté consumeSyncMessage → payload mal formé.
+    return 'parse';
+  }
+  if (err instanceof Error) {
+    // Tout le reste tombe sous "decrypt" : MAC invalide, clé incorrecte,
+    // nonce rejoué, etc. — comportement attendu en cas d'attaque MITM ou
+    // de désynchronisation de clé.
+    return 'decrypt';
+  }
+  return 'unknown';
+}
+
+/** Arrondit un timestamp à la minute (réduction d'entropie). */
+function isoMinute(nowMs: number): string {
+  const rounded = Math.floor(nowMs / 60_000) * 60_000;
+  return new Date(rounded).toISOString();
+}
+
+/**
+ * Crée un rapporteur d'événements `sync.decrypt_failed` avec rate-limit
+ * glissant en mémoire.
+ *
+ * Le rapporteur retourné est **autonome** : il gère sa propre fenêtre.
+ * Il faut en créer un nouveau par instance de hook (fait dans `useRelaySync`
+ * via `useRef`).
+ */
+export function createDecryptFailedReporter(deps: {
+  readonly platform: 'web' | 'mobile';
+  readonly hashHousehold: HashHousehold;
+  readonly report?: ReportDecryptFailed;
+  /** Horloge injectable pour tests. Par défaut `Date.now`. */
+  readonly now?: () => number;
+}): {
+  readonly track: (params: {
+    householdId: string;
+    errorClass: DecryptErrorClass;
+    seq: number;
+  }) => void;
+  /**
+   * À appeler au démontage : flush l'événement `_storm` en cours si le
+   * compteur de fenêtre contient encore des suppressions non reportées.
+   */
+  readonly flush: () => void;
+} {
+  const now = deps.now ?? Date.now;
+  const windows = new Map<string, WindowState>();
+
+  function maybeEmitStorm(pseudonym: string, state: WindowState): void {
+    if (deps.report === undefined) return;
+    const suppressed = state.total - RATE_LIMIT_MAX;
+    if (suppressed <= 0) return;
+    deps.report({
+      name: 'sync.decrypt_failed_storm',
+      timestamp: isoMinute(state.windowStartMs),
+      platform: deps.platform,
+      errorClass: 'unknown',
+      seq: 0,
+      householdPseudonym: pseudonym,
+      count: suppressed,
+    });
+  }
+
+  return {
+    track({ householdId, errorClass, seq }): void {
+      // Pseudonymise AVANT tout traitement — le householdId ne doit pas
+      // exister en clair au-delà de cette ligne dans le module télémétrie.
+      const pseudonym = deps.hashHousehold(householdId);
+      const currentMs = now();
+
+      let state = windows.get(pseudonym);
+      if (state === undefined || currentMs - state.windowStartMs >= RATE_LIMIT_WINDOW_MS) {
+        // Si la fenêtre précédente avait dépassé le seuil, on flushe son
+        // storm aggregate avant de la remplacer.
+        if (state !== undefined) {
+          maybeEmitStorm(pseudonym, state);
+        }
+        state = { windowStartMs: currentMs, total: 0 };
+        windows.set(pseudonym, state);
+      }
+
+      state.total += 1;
+
+      if (state.total <= RATE_LIMIT_MAX) {
+        if (deps.report === undefined) return;
+        deps.report({
+          name: 'sync.decrypt_failed',
+          timestamp: isoMinute(currentMs),
+          platform: deps.platform,
+          errorClass,
+          seq,
+          householdPseudonym: pseudonym,
+        });
+      }
+      // Au-delà de RATE_LIMIT_MAX, on ne fait rien de plus ici : le storm
+      // sera émis à la bascule de fenêtre (ou au flush).
+    },
+    flush(): void {
+      for (const [pseudonym, state] of windows) {
+        maybeEmitStorm(pseudonym, state);
+      }
+      windows.clear();
+    },
+  };
+}

--- a/packages/sync/src/client/telemetry.ts
+++ b/packages/sync/src/client/telemetry.ts
@@ -78,19 +78,25 @@ interface WindowState {
  *
  * Heuristique : on inspecte **uniquement** `err.name` (valeur connue du code)
  * et le type de l'objet. On ne lit jamais `err.message`.
+ *
+ * Robustesse cross-realm : le check `instanceof SyntaxError` casse si l'erreur
+ * provient d'un autre realm JS (WebWorker, iframe, bridge React Native) car le
+ * constructeur `SyntaxError` est distinct d'un realm à l'autre. On ajoute un
+ * fallback sur `err.name === 'SyntaxError'` qui est préservé au travers des
+ * bridges (simple string, sérialisée tel quel).
  */
 export function classifyDecryptError(err: unknown): DecryptErrorClass {
-  if (err instanceof SyntaxError) {
+  if (!(err instanceof Error)) {
+    return 'unknown';
+  }
+  if (err instanceof SyntaxError || err.name === 'SyntaxError') {
     // JSON.parse côté consumeSyncMessage → payload mal formé.
     return 'parse';
   }
-  if (err instanceof Error) {
-    // Tout le reste tombe sous "decrypt" : MAC invalide, clé incorrecte,
-    // nonce rejoué, etc. — comportement attendu en cas d'attaque MITM ou
-    // de désynchronisation de clé.
-    return 'decrypt';
-  }
-  return 'unknown';
+  // Tout le reste tombe sous "decrypt" : MAC invalide, clé incorrecte,
+  // nonce rejoué, etc. — comportement attendu en cas d'attaque MITM ou
+  // de désynchronisation de clé.
+  return 'decrypt';
 }
 
 /** Arrondit un timestamp à la minute (réduction d'entropie). */
@@ -137,7 +143,10 @@ export function createDecryptFailedReporter(deps: {
       timestamp: isoMinute(state.windowStartMs),
       platform: deps.platform,
       errorClass: 'unknown',
-      seq: 0,
+      // `seq: -1` sentinelle explicite : un storm agrège N événements dont les
+      // `seq` individuels ont été volontairement omis. Ne jamais confondre avec
+      // un vrai numéro de séquence (qui est toujours >= 0 côté buildSyncMessage).
+      seq: -1,
       householdPseudonym: pseudonym,
       count: suppressed,
     });

--- a/packages/sync/src/client/useRelaySync.ts
+++ b/packages/sync/src/client/useRelaySync.ts
@@ -122,12 +122,12 @@ export function useRelaySync(deps: UseRelaySyncDeps): { connected: boolean } {
 
   // Reporter de télémétrie `sync.decrypt_failed` (KIN-040). Stable pour la
   // durée de vie du hook — le rate-limiter vit dans la closure du reporter.
-  // La plateforme, le hashHousehold et reportDecryptFailed sont relus via
-  // refs ci-dessous pour ne jamais invalider l'effet WS.
-  const platformRef = React.useRef(deps.platform);
+  // `platform` est capturé une seule fois à la première création (valeur
+  // immuable côté wrappers web/mobile). `hashHousehold` et `reportDecryptFailed`
+  // sont relus via refs pour ne jamais invalider l'effet WS tout en captant
+  // la dernière valeur injectée par les wrappers.
   const hashHouseholdRef = React.useRef(deps.hashHousehold);
   const reportDecryptFailedRef = React.useRef(deps.reportDecryptFailed);
-  platformRef.current = deps.platform;
   hashHouseholdRef.current = deps.hashHousehold;
   reportDecryptFailedRef.current = deps.reportDecryptFailed;
 
@@ -136,7 +136,7 @@ export function useRelaySync(deps: UseRelaySyncDeps): { connected: boolean } {
   );
   if (telemetryReporterRef.current === null) {
     telemetryReporterRef.current = createDecryptFailedReporter({
-      platform: platformRef.current,
+      platform: deps.platform,
       hashHousehold: (id) => hashHouseholdRef.current(id),
       report: (event) => reportDecryptFailedRef.current?.(event),
     });

--- a/packages/sync/src/client/useRelaySync.ts
+++ b/packages/sync/src/client/useRelaySync.ts
@@ -10,6 +10,12 @@ import {
 } from '../index.js';
 import type { SyncCursor } from '../index.js';
 import type { KinhaleDoc } from '../doc/schema.js';
+import {
+  classifyDecryptError,
+  createDecryptFailedReporter,
+  type HashHousehold,
+  type ReportDecryptFailed,
+} from './telemetry.js';
 
 /** Document Automerge d'un foyer (alias pour lisibilité). */
 type KinhaleDocument = A.Doc<KinhaleDoc>;
@@ -60,6 +66,24 @@ export interface UseRelaySyncDeps {
   readonly createRelayClient: CreateRelayClient;
   /** Dérive la groupKey (Argon2id, cachée) pour un foyer. */
   readonly deriveGroupKey: (householdId: string) => Promise<Uint8Array>;
+  /**
+   * Identifiant de plateforme émettrice, utilisé uniquement dans la
+   * télémétrie pseudonymisée (champ `platform`).
+   */
+  readonly platform: 'web' | 'mobile';
+  /**
+   * Pseudonymise un `householdId` (BLAKE2b keyed avec l'app_secret de l'app).
+   * **Obligatoire** — la fonction doit toujours produire une sortie non
+   * réversible (voir `blake2bHex` dans `@kinhale/crypto`). Jamais d'identité.
+   */
+  readonly hashHousehold: HashHousehold;
+  /**
+   * Rapporteur d'événements `sync.decrypt_failed` / `_storm`. Optionnel :
+   * si omis, le hook fonctionne exactement comme avant (no-op silencieux).
+   * Aucune donnée santé ne doit transiter par cette fonction — le schéma
+   * d'événement est figé par le type `DecryptFailedEvent`.
+   */
+  readonly reportDecryptFailed?: ReportDecryptFailed;
 }
 
 /**
@@ -95,6 +119,28 @@ export function useRelaySync(deps: UseRelaySyncDeps): { connected: boolean } {
   const cursorRef = React.useRef<SyncCursor>(createCursor());
   const seqRef = React.useRef(0);
   const keyRef = React.useRef<Uint8Array | null>(null);
+
+  // Reporter de télémétrie `sync.decrypt_failed` (KIN-040). Stable pour la
+  // durée de vie du hook — le rate-limiter vit dans la closure du reporter.
+  // La plateforme, le hashHousehold et reportDecryptFailed sont relus via
+  // refs ci-dessous pour ne jamais invalider l'effet WS.
+  const platformRef = React.useRef(deps.platform);
+  const hashHouseholdRef = React.useRef(deps.hashHousehold);
+  const reportDecryptFailedRef = React.useRef(deps.reportDecryptFailed);
+  platformRef.current = deps.platform;
+  hashHouseholdRef.current = deps.hashHousehold;
+  reportDecryptFailedRef.current = deps.reportDecryptFailed;
+
+  const telemetryReporterRef = React.useRef<ReturnType<typeof createDecryptFailedReporter> | null>(
+    null,
+  );
+  if (telemetryReporterRef.current === null) {
+    telemetryReporterRef.current = createDecryptFailedReporter({
+      platform: platformRef.current,
+      hashHousehold: (id) => hashHouseholdRef.current(id),
+      report: (event) => reportDecryptFailedRef.current?.(event),
+    });
+  }
 
   // Dépendance sur `docReady` (booléen dérivé) pour éviter de rouvrir la WS à
   // chaque mutation du doc. La connexion ne se (re)crée que quand auth ou doc
@@ -140,10 +186,17 @@ export function useRelaySync(deps: UseRelaySyncDeps): { connected: boolean } {
             receiveChanges(deltaChanges);
             cursorRef.current = recordReceived(cursorRef.current, deltaChanges);
           }
-        } catch {
-          // Message invalide, corrompu ou clé incorrecte — ignoré silencieusement.
-          // Aucune donnée santé dans les logs (principe zero-knowledge).
-          // Refs: KIN-040 (télémétrie sync.decrypt_failed à ajouter post-KIN-039).
+        } catch (err: unknown) {
+          // Message invalide, corrompu ou clé incorrecte — la sync continue.
+          // Aucune donnée santé n'est loggée : on n'émet qu'un événement de
+          // télémétrie pseudonymisé (payload figé par `DecryptFailedEvent`),
+          // jamais `err.message` ni `err.stack`.
+          // Refs: KIN-040, kz-securite-KIN-038.md §M2.
+          telemetryReporterRef.current?.track({
+            householdId,
+            errorClass: classifyDecryptError(err),
+            seq: msg.seq,
+          });
         }
       });
 
@@ -157,6 +210,8 @@ export function useRelaySync(deps: UseRelaySyncDeps): { connected: boolean } {
       clientRef.current = null;
       keyRef.current = null;
       setConnected(false);
+      // Flush le storm en cours avant de perdre la fenêtre rate-limit.
+      telemetryReporterRef.current?.flush();
     };
   }, [accessToken, deviceId, householdId, docReady, receiveChanges]);
 


### PR DESCRIPTION
## Contexte

L'issue #191 demandait d'instrumenter le `try/catch` silencieux autour de `consumeSyncMessage` laissé par KIN-038 PR A/B (zone aveugle opérationnelle en cas d'échec crypto / attaque MITM). Grâce au refactor KIN-039, le fix se fait une seule fois dans `packages/sync/src/client/` et couvre web + mobile.

⚠️ Zone ultra-critique : crypto + télémétrie + données santé. Revues qualité + sécurité passées **avant** ouverture.

## Ce qui est livré

### Nouveau module : `packages/sync/src/client/telemetry.ts`
- `DecryptFailedEvent` (type `readonly`) : schéma strict — `name`, `timestamp` (ISO 8601 arrondi minute), `platform`, `errorClass`, `seq`, `householdPseudonym`. **Aucun** autre champ autorisé.
- `classifyDecryptError(err)` → `'parse' | 'decrypt' | 'unknown'` : classification **cross-realm robuste** sans jamais lire `err.message` (invariant testé).
- Rate limit **100 événements / 60s par pseudonyme** → au-delà, un seul événement agrégé `sync.decrypt_failed_storm` (avec `count`, `seq: -1` sentinelle).
- Isolation par foyer, reset de fenêtre, flush idempotent au démontage.

### Nouvelle primitive crypto : `packages/crypto/src/hash/blake2b.ts`
- Wrapper `crypto_generichash` libsodium.
- Tests incluent **test vector RFC 7693** (BLAKE2b-512 de `"abc"`) + ancre de régression BLAKE2b-256.

### Intégration dans `useRelaySync`
- `UseRelaySyncDeps` étendu avec `hashHousehold` (obligatoire) et `reportDecryptFailed?` (optionnel → rétro-compat).
- Chemin d'erreur instrumenté, chemin succès strictement inchangé.

### Wrappers applicatifs (`apps/{web,mobile}/src/lib/sync/index.ts`)
- `hashHousehold` via BLAKE2b keyed avec `APP_SECRET` + placeholder FNV-1a pendant le warm-up async (fenêtre < 1 ms en pratique).
- `reportDecryptFailed` : `console.info` préfixé `[kinhale.sync]` pour v1.0 (intégration Sentry réelle : ticket ultérieur).
- `APP_SECRET` : lu depuis env (`NEXT_PUBLIC_KINHALE_APP_SECRET` web / `expo-constants.extra` mobile), fallback dev `'dev-secret-v1'` **avec warn si prod**.

## Garanties zero-knowledge (vérifiées par test dédié)

Un test de scrubbing émet un événement depuis un blob malicieux contenant `'child-Léo ventoline 2mg'` dans le message d'erreur → **aucun** de ces tokens ne se retrouve dans le payload émis. Whitelist `ALLOWED_KEYS` + blacklist testée (`householdId`, `doseId`, `childId`, `pumpId`, `message`, `stack`, `rawError`, `blobJson`, `token`, etc.).

## Revues préalables

### `kz-review` — APPROUVÉ sous réserve
Tous les MINEURS pertinents corrigés dans le commit `440907e` (`.catch` blake2bHex, `platformRef` inutile retiré, `seq` storm clarifié, commentaires collisions FNV-1a, warn APP_SECRET prod, JSDoc BLAKE2b).

### `kz-securite` — 0 P0/P1 bloquant
**1 MAJEUR corrigé dans cette PR** :
- **M1** : `classifyDecryptError` utilisait `instanceof SyntaxError` fragile cross-realm (WebWorker / iframe / RN bridge). Fix : fallback `err.name === 'SyntaxError'`. Test cross-realm ajouté.

**5 MINEURS** évalués :
- 2 corrigés (m2 `.catch` blake2bHex, m3 warn APP_SECRET prod, m4/m5 JSDoc)
- 1 en ticket de suivi (`m1` — Map sans TTL, non critique en usage réel)

Rapports : `.agents/current-run/kz-review-KIN-040.md`, `.agents/current-run/kz-securite-KIN-040.md`.

## Diff-stat

**12 fichiers, +1157 / -8 lignes.** PR grosse mais **justifiée** par la cohérence web+mobile en une seule PR (exigence explicite de l'issue #191 pour éviter la double implémentation).

## Plan de test

- [x] `pnpm --filter @kinhale/crypto test` — **94/94**
- [x] `pnpm --filter @kinhale/sync test` — **101/101**
- [x] `pnpm --filter @kinhale/web test` — **91/91**
- [x] `pnpm --filter @kinhale/mobile test` — **69/69**
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `pnpm lint:root` — **tous verts**
- [ ] Test manuel post-merge : provoquer un échec de déchiffrement (blob tampered) → vérifier un `[kinhale.sync] sync.decrypt_failed` dans la console sans aucune donnée santé.

## Invariants préservés

- **Zero-knowledge** : `groupKey` toujours exclusivement en mémoire. `householdPseudonym` non réversible (BLAKE2b keyed).
- **Aucune donnée santé** dans les logs ni le payload télémétrie (test défensif actif).
- **Pas de nouvelle dépendance npm** (BLAKE2b via `crypto_generichash` libsodium déjà présent).
- **Comportement succès** du hook strictement inchangé.

## Conformité Loi 25 / RGPD

Le `householdPseudonym` est stable dans le temps et constitue une donnée personnelle indirecte. v1.0 : `console.info` local uniquement, pas de transfert réseau. **L'intégration Sentry future devra repasser par `kz-conformite`** (à tracer dans le plan).

## Tickets de suivi à ouvrir après merge

- **KIN-041** : Map `windows` TTL éviction (MINEUR sécu m1)
- **KIN-042** : `APP_SECRET` spécifique par env via CDK (MINEUR sécu m3 infra)
- Intégration Sentry réelle : PR dédiée, avec audit `kz-conformite`

Refs: KIN-040
Closes: #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)