### PR TITLE
feat(KIN-038 PR C): scheduler rappels de dose + détection dose manquée (RM25)

### DIFF
--- a/apps/mobile/src/__mocks__/expo-notifications.ts
+++ b/apps/mobile/src/__mocks__/expo-notifications.ts
@@ -9,6 +9,7 @@ export const addNotificationResponseReceivedListener = jest
   .mockReturnValue({ remove: jest.fn() });
 export const scheduleNotificationAsync = jest.fn().mockResolvedValue('notification-id-mock');
 export const cancelScheduledNotificationAsync = jest.fn().mockResolvedValue(undefined);
+export const getAllScheduledNotificationsAsync = jest.fn().mockResolvedValue([]);
 export const setNotificationHandler = jest.fn();
 
 export const AndroidImportance = { MAX: 5 };

--- a/apps/mobile/src/lib/sync/index.ts
+++ b/apps/mobile/src/lib/sync/index.ts
@@ -1,5 +1,9 @@
+import { useTranslation } from 'react-i18next';
+import * as Notifications from 'expo-notifications';
 import {
   useRelaySync as useRelaySyncCore,
+  useReminderScheduler as useReminderSchedulerCore,
+  useMissedDoseWatcher as useMissedDoseWatcherCore,
   getGroupKey,
   type DecryptFailedEvent,
 } from '@kinhale/sync/client';
@@ -143,5 +147,88 @@ export function useRelaySync(): { connected: boolean } {
  */
 export function RelaySyncBootstrap(): null {
   useRelaySync();
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Rappels de dose (KIN-038) : scheduler + watcher missed.
+// ---------------------------------------------------------------------------
+
+/**
+ * Programme une notification locale Expo au `triggerAtUtc`. Si l'instant est
+ * dans le passé, Expo rejette silencieusement ; on renvoie une Promise
+ * résolue pour ne pas polluer la sync du hook.
+ *
+ * Pas de donnée santé dans `title`/`body` — chaînes déjà traduites passées
+ * par le hook (contrat `UseReminderSchedulerDeps.reminderTitle` / `reminderBody`).
+ */
+async function scheduleLocalNotification(args: {
+  id: string;
+  triggerAtUtc: string;
+  title: string;
+  body: string;
+}): Promise<void> {
+  const seconds = Math.max(1, Math.floor((Date.parse(args.triggerAtUtc) - Date.now()) / 1000));
+  await Notifications.scheduleNotificationAsync({
+    identifier: args.id,
+    content: { title: args.title, body: args.body },
+    trigger: {
+      type: Notifications.SchedulableTriggerInputTypes.TIME_INTERVAL,
+      seconds,
+    },
+  });
+}
+
+async function cancelLocalNotification(id: string): Promise<void> {
+  try {
+    await Notifications.cancelScheduledNotificationAsync(id);
+  } catch {
+    // Identifier inconnu côté Expo : aucun log (pas d'info pertinente à
+    // surveiller ; pas de donnée santé à exfiltrer).
+  }
+}
+
+async function notifyMissedDoseNow(args: {
+  id: string;
+  title: string;
+  body: string;
+}): Promise<void> {
+  await Notifications.scheduleNotificationAsync({
+    identifier: args.id,
+    content: { title: args.title, body: args.body },
+    trigger: null, // immédiat
+  });
+}
+
+/**
+ * Monte le scheduler de rappels (E5-S01 + E5-S02) et le watcher de doses
+ * manquées (E5-S03) en arrière-plan. Dépend de i18next pour les chaînes —
+ * à inclure **sous** le `I18nextProvider`.
+ */
+export function RemindersBootstrap(): null {
+  const { t } = useTranslation('common');
+
+  useReminderSchedulerCore({
+    useDoc: () => useDocStore((s) => s.doc),
+    scheduleLocalNotification,
+    cancelLocalNotification,
+    now: () => new Date(),
+    reminderTitle: t('reminder.title'),
+    reminderBody: t('reminder.body'),
+  });
+
+  useMissedDoseWatcherCore({
+    useDoc: () => useDocStore((s) => s.doc),
+    // v1.0 : pas de persistance du statut `missed` dans le doc Automerge
+    // (pas d'événement `ReminderStatusChanged` défini). La transition est
+    // donc purement en mémoire pour l'instant ; elle sera branchée dès que
+    // le format d'événement sera stabilisé (ticket de suivi).
+    markReminderMissed: () => undefined,
+    notifyMissedDose: notifyMissedDoseNow,
+    now: () => new Date(),
+    missedDoseTitle: t('missed_dose.title'),
+    missedDoseBody: t('missed_dose.body'),
+  });
+
   return null;
 }

--- a/apps/mobile/src/lib/sync/index.ts
+++ b/apps/mobile/src/lib/sync/index.ts
@@ -188,6 +188,45 @@ async function cancelLocalNotification(id: string): Promise<void> {
   }
 }
 
+/**
+ * Préfixe déterministe des identifiants de rappels projetés depuis le doc
+ * (`r:<planId>:<targetIso>` — cf. `packages/sync/src/projections/reminders.ts`).
+ * Utilisé pour filtrer les notifications Expo au moment de l'hydratation :
+ * on ne veut repeupler `scheduledIdsRef` qu'avec des ids de ce canal, pas
+ * d'autres notifs OS (pushs, locales hors rappels) qui pourraient exister.
+ */
+const REMINDER_ID_PREFIX = 'r:';
+
+/**
+ * Hydratation cross-session côté mobile : au montage, reconstruit la liste
+ * des ids de rappels déjà programmés côté OS. Essentiel car
+ * `scheduledIdsRef` côté React est vide après un redémarrage du process
+ * RN ou un logout/re-login, alors que les notifs Expo persistent — sans
+ * ça, on (re)programmerait par-dessus, risquant des doublons Android sur
+ * expo-notifications < 0.29.
+ *
+ * Échec silencieux : `getAllScheduledNotificationsAsync` peut rejeter si
+ * le module natif n'est pas encore prêt (cold start). On retourne `[]` et
+ * on laisse le hook continuer best-effort.
+ *
+ * Refs: KIN-038 (kz-securite M1).
+ */
+async function hydrateScheduledReminderIds(): Promise<ReadonlyArray<string>> {
+  try {
+    const scheduled = await Notifications.getAllScheduledNotificationsAsync();
+    const ids: string[] = [];
+    for (const entry of scheduled) {
+      const id = entry.identifier;
+      if (typeof id === 'string' && id.startsWith(REMINDER_ID_PREFIX)) {
+        ids.push(id);
+      }
+    }
+    return ids;
+  } catch {
+    return [];
+  }
+}
+
 async function notifyMissedDoseNow(args: {
   id: string;
   title: string;
@@ -212,6 +251,7 @@ export function RemindersBootstrap(): null {
     useDoc: () => useDocStore((s) => s.doc),
     scheduleLocalNotification,
     cancelLocalNotification,
+    hydrateScheduledIds: hydrateScheduledReminderIds,
     now: () => new Date(),
     reminderTitle: t('reminder.title'),
     reminderBody: t('reminder.body'),

--- a/apps/mobile/src/providers/index.tsx
+++ b/apps/mobile/src/providers/index.tsx
@@ -3,7 +3,7 @@ import { TamaguiProvider } from 'tamagui';
 import { I18nextProvider } from 'react-i18next';
 import config from '../lib/tamagui.config';
 import i18n from '../lib/i18n';
-import { RelaySyncBootstrap } from '../lib/sync';
+import { RelaySyncBootstrap, RemindersBootstrap } from '../lib/sync';
 
 export function Providers({ children }: { children: ReactNode }): JSX.Element {
   return (
@@ -11,6 +11,8 @@ export function Providers({ children }: { children: ReactNode }): JSX.Element {
       <TamaguiProvider config={config} defaultTheme="light">
         {/* Monte la sync WS E2EE bidirectionnelle en arrière-plan */}
         <RelaySyncBootstrap />
+        {/* Programme les rappels de dose + surveille les doses manquées */}
+        <RemindersBootstrap />
         {children}
       </TamaguiProvider>
     </I18nextProvider>

--- a/apps/web/src/lib/sync/index.ts
+++ b/apps/web/src/lib/sync/index.ts
@@ -1,7 +1,10 @@
 'use client';
 
+import { useTranslation } from 'react-i18next';
 import {
   useRelaySync as useRelaySyncCore,
+  useReminderScheduler as useReminderSchedulerCore,
+  useMissedDoseWatcher as useMissedDoseWatcherCore,
   getGroupKey,
   type DecryptFailedEvent,
 } from '@kinhale/sync/client';
@@ -159,5 +162,112 @@ export function useRelaySync(): { connected: boolean } {
  */
 export function RelaySyncBootstrap(): null {
   useRelaySync();
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Rappels de dose (KIN-038) : scheduler + watcher missed.
+// ---------------------------------------------------------------------------
+
+/**
+ * État interne minimal : mapping `reminderId → setTimeout handle` pour les
+ * rappels programmés via l'API Web Notifications. Limité à la session
+ * onglet : à la fermeture de l'onglet, les timers sont perdus — c'est
+ * acceptable car un onglet fermé n'a de toute façon pas de notif active.
+ *
+ * Pour la v1.0, le web est secondaire (le vrai moteur de rappels est
+ * mobile natif). L'implémentation web assure une expérience cohérente
+ * quand l'app est ouverte, et reste un no-op silencieux si l'API
+ * Notifications n'est pas disponible (SSR, navigateur désactivé, permission
+ * refusée).
+ */
+const webReminderTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function hasWebNotifications(): boolean {
+  return typeof window !== 'undefined' && 'Notification' in window;
+}
+
+async function ensureWebNotificationPermission(): Promise<boolean> {
+  if (!hasWebNotifications()) return false;
+  if (Notification.permission === 'granted') return true;
+  if (Notification.permission === 'denied') return false;
+  const result = await Notification.requestPermission();
+  return result === 'granted';
+}
+
+async function scheduleLocalNotificationWeb(args: {
+  id: string;
+  triggerAtUtc: string;
+  title: string;
+  body: string;
+}): Promise<void> {
+  const granted = await ensureWebNotificationPermission();
+  if (!granted) return;
+
+  const delayMs = Math.max(0, Date.parse(args.triggerAtUtc) - Date.now());
+  const existing = webReminderTimers.get(args.id);
+  if (existing !== undefined) clearTimeout(existing);
+
+  const handle = setTimeout(() => {
+    webReminderTimers.delete(args.id);
+    if (hasWebNotifications() && Notification.permission === 'granted') {
+      // Payload minimal — aucune donnée santé. Conforme RM16 + CLAUDE.md.
+      new Notification(args.title, { body: args.body, tag: args.id });
+    }
+  }, delayMs);
+  webReminderTimers.set(args.id, handle);
+}
+
+async function cancelLocalNotificationWeb(id: string): Promise<void> {
+  const handle = webReminderTimers.get(id);
+  if (handle !== undefined) {
+    clearTimeout(handle);
+    webReminderTimers.delete(id);
+  }
+}
+
+async function notifyMissedDoseNowWeb(args: {
+  id: string;
+  title: string;
+  body: string;
+}): Promise<void> {
+  const granted = await ensureWebNotificationPermission();
+  if (!granted) return;
+  if (hasWebNotifications() && Notification.permission === 'granted') {
+    new Notification(args.title, { body: args.body, tag: args.id });
+  }
+}
+
+/**
+ * Monte le scheduler de rappels (E5-S01 + E5-S02, best-effort côté web) et
+ * le watcher de doses manquées (E5-S03). Le web utilise l'API Web
+ * Notifications quand disponible ; sinon no-op silencieux (le vrai moteur
+ * de rappels est mobile natif, §9 SPECS).
+ */
+export function RemindersBootstrap(): null {
+  const { t } = useTranslation('common');
+
+  useReminderSchedulerCore({
+    useDoc: () => useDocStore((s) => s.doc),
+    scheduleLocalNotification: scheduleLocalNotificationWeb,
+    cancelLocalNotification: cancelLocalNotificationWeb,
+    now: () => new Date(),
+    reminderTitle: t('reminder.title'),
+    reminderBody: t('reminder.body'),
+  });
+
+  useMissedDoseWatcherCore({
+    useDoc: () => useDocStore((s) => s.doc),
+    // v1.0 : pas de persistance du statut `missed` dans le doc Automerge
+    // (pas d'événement `ReminderStatusChanged` défini). La transition reste
+    // en mémoire pour l'instant ; branchement prévu dès que le format
+    // d'événement sera stabilisé (ticket de suivi).
+    markReminderMissed: () => undefined,
+    notifyMissedDose: notifyMissedDoseNowWeb,
+    now: () => new Date(),
+    missedDoseTitle: t('missed_dose.title'),
+    missedDoseBody: t('missed_dose.body'),
+  });
+
   return null;
 }

--- a/apps/web/src/lib/sync/index.ts
+++ b/apps/web/src/lib/sync/index.ts
@@ -187,7 +187,38 @@ function hasWebNotifications(): boolean {
   return typeof window !== 'undefined' && 'Notification' in window;
 }
 
-async function ensureWebNotificationPermission(): Promise<boolean> {
+/**
+ * Vérifie si la permission Web Notifications est déjà accordée. **Ne
+ * déclenche jamais `Notification.requestPermission()`** — les navigateurs
+ * (Chrome, Firefox) recommandent fortement d'exiger un geste utilisateur
+ * avant la demande, sous peine de refus définitif (UX pattern browser).
+ *
+ * La demande est portée par {@link enableWebReminders}, qui doit être
+ * appelée depuis un handler de bouton UI (ticket de suivi : onboarding
+ * « Activer les rappels »).
+ */
+function isWebNotificationPermissionGranted(): boolean {
+  if (!hasWebNotifications()) return false;
+  return Notification.permission === 'granted';
+}
+
+/**
+ * Active explicitement les rappels web en demandant la permission à
+ * l'utilisateur. **DOIT être appelée depuis un event handler UI (clic
+ * d'un toggle réglages)** pour respecter le contrat Chrome/Firefox :
+ * `requestPermission` hors gesture est ignorée ou bloquée, et peut
+ * pousser le navigateur à poser `denied` de façon permanente.
+ *
+ * Retourne `true` si la permission est (ou vient d'être) accordée,
+ * `false` sinon (permission refusée, API indisponible, SSR). L'UI peut
+ * utiliser cette valeur pour afficher un état désactivé.
+ *
+ * TODO (ticket de suivi « Onboarding permission notifications web ») :
+ * brancher un toggle dans les réglages web ; tant que ce toggle n'est
+ * pas posé, le web reste no-op silencieux si l'utilisateur n'a pas
+ * activé la permission dans le navigateur par un autre canal.
+ */
+export async function enableWebReminders(): Promise<boolean> {
   if (!hasWebNotifications()) return false;
   if (Notification.permission === 'granted') return true;
   if (Notification.permission === 'denied') return false;
@@ -201,8 +232,9 @@ async function scheduleLocalNotificationWeb(args: {
   title: string;
   body: string;
 }): Promise<void> {
-  const granted = await ensureWebNotificationPermission();
-  if (!granted) return;
+  // Pas de demande intempestive de permission : si le user n'a pas encore
+  // activé les rappels web via `enableWebReminders`, no-op silencieux.
+  if (!isWebNotificationPermissionGranted()) return;
 
   const delayMs = Math.max(0, Date.parse(args.triggerAtUtc) - Date.now());
   const existing = webReminderTimers.get(args.id);
@@ -210,7 +242,7 @@ async function scheduleLocalNotificationWeb(args: {
 
   const handle = setTimeout(() => {
     webReminderTimers.delete(args.id);
-    if (hasWebNotifications() && Notification.permission === 'granted') {
+    if (isWebNotificationPermissionGranted()) {
       // Payload minimal — aucune donnée santé. Conforme RM16 + CLAUDE.md.
       new Notification(args.title, { body: args.body, tag: args.id });
     }
@@ -231,11 +263,11 @@ async function notifyMissedDoseNowWeb(args: {
   title: string;
   body: string;
 }): Promise<void> {
-  const granted = await ensureWebNotificationPermission();
-  if (!granted) return;
-  if (hasWebNotifications() && Notification.permission === 'granted') {
-    new Notification(args.title, { body: args.body, tag: args.id });
-  }
+  // Même contrat que `scheduleLocalNotificationWeb` : aucune demande
+  // implicite de permission. L'utilisateur doit l'avoir activée
+  // explicitement via `enableWebReminders`.
+  if (!isWebNotificationPermissionGranted()) return;
+  new Notification(args.title, { body: args.body, tag: args.id });
 }
 
 /**

--- a/apps/web/src/providers/index.tsx
+++ b/apps/web/src/providers/index.tsx
@@ -6,7 +6,7 @@ import { I18nextProvider } from 'react-i18next';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import config from '../lib/tamagui.config';
 import i18n from '../lib/i18n';
-import { RelaySyncBootstrap } from '../lib/sync';
+import { RelaySyncBootstrap, RemindersBootstrap } from '../lib/sync';
 
 export function Providers({ children }: { children: ReactNode }): JSX.Element {
   const [queryClient] = useState(() => new QueryClient());
@@ -17,6 +17,8 @@ export function Providers({ children }: { children: ReactNode }): JSX.Element {
         <TamaguiProvider config={config} defaultTheme="light">
           {/* Monte la sync WS E2EE bidirectionnelle en arrière-plan */}
           <RelaySyncBootstrap />
+          {/* Programme les rappels de dose + surveille les doses manquées */}
+          <RemindersBootstrap />
           {children}
         </TamaguiProvider>
       </I18nextProvider>

--- a/packages/domain/src/entities/index.ts
+++ b/packages/domain/src/entities/index.ts
@@ -5,4 +5,5 @@ export * from './household';
 export * from './invitation';
 export * from './plan';
 export * from './pump';
+export * from './reminder';
 export * from './role';

--- a/packages/domain/src/entities/reminder.test.ts
+++ b/packages/domain/src/entities/reminder.test.ts
@@ -34,9 +34,9 @@ describe('Reminder — isReminder (garde-fou structurel)', () => {
   });
 
   it('accepte un rappel confirmé avec confirmedByDoseId', () => {
-    expect(
-      isReminder({ ...validReminder, status: 'confirmed', confirmedByDoseId: 'dose-7' }),
-    ).toBe(true);
+    expect(isReminder({ ...validReminder, status: 'confirmed', confirmedByDoseId: 'dose-7' })).toBe(
+      true,
+    );
   });
 
   it('rejette un objet null ou non-objet', () => {

--- a/packages/domain/src/entities/reminder.test.ts
+++ b/packages/domain/src/entities/reminder.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { isReminder, REMINDER_STATUSES, type Reminder } from './reminder';
+
+const validReminder: Reminder = {
+  id: 'reminder-1',
+  planId: 'plan-abc',
+  targetAtUtc: '2026-04-22T08:00:00.000Z',
+  windowStartUtc: '2026-04-22T07:55:00.000Z',
+  windowEndUtc: '2026-04-22T08:30:00.000Z',
+  status: 'scheduled',
+};
+
+describe('Reminder — REMINDER_STATUSES', () => {
+  it('liste tous les statuts légaux (SPECS §3.7)', () => {
+    expect(REMINDER_STATUSES).toEqual([
+      'scheduled',
+      'sent',
+      'confirmed',
+      'missed',
+      'snoozed',
+      'cancelled',
+    ]);
+  });
+
+  it('est gelé comme readonly (annotation type, pas d’immuabilité runtime)', () => {
+    // Sanity check sur la cardinalité ; si on modifie l’enum, ce test saute.
+    expect(REMINDER_STATUSES).toHaveLength(6);
+  });
+});
+
+describe('Reminder — isReminder (garde-fou structurel)', () => {
+  it('accepte un rappel valide minimal', () => {
+    expect(isReminder(validReminder)).toBe(true);
+  });
+
+  it('accepte un rappel confirmé avec confirmedByDoseId', () => {
+    expect(
+      isReminder({ ...validReminder, status: 'confirmed', confirmedByDoseId: 'dose-7' }),
+    ).toBe(true);
+  });
+
+  it('rejette un objet null ou non-objet', () => {
+    expect(isReminder(null)).toBe(false);
+    expect(isReminder(undefined)).toBe(false);
+    expect(isReminder('reminder')).toBe(false);
+    expect(isReminder(42)).toBe(false);
+  });
+
+  it('rejette un rappel sans id / planId', () => {
+    expect(isReminder({ ...validReminder, id: '' })).toBe(false);
+    expect(isReminder({ ...validReminder, planId: '' })).toBe(false);
+    const { id: _id, ...sansId } = validReminder;
+    expect(isReminder(sansId)).toBe(false);
+  });
+
+  it('rejette un statut hors énumération', () => {
+    expect(isReminder({ ...validReminder, status: 'pending' })).toBe(false);
+    expect(isReminder({ ...validReminder, status: 42 })).toBe(false);
+  });
+
+  it('rejette des horodatages ISO invalides', () => {
+    expect(isReminder({ ...validReminder, targetAtUtc: 'not-a-date' })).toBe(false);
+    expect(isReminder({ ...validReminder, windowStartUtc: 'bad' })).toBe(false);
+    expect(isReminder({ ...validReminder, windowEndUtc: '' })).toBe(false);
+  });
+
+  it('rejette un confirmedByDoseId de type non-string', () => {
+    expect(isReminder({ ...validReminder, confirmedByDoseId: 42 })).toBe(false);
+  });
+
+  it('accepte confirmedByDoseId absent (optional)', () => {
+    // Explicitement absent, pas undefined (exactOptionalPropertyTypes).
+    const noDose: Reminder = {
+      id: 'r1',
+      planId: 'p1',
+      targetAtUtc: '2026-04-22T08:00:00Z',
+      windowStartUtc: '2026-04-22T07:55:00Z',
+      windowEndUtc: '2026-04-22T08:30:00Z',
+      status: 'scheduled',
+    };
+    expect(isReminder(noDose)).toBe(true);
+  });
+});

--- a/packages/domain/src/entities/reminder.ts
+++ b/packages/domain/src/entities/reminder.ts
@@ -1,0 +1,96 @@
+/**
+ * Statuts possibles d'un rappel de dose de fond (SPECS §3.7 — Rappel).
+ *
+ * Transitions légales (simplifiées pour v1.0 — le flux complet est porté par
+ * W4 et RM25) :
+ * - `scheduled` → `sent`        : le device a déclenché la notification locale à T-0.
+ * - `scheduled`/`sent` → `confirmed` : un aidant a saisi la dose dans la
+ *   fenêtre `[target - X, target + X]` (RM2). Le champ `confirmedByDoseId`
+ *   porte l'ID de la prise qui a clos le rappel.
+ * - `scheduled`/`sent` → `missed`    : la fenêtre s'est écoulée sans
+ *   confirmation (RM25). Les relances éventuelles sont portées par
+ *   `rm25-reminder-retries`.
+ * - `scheduled`/`sent` → `snoozed`  : report manuel par un aidant (W4 bis —
+ *   hors périmètre v1.0 PR C).
+ * - `scheduled`/`sent` → `cancelled` : plan mis en pause/archivé,
+ *   disparition de la pompe associée, etc.
+ */
+export type ReminderStatus =
+  | 'scheduled'
+  | 'sent'
+  | 'confirmed'
+  | 'missed'
+  | 'snoozed'
+  | 'cancelled';
+
+/**
+ * Rappel de dose de fond — entité purement projetée depuis le document
+ * Automerge (plans + doses confirmées). Aucun état de rappel n'est persisté
+ * comme événement domaine en v1.0 : la source de vérité reste le plan et les
+ * prises. Le statut est recalculé à chaque projection.
+ *
+ * Tous les instants sont en UTC (ISO 8601). La fenêtre de confirmation
+ * `[windowStartUtc, windowEndUtc]` est dérivée de RM2 (défaut ±X min autour
+ * de `targetAtUtc`, avec une pré-amorce de 5 min côté amont pour tolérer les
+ * avances de pompe).
+ *
+ * Zéro donnée santé : un `Reminder` ne référence ni le prénom de l'enfant,
+ * ni le nom de la pompe, ni la dose. Il n'expose que des identifiants opaques
+ * et des horodatages.
+ *
+ * Refs: SPECS §3.7 (structure), §9 (délais), §W4 (parcours), RM2, RM25.
+ */
+export interface Reminder {
+  /** UUID stable, déterministe : `planId + targetAtUtc` pour idempotence. */
+  readonly id: string;
+  /** Plan de traitement émetteur (RM3 : jamais une pompe de secours). */
+  readonly planId: string;
+  /** Heure cible prévue (ISO 8601 UTC). */
+  readonly targetAtUtc: string;
+  /** Début de la fenêtre de confirmation (ISO 8601 UTC). */
+  readonly windowStartUtc: string;
+  /** Fin de la fenêtre de confirmation (ISO 8601 UTC). */
+  readonly windowEndUtc: string;
+  /** Statut courant — voir {@link ReminderStatus}. */
+  readonly status: ReminderStatus;
+  /** Si `status === 'confirmed'`, ID de la prise qui a clos le rappel. */
+  readonly confirmedByDoseId?: string;
+}
+
+/** Ensemble fermé des statuts valides — utile pour valider un input externe. */
+export const REMINDER_STATUSES: ReadonlyArray<ReminderStatus> = [
+  'scheduled',
+  'sent',
+  'confirmed',
+  'missed',
+  'snoozed',
+  'cancelled',
+] as const;
+
+/**
+ * Garde-fou structurel — vérifie qu'un objet inconnu (ex. désérialisé d'un
+ * JSON tiers) est bien un `Reminder` valide. N'est **pas** un validateur
+ * métier (ne contrôle pas la cohérence des fenêtres ni des transitions).
+ *
+ * Utilisable côté tests et côté projection pour écarter les payloads
+ * malformés silencieusement (même pattern que `projectDoses`).
+ */
+export function isReminder(value: unknown): value is Reminder {
+  if (typeof value !== 'object' || value === null) return false;
+  const r = value as Record<string, unknown>;
+  if (typeof r['id'] !== 'string' || r['id'].length === 0) return false;
+  if (typeof r['planId'] !== 'string' || r['planId'].length === 0) return false;
+  if (typeof r['targetAtUtc'] !== 'string') return false;
+  if (typeof r['windowStartUtc'] !== 'string') return false;
+  if (typeof r['windowEndUtc'] !== 'string') return false;
+  if (typeof r['status'] !== 'string') return false;
+  if (!REMINDER_STATUSES.includes(r['status'] as ReminderStatus)) return false;
+  if (r['confirmedByDoseId'] !== undefined && typeof r['confirmedByDoseId'] !== 'string') {
+    return false;
+  }
+  // Les ISO strings doivent être parsables.
+  if (Number.isNaN(Date.parse(r['targetAtUtc']))) return false;
+  if (Number.isNaN(Date.parse(r['windowStartUtc']))) return false;
+  if (Number.isNaN(Date.parse(r['windowEndUtc']))) return false;
+  return true;
+}

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -90,7 +90,11 @@ export type {
   ReminderRetryStep,
   ReminderRetryStepIndex,
 } from './rm25-reminder-retries';
-export { detectMissedReminders, MISSED_ELIGIBLE_STATUSES } from './rm25-missed-dose';
+export {
+  detectMissedReminders,
+  MISSED_DOSE_CLOCK_SKEW_BUFFER_MS,
+  MISSED_ELIGIBLE_STATUSES,
+} from './rm25-missed-dose';
 export type { MissedReminder } from './rm25-missed-dose';
 export {
   DAILY_NOTIFICATION_HARD_CAP,

--- a/packages/domain/src/rules/index.ts
+++ b/packages/domain/src/rules/index.ts
@@ -90,6 +90,8 @@ export type {
   ReminderRetryStep,
   ReminderRetryStepIndex,
 } from './rm25-reminder-retries';
+export { detectMissedReminders, MISSED_ELIGIBLE_STATUSES } from './rm25-missed-dose';
+export type { MissedReminder } from './rm25-missed-dose';
 export {
   DAILY_NOTIFICATION_HARD_CAP,
   decidePeerNotification,

--- a/packages/domain/src/rules/rm25-missed-dose.test.ts
+++ b/packages/domain/src/rules/rm25-missed-dose.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import type { Reminder } from '../entities/reminder';
-import { detectMissedReminders, MISSED_ELIGIBLE_STATUSES } from './rm25-missed-dose';
+import {
+  detectMissedReminders,
+  MISSED_DOSE_CLOCK_SKEW_BUFFER_MS,
+  MISSED_ELIGIBLE_STATUSES,
+} from './rm25-missed-dose';
 
 function makeReminder(overrides: Partial<Reminder> = {}): Reminder {
   return {
@@ -87,5 +91,33 @@ describe('RM25 — detectMissedReminders', () => {
 
   it('MISSED_ELIGIBLE_STATUSES = [scheduled, sent]', () => {
     expect(MISSED_ELIGIBLE_STATUSES).toEqual(['scheduled', 'sent']);
+  });
+
+  describe('tolérance dérive d’horloge (MISSED_DOSE_CLOCK_SKEW_BUFFER_MS = 120s)', () => {
+    it('expose un buffer de 120 000 ms', () => {
+      expect(MISSED_DOSE_CLOCK_SKEW_BUFFER_MS).toBe(120_000);
+    });
+
+    it('ne bascule pas missed à windowEnd + 60s (dérive potentielle tolérée)', () => {
+      const reminder = makeReminder({ status: 'scheduled' });
+      const now = new Date(Date.parse(reminder.windowEndUtc) + 60_000);
+      expect(detectMissedReminders([reminder], now)).toEqual([]);
+    });
+
+    it('ne bascule pas missed exactement à windowEnd + buffer (borne stricte)', () => {
+      const reminder = makeReminder({ status: 'scheduled' });
+      const now = new Date(Date.parse(reminder.windowEndUtc) + MISSED_DOSE_CLOCK_SKEW_BUFFER_MS);
+      expect(detectMissedReminders([reminder], now)).toEqual([]);
+    });
+
+    it('bascule missed à windowEnd + buffer + 1s (au-delà du buffer)', () => {
+      const reminder = makeReminder({ status: 'scheduled' });
+      const now = new Date(
+        Date.parse(reminder.windowEndUtc) + MISSED_DOSE_CLOCK_SKEW_BUFFER_MS + 1_000,
+      );
+      const result = detectMissedReminders([reminder], now);
+      expect(result).toHaveLength(1);
+      expect(result[0]?.status).toBe('missed');
+    });
   });
 });

--- a/packages/domain/src/rules/rm25-missed-dose.test.ts
+++ b/packages/domain/src/rules/rm25-missed-dose.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import type { Reminder } from '../entities/reminder';
+import { detectMissedReminders, MISSED_ELIGIBLE_STATUSES } from './rm25-missed-dose';
+
+function makeReminder(overrides: Partial<Reminder> = {}): Reminder {
+  return {
+    id: 'r1',
+    planId: 'plan-1',
+    targetAtUtc: '2026-04-22T08:00:00.000Z',
+    windowStartUtc: '2026-04-22T07:55:00.000Z',
+    windowEndUtc: '2026-04-22T08:30:00.000Z',
+    status: 'scheduled',
+    ...overrides,
+  };
+}
+
+describe('RM25 — detectMissedReminders', () => {
+  const NOW_BEFORE = new Date('2026-04-22T07:50:00.000Z'); // avant la fenêtre
+  const NOW_IN_WINDOW = new Date('2026-04-22T08:10:00.000Z'); // dans la fenêtre
+  const NOW_AT_END = new Date('2026-04-22T08:30:00.000Z'); // borne stricte
+  const NOW_AFTER = new Date('2026-04-22T08:45:00.000Z'); // après la fenêtre
+
+  it('retourne un tableau vide si aucun rappel fourni', () => {
+    expect(detectMissedReminders([], NOW_AFTER)).toEqual([]);
+  });
+
+  it('ignore un rappel dont la fenêtre n’est pas encore passée (avant)', () => {
+    const reminder = makeReminder({ status: 'scheduled' });
+    expect(detectMissedReminders([reminder], NOW_BEFORE)).toEqual([]);
+  });
+
+  it('ignore un rappel dans sa fenêtre', () => {
+    const reminder = makeReminder({ status: 'scheduled' });
+    expect(detectMissedReminders([reminder], NOW_IN_WINDOW)).toEqual([]);
+  });
+
+  it('borne windowEndUtc est exclusive : à T=windowEnd, le rappel reste scheduled', () => {
+    const reminder = makeReminder({ status: 'scheduled' });
+    expect(detectMissedReminders([reminder], NOW_AT_END)).toEqual([]);
+  });
+
+  it('transitionne un rappel `scheduled` à `missed` une fois la fenêtre passée', () => {
+    const reminder = makeReminder({ status: 'scheduled' });
+    const result = detectMissedReminders([reminder], NOW_AFTER);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.status).toBe('missed');
+    expect(result[0]?.id).toBe('r1');
+    expect(result[0]?.targetAtUtc).toBe(reminder.targetAtUtc);
+  });
+
+  it('transitionne aussi un rappel `sent`', () => {
+    const reminder = makeReminder({ status: 'sent' });
+    const result = detectMissedReminders([reminder], NOW_AFTER);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.status).toBe('missed');
+  });
+
+  it.each(['confirmed', 'missed', 'snoozed', 'cancelled'] as const)(
+    'ignore un rappel déjà `%s` même si fenêtre dépassée',
+    (status) => {
+      const reminder = makeReminder({ status });
+      expect(detectMissedReminders([reminder], NOW_AFTER)).toEqual([]);
+    },
+  );
+
+  it('préserve l’ordre d’entrée et ne mute pas les rappels sources', () => {
+    const r1 = makeReminder({ id: 'r1', status: 'scheduled' });
+    const r2 = makeReminder({
+      id: 'r2',
+      status: 'scheduled',
+      windowEndUtc: '2026-04-22T09:00:00.000Z',
+    });
+    const snapshot = JSON.parse(JSON.stringify([r1, r2])) as Reminder[];
+    const now = new Date('2026-04-22T09:30:00.000Z');
+    const result = detectMissedReminders([r1, r2], now);
+    expect(result.map((r) => r.id)).toEqual(['r1', 'r2']);
+    // Les originaux ne sont pas mutés.
+    expect(r1.status).toBe('scheduled');
+    expect(r2.status).toBe('scheduled');
+    expect([r1, r2]).toEqual(snapshot);
+  });
+
+  it('ignore silencieusement un rappel avec windowEndUtc non parsable', () => {
+    const reminder = makeReminder({ windowEndUtc: 'not-a-date' });
+    expect(detectMissedReminders([reminder], NOW_AFTER)).toEqual([]);
+  });
+
+  it('MISSED_ELIGIBLE_STATUSES = [scheduled, sent]', () => {
+    expect(MISSED_ELIGIBLE_STATUSES).toEqual(['scheduled', 'sent']);
+  });
+});

--- a/packages/domain/src/rules/rm25-missed-dose.ts
+++ b/packages/domain/src/rules/rm25-missed-dose.ts
@@ -22,16 +22,33 @@ export const MISSED_ELIGIBLE_STATUSES: ReadonlyArray<Reminder['status']> = [
 const MISSED_ELIGIBLE_SET = new Set<Reminder['status']>(MISSED_ELIGIBLE_STATUSES);
 
 /**
+ * Tolérance appliquée sur `windowEndUtc` avant qu'un rappel ne soit
+ * considéré manqué. Protège contre une dérive d'horloge device (NTP cassé
+ * sur Android, tablette partagée en garderie) : si l'horloge locale est en
+ * avance de ~2 min, on évite de basculer prématurément un rappel dont la
+ * fenêtre est encore ouverte côté serveur / pairs.
+ *
+ * Valeur : 120 s — couvre les dérives observées sur parc public (< 60 s
+ * en régime nominal, pic autour de 90 s après reboot NTP), sans trop
+ * retarder la détection missed (O4 cible ≤ 60 s côté SLA produit mais le
+ * buffer ne s'ajoute qu'au **seuil de bascule**, pas à la latence du tick).
+ *
+ * Refs: KIN-038 (kz-securite M2).
+ */
+export const MISSED_DOSE_CLOCK_SKEW_BUFFER_MS = 120_000;
+
+/**
  * RM25 — détecte les rappels qui doivent transitionner vers `missed`.
  *
  * Un rappel est considéré manqué si :
  * - son `status` est `scheduled` ou `sent` (candidat à la confirmation —
  *   les états terminaux sont ignorés) ;
- * - l'instant courant dépasse **strictement** `windowEndUtc` (borne
- *   exclusive : à T = windowEndUtc la fenêtre est encore ouverte d'une
- *   milliseconde — cohérent avec RM2 qui traite la borne supérieure comme
- *   inclusive via la dose, mais côté rappel on évite un race avec la dose
- *   qui arrive à l'instant pile).
+ * - l'instant courant dépasse **strictement** `windowEndUtc +
+ *   MISSED_DOSE_CLOCK_SKEW_BUFFER_MS` (la borne nue reste exclusive : à
+ *   T = windowEndUtc la fenêtre est encore ouverte d'une milliseconde ;
+ *   on ajoute par-dessus un buffer de tolérance à la dérive d'horloge
+ *   pour éviter de trigger un « Dose non confirmée » pendant que les
+ *   pairs voient encore la fenêtre ouverte).
  *
  * Fonction **pure** : pas d'horloge injectée depuis le module (on reçoit
  * `now`), pas d'I/O. Retourne les rappels concernés en conservant leur
@@ -65,7 +82,7 @@ export function detectMissedReminders(
     // avec la robustesse des projections (jamais de crash côté lecture).
     if (Number.isNaN(endMs)) continue;
 
-    if (nowMs > endMs) {
+    if (nowMs > endMs + MISSED_DOSE_CLOCK_SKEW_BUFFER_MS) {
       result.push({ ...reminder, status: 'missed' });
     }
   }

--- a/packages/domain/src/rules/rm25-missed-dose.ts
+++ b/packages/domain/src/rules/rm25-missed-dose.ts
@@ -1,0 +1,74 @@
+import type { Reminder } from '../entities/reminder';
+
+/**
+ * Variante de {@link Reminder} avec un statut strictement `missed` — sortie
+ * de {@link detectMissedReminders}. Permet au consommateur d'exprimer dans
+ * son type que la transition a bien été calculée.
+ */
+export type MissedReminder = Reminder & { status: 'missed' };
+
+/**
+ * Statuts dont un rappel doit partir pour pouvoir transitionner vers
+ * `missed`. `confirmed`, `missed`, `snoozed`, `cancelled` sont des états
+ * terminaux (ou déjà missed) — aucune nouvelle détection n'est possible.
+ *
+ * Exposé pour documentation ; l'implémentation utilise un set pour O(1).
+ */
+export const MISSED_ELIGIBLE_STATUSES: ReadonlyArray<Reminder['status']> = [
+  'scheduled',
+  'sent',
+] as const;
+
+const MISSED_ELIGIBLE_SET = new Set<Reminder['status']>(MISSED_ELIGIBLE_STATUSES);
+
+/**
+ * RM25 — détecte les rappels qui doivent transitionner vers `missed`.
+ *
+ * Un rappel est considéré manqué si :
+ * - son `status` est `scheduled` ou `sent` (candidat à la confirmation —
+ *   les états terminaux sont ignorés) ;
+ * - l'instant courant dépasse **strictement** `windowEndUtc` (borne
+ *   exclusive : à T = windowEndUtc la fenêtre est encore ouverte d'une
+ *   milliseconde — cohérent avec RM2 qui traite la borne supérieure comme
+ *   inclusive via la dose, mais côté rappel on évite un race avec la dose
+ *   qui arrive à l'instant pile).
+ *
+ * Fonction **pure** : pas d'horloge injectée depuis le module (on reçoit
+ * `now`), pas d'I/O. Retourne les rappels concernés en conservant leur
+ * `targetAtUtc` d'origine ; l'appelant est responsable d'appliquer la
+ * transition dans le document Automerge et d'émettre la notification
+ * `missed_dose`.
+ *
+ * Si aucun rappel ne doit transitionner, retourne un tableau vide.
+ *
+ * Note d'implémentation : la sortie est un nouveau tableau, jamais l'entrée
+ * d'origine mutée — conforme au principe « pas d'effet de bord » et à
+ * l'immutabilité des projections.
+ *
+ * Refs: SPECS §W4 (parcours dose manquée), §9 (types de notifications),
+ * RM25. Ce fichier est complémentaire à `rm25-reminder-retries` : ici on
+ * calcule **la transition vers missed** ; le plan de relances ultérieur
+ * est porté par `planReminderRetries`.
+ */
+export function detectMissedReminders(
+  reminders: ReadonlyArray<Reminder>,
+  now: Date,
+): MissedReminder[] {
+  const nowMs = now.getTime();
+  const result: MissedReminder[] = [];
+
+  for (const reminder of reminders) {
+    if (!MISSED_ELIGIBLE_SET.has(reminder.status)) continue;
+
+    const endMs = Date.parse(reminder.windowEndUtc);
+    // windowEndUtc ISO invalide : on ignore plutôt que de throw — cohérent
+    // avec la robustesse des projections (jamais de crash côté lecture).
+    if (Number.isNaN(endMs)) continue;
+
+    if (nowMs > endMs) {
+      result.push({ ...reminder, status: 'missed' });
+    }
+  }
+
+  return result;
+}

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -59,6 +59,14 @@
     "loading": "Loading…",
     "back": "Back"
   },
+  "reminder": {
+    "title": "Kinhale",
+    "body": "Dose reminder"
+  },
+  "missed_dose": {
+    "title": "Kinhale",
+    "body": "Dose not confirmed"
+  },
   "onboarding": {
     "child": {
       "title": "Your child",

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -59,6 +59,14 @@
     "loading": "Chargement…",
     "back": "Retour"
   },
+  "reminder": {
+    "title": "Kinhale",
+    "body": "Prise prévue"
+  },
+  "missed_dose": {
+    "title": "Kinhale",
+    "body": "Dose non confirmée"
+  },
   "onboarding": {
     "child": {
       "title": "Votre enfant",

--- a/packages/sync/package.json
+++ b/packages/sync/package.json
@@ -19,7 +19,8 @@
   },
   "dependencies": {
     "@automerge/automerge": "^2.2.0",
-    "@kinhale/crypto": "workspace:*"
+    "@kinhale/crypto": "workspace:*",
+    "@kinhale/domain": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=18.0.0"

--- a/packages/sync/src/__tests__/projections/reminders.test.ts
+++ b/packages/sync/src/__tests__/projections/reminders.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect } from 'vitest';
+import { projectScheduledReminders } from '../../projections/reminders.js';
+import type { KinhaleDoc, SignedEventRecord } from '../../doc/schema.js';
+import type { DoseAdministeredPayload, PlanUpdatedPayload } from '../../events/types.js';
+
+const HH_ID = 'hh-1';
+const PUMP_ID = 'pump-1';
+const PLAN_ID = 'plan-1';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function planEvent(
+  overrides: Partial<PlanUpdatedPayload> = {},
+  occurredAtMs = 1_000_000,
+  id = 'evt-plan',
+): SignedEventRecord {
+  const payload: PlanUpdatedPayload = {
+    planId: PLAN_ID,
+    pumpId: PUMP_ID,
+    scheduledHoursUtc: [8, 20],
+    startAtMs: 0,
+    endAtMs: null,
+    ...overrides,
+  };
+  return {
+    id,
+    type: 'PlanUpdated',
+    payloadJson: JSON.stringify(payload),
+    signerPublicKeyHex: 'a'.repeat(64),
+    signatureHex: 'b'.repeat(128),
+    deviceId: 'dev-1',
+    occurredAtMs,
+  };
+}
+
+function doseEvent(
+  overrides: Partial<DoseAdministeredPayload> = {},
+  id = 'evt-dose',
+): SignedEventRecord {
+  const payload: DoseAdministeredPayload = {
+    doseId: 'dose-1',
+    pumpId: PUMP_ID,
+    childId: 'child-1',
+    caregiverId: 'cg-1',
+    administeredAtMs: 0,
+    doseType: 'maintenance',
+    dosesAdministered: 1,
+    symptoms: [],
+    circumstances: [],
+    freeFormTag: null,
+    ...overrides,
+  };
+  return {
+    id,
+    type: 'DoseAdministered',
+    payloadJson: JSON.stringify(payload),
+    signerPublicKeyHex: 'a'.repeat(64),
+    signatureHex: 'b'.repeat(128),
+    deviceId: 'dev-1',
+    occurredAtMs: payload.administeredAtMs,
+  };
+}
+
+function makeDoc(events: SignedEventRecord[]): KinhaleDoc {
+  return { householdId: HH_ID, events };
+}
+
+describe('projectScheduledReminders', () => {
+  const NOW = new Date('2026-04-22T00:00:00.000Z');
+
+  it('retourne un tableau vide pour un doc sans plan', () => {
+    const doc = makeDoc([]);
+    expect(projectScheduledReminders(doc, NOW)).toEqual([]);
+  });
+
+  it('matérialise les créneaux d’un plan simple sur l’horizon par défaut (48 h)', () => {
+    // Plan [8, 20] UTC → sur 48 h depuis 2026-04-22T00:00Z :
+    // 2026-04-22T08, 2026-04-22T20, 2026-04-23T08, 2026-04-23T20
+    const doc = makeDoc([planEvent({ scheduledHoursUtc: [8, 20] })]);
+    const result = projectScheduledReminders(doc, NOW);
+    expect(result).toHaveLength(4);
+    expect(result[0]?.targetAtUtc).toBe('2026-04-22T08:00:00.000Z');
+    expect(result[1]?.targetAtUtc).toBe('2026-04-22T20:00:00.000Z');
+    expect(result[2]?.targetAtUtc).toBe('2026-04-23T08:00:00.000Z');
+    expect(result[3]?.targetAtUtc).toBe('2026-04-23T20:00:00.000Z');
+  });
+
+  it('construit la fenêtre [target-5min, target+30min] pour chaque créneau', () => {
+    const doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    const result = projectScheduledReminders(doc, NOW);
+    expect(result).toHaveLength(2); // 2 jours × 1 créneau
+    const first = result[0];
+    expect(first?.targetAtUtc).toBe('2026-04-22T08:00:00.000Z');
+    expect(first?.windowStartUtc).toBe('2026-04-22T07:55:00.000Z');
+    expect(first?.windowEndUtc).toBe('2026-04-22T08:30:00.000Z');
+    expect(first?.status).toBe('scheduled');
+    expect(first?.planId).toBe(PLAN_ID);
+  });
+
+  it('id déterministe : identique à entrée égale (idempotence)', () => {
+    const doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    const a = projectScheduledReminders(doc, NOW);
+    const b = projectScheduledReminders(doc, NOW);
+    expect(a.map((r) => r.id)).toEqual(b.map((r) => r.id));
+    expect(a[0]?.id).toBeDefined();
+    expect(a[0]?.id).not.toBe('');
+  });
+
+  it('tri par targetAtUtc croissant', () => {
+    // Ordre des heures intentionnellement inversé dans le plan.
+    const doc = makeDoc([planEvent({ scheduledHoursUtc: [20, 8] })]);
+    const result = projectScheduledReminders(doc, NOW);
+    const targets = result.map((r) => r.targetAtUtc);
+    const sorted = [...targets].sort();
+    expect(targets).toEqual(sorted);
+  });
+
+  it('filtre les créneaux passés (antérieurs à now)', () => {
+    // now = 10:00 → les créneaux 8h du jour courant ne doivent pas sortir.
+    const now = new Date('2026-04-22T10:00:00.000Z');
+    const doc = makeDoc([planEvent({ scheduledHoursUtc: [8, 20] })]);
+    const result = projectScheduledReminders(doc, now);
+    const targets = result.map((r) => r.targetAtUtc);
+    // L'index 2026-04-22T08 doit être exclu.
+    expect(targets).not.toContain('2026-04-22T08:00:00.000Z');
+    // 20h du jour présent et 8/20h du lendemain restent.
+    expect(targets).toContain('2026-04-22T20:00:00.000Z');
+    expect(targets).toContain('2026-04-23T08:00:00.000Z');
+  });
+
+  it('respecte un horizonMs personnalisé (24 h)', () => {
+    const doc = makeDoc([planEvent({ scheduledHoursUtc: [8, 20] })]);
+    const result = projectScheduledReminders(doc, NOW, DAY_MS);
+    // Sur 24h depuis 2026-04-22T00Z : 08:00 + 20:00 = 2 créneaux.
+    expect(result).toHaveLength(2);
+  });
+
+  it('exclut un créneau déjà confirmé par une dose dans la fenêtre', () => {
+    const doc = makeDoc([
+      planEvent({ scheduledHoursUtc: [8, 20] }),
+      doseEvent({
+        doseId: 'dose-confirm',
+        administeredAtMs: new Date('2026-04-22T08:05:00.000Z').getTime(),
+        doseType: 'maintenance',
+      }),
+    ]);
+    const result = projectScheduledReminders(doc, NOW);
+    const targets = result.map((r) => r.targetAtUtc);
+    expect(targets).not.toContain('2026-04-22T08:00:00.000Z');
+  });
+
+  it('ne confirme que les doses maintenance (les rescue sont ignorées)', () => {
+    const doc = makeDoc([
+      planEvent({ scheduledHoursUtc: [8] }),
+      doseEvent({
+        doseId: 'dose-rescue',
+        administeredAtMs: new Date('2026-04-22T08:05:00.000Z').getTime(),
+        doseType: 'rescue',
+      }),
+    ]);
+    const result = projectScheduledReminders(doc, NOW);
+    expect(result.map((r) => r.targetAtUtc)).toContain('2026-04-22T08:00:00.000Z');
+  });
+
+  it('retourne [] si endAtMs du plan est antérieur à now', () => {
+    const doc = makeDoc([
+      planEvent({
+        scheduledHoursUtc: [8, 20],
+        startAtMs: 0,
+        endAtMs: new Date('2026-04-21T23:00:00.000Z').getTime(),
+      }),
+    ]);
+    expect(projectScheduledReminders(doc, NOW)).toEqual([]);
+  });
+
+  it('retient le dernier PlanUpdated en cas de multiples', () => {
+    const older = planEvent({ scheduledHoursUtc: [6] }, 1_000, 'evt-old');
+    const newer = planEvent({ scheduledHoursUtc: [8, 20] }, 2_000, 'evt-new');
+    const doc = makeDoc([older, newer]);
+    const result = projectScheduledReminders(doc, NOW);
+    // Les créneaux doivent être issus du PLUS RÉCENT plan (8, 20), pas [6].
+    const hours = new Set(result.map((r) => r.targetAtUtc.slice(11, 13)));
+    expect(hours).toEqual(new Set(['08', '20']));
+  });
+
+  it('tolère une dose confirmée attachée à une autre pompe (ne confirme pas)', () => {
+    const doc = makeDoc([
+      planEvent({ scheduledHoursUtc: [8], pumpId: PUMP_ID }),
+      doseEvent({
+        doseId: 'dose-other',
+        pumpId: 'other-pump',
+        administeredAtMs: new Date('2026-04-22T08:05:00.000Z').getTime(),
+        doseType: 'maintenance',
+      }),
+    ]);
+    const result = projectScheduledReminders(doc, NOW);
+    expect(result.map((r) => r.targetAtUtc)).toContain('2026-04-22T08:00:00.000Z');
+  });
+});

--- a/packages/sync/src/__tests__/projections/reminders.test.ts
+++ b/packages/sync/src/__tests__/projections/reminders.test.ts
@@ -115,17 +115,27 @@ describe('projectScheduledReminders', () => {
     expect(targets).toEqual(sorted);
   });
 
-  it('filtre les créneaux passés (antérieurs à now)', () => {
-    // now = 10:00 → les créneaux 8h du jour courant ne doivent pas sortir.
+  it('conserve les créneaux récents (lookback par défaut 2h) pour la détection missed', () => {
+    // now = 10:00 → 08:00 est dans la rétro-fenêtre (2h) : on le garde.
     const now = new Date('2026-04-22T10:00:00.000Z');
     const doc = makeDoc([planEvent({ scheduledHoursUtc: [8, 20] })]);
     const result = projectScheduledReminders(doc, now);
     const targets = result.map((r) => r.targetAtUtc);
-    // L'index 2026-04-22T08 doit être exclu.
-    expect(targets).not.toContain('2026-04-22T08:00:00.000Z');
-    // 20h du jour présent et 8/20h du lendemain restent.
+    // Le 08h reste visible pour que le watcher puisse détecter le missed.
+    expect(targets).toContain('2026-04-22T08:00:00.000Z');
+    // 20h du jour présent et 8/20h du lendemain aussi.
     expect(targets).toContain('2026-04-22T20:00:00.000Z');
     expect(targets).toContain('2026-04-23T08:00:00.000Z');
+  });
+
+  it('filtre les créneaux antérieurs à la rétro-fenêtre (lookbackMs=0)', () => {
+    // Avec lookbackMs=0 le comportement strict « aucun passé » est rétabli.
+    const now = new Date('2026-04-22T10:00:00.000Z');
+    const doc = makeDoc([planEvent({ scheduledHoursUtc: [8, 20] })]);
+    const result = projectScheduledReminders(doc, now, DAY_MS * 2, 0);
+    const targets = result.map((r) => r.targetAtUtc);
+    expect(targets).not.toContain('2026-04-22T08:00:00.000Z');
+    expect(targets).toContain('2026-04-22T20:00:00.000Z');
   });
 
   it('respecte un horizonMs personnalisé (24 h)', () => {

--- a/packages/sync/src/client/__tests__/useMissedDoseWatcher.test.tsx
+++ b/packages/sync/src/client/__tests__/useMissedDoseWatcher.test.tsx
@@ -78,12 +78,17 @@ describe('useMissedDoseWatcher', () => {
     expect(notify).not.toHaveBeenCalled();
   });
 
-  it('ne déclenche rien au montage (timer uniquement)', () => {
+  it('détecte immédiatement un rappel missed au montage (sans attendre tickMs)', async () => {
     doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    // Au moment du montage, la fenêtre du 8h est déjà passée (buffer +2 min inclus).
     now = new Date('2026-04-22T10:00:00.000Z');
     renderHook(() => useMissedDoseWatcher(buildDeps()));
-    expect(mark).not.toHaveBeenCalled();
-    expect(notify).not.toHaveBeenCalled();
+    // Laisse une microtâche pour la notification asynchrone.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mark).toHaveBeenCalledTimes(1);
+    expect(notify).toHaveBeenCalledTimes(1);
   });
 
   it('à un tick avec un rappel dont la fenêtre est passée, marque missed + émet la notif', async () => {
@@ -181,5 +186,61 @@ describe('useMissedDoseWatcher', () => {
       await Promise.resolve();
     });
     expect(mark).toHaveBeenCalledTimes(1);
+  });
+
+  it('après TTL 24h, un rappel dont la fenêtre réapparaît (collision d’id) est renotifié', async () => {
+    // Scénario défensif : un rappel du 22-04 est notifié, puis un plan
+    // modifié réexpose la MÊME id de rappel (collision improbable mais
+    // couverte). Après 24 h, le Set est purgé et la nouvelle occurrence
+    // redéclenche la notification.
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    renderHook(() => useMissedDoseWatcher(buildDeps()));
+
+    now = new Date('2026-04-22T09:00:00.000Z');
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    // Avance de > 24 h : le tick purge l'id ; le rappel du 23-04 (08:00)
+    // est une NOUVELLE fenêtre (id différent) → 2e notif attendue.
+    now = new Date('2026-04-23T10:00:00.000Z');
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+    expect(notify).toHaveBeenCalledTimes(2);
+    // La purge du 22-04 est implicite : à ce stade, notifiedIdsRef ne
+    // contient plus que l'id du 23-04, pas celui du 22-04 (croissance
+    // bornée par TTL — cf. NOTIFIED_IDS_TTL_MS).
+  });
+
+  it('reset le dédoublonnage au changement de householdId (switch de foyer)', async () => {
+    doc = { householdId: 'hh-1', events: [planEvent({ scheduledHoursUtc: [8] })] };
+    const { rerender } = renderHook(() => useMissedDoseWatcher(buildDeps()));
+
+    now = new Date('2026-04-22T09:00:00.000Z');
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    // Switch vers un autre foyer qui porte un plan avec le MÊME id de
+    // rappel (collision improbable mais possible si on rejoue un export).
+    doc = { householdId: 'hh-2', events: [planEvent({ scheduledHoursUtc: [8] })] };
+    await act(async () => {
+      rerender();
+      await Promise.resolve();
+    });
+
+    now = new Date('2026-04-22T09:30:00.000Z');
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+    // Le dédoublonnage a été reset : le rappel est renotifié pour le nouveau foyer.
+    expect(notify).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/sync/src/client/__tests__/useMissedDoseWatcher.test.tsx
+++ b/packages/sync/src/client/__tests__/useMissedDoseWatcher.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useMissedDoseWatcher } from '../useMissedDoseWatcher.js';
+import type { KinhaleDoc, SignedEventRecord } from '../../doc/schema.js';
+import type { PlanUpdatedPayload } from '../../events/types.js';
+
+function planEvent(payload: Partial<PlanUpdatedPayload> = {}): SignedEventRecord {
+  const p: PlanUpdatedPayload = {
+    planId: 'plan-1',
+    pumpId: 'pump-1',
+    scheduledHoursUtc: [8],
+    startAtMs: 0,
+    endAtMs: null,
+    ...payload,
+  };
+  return {
+    id: 'evt-plan',
+    type: 'PlanUpdated',
+    payloadJson: JSON.stringify(p),
+    signerPublicKeyHex: 'a'.repeat(64),
+    signatureHex: 'b'.repeat(128),
+    deviceId: 'dev-1',
+    occurredAtMs: 1000,
+  };
+}
+
+function makeDoc(events: SignedEventRecord[]): KinhaleDoc {
+  return { householdId: 'hh-1', events };
+}
+
+let doc: KinhaleDoc | null;
+let mark: Mock;
+let notify: Mock;
+let now: Date;
+
+function buildDeps(overrides: Partial<Parameters<typeof useMissedDoseWatcher>[0]> = {}) {
+  return {
+    useDoc: () => doc,
+    markReminderMissed: mark as unknown as (id: string) => void,
+    notifyMissedDose: notify as unknown as (args: {
+      id: string;
+      title: string;
+      body: string;
+    }) => Promise<void>,
+    now: () => now,
+    missedDoseTitle: 'Kinhale',
+    missedDoseBody: 'Dose non confirmée',
+    tickMs: 60_000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  doc = null;
+  mark = vi.fn();
+  notify = vi.fn(async () => undefined);
+  now = new Date('2026-04-22T00:00:00.000Z');
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useMissedDoseWatcher', () => {
+  it('no-op si le doc est null', async () => {
+    renderHook(() => useMissedDoseWatcher(buildDeps()));
+    now = new Date('2026-04-22T09:00:00.000Z'); // après la fenêtre du 8h
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+    expect(mark).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('ne déclenche rien au montage (timer uniquement)', () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    now = new Date('2026-04-22T10:00:00.000Z');
+    renderHook(() => useMissedDoseWatcher(buildDeps()));
+    expect(mark).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('à un tick avec un rappel dont la fenêtre est passée, marque missed + émet la notif', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    // now initial = 00:00 (fenêtre future) — le premier tick devra le voir passé.
+    renderHook(() => useMissedDoseWatcher(buildDeps()));
+
+    // Avance l'horloge simulée à 09:00 (fenêtre 7:55→8:30 dépassée).
+    now = new Date('2026-04-22T09:00:00.000Z');
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    expect(mark).toHaveBeenCalledTimes(1);
+    expect(mark.mock.calls[0]?.[0]).toContain('2026-04-22T08:00:00');
+    expect(notify).toHaveBeenCalledTimes(1);
+    const args = notify.mock.calls[0]?.[0] as { id: string; title: string; body: string };
+    expect(args.title).toBe('Kinhale');
+    expect(args.body).toBe('Dose non confirmée');
+  });
+
+  it('ne re-notifie pas le même rappel au tick suivant (dédoublonnage)', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    renderHook(() => useMissedDoseWatcher(buildDeps()));
+
+    now = new Date('2026-04-22T09:00:00.000Z');
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+    expect(notify).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+    expect(notify).toHaveBeenCalledTimes(1); // toujours 1
+    expect(mark).toHaveBeenCalledTimes(1);
+  });
+
+  it('ne déclenche rien tant que la fenêtre n’est pas passée', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    renderHook(() => useMissedDoseWatcher(buildDeps()));
+
+    now = new Date('2026-04-22T08:10:00.000Z'); // dans la fenêtre
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+    expect(mark).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('n’émet pas de notif si notifyMissedDose est absent (mark only)', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    const { notifyMissedDose: _notify, ...deps } = buildDeps();
+    renderHook(() => useMissedDoseWatcher(deps));
+
+    now = new Date('2026-04-22T09:00:00.000Z');
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
+      await Promise.resolve();
+    });
+
+    expect(mark).toHaveBeenCalledTimes(1);
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('clearInterval au démontage', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    const { unmount } = renderHook(() => useMissedDoseWatcher(buildDeps()));
+
+    act(() => {
+      unmount();
+    });
+
+    now = new Date('2026-04-22T09:00:00.000Z');
+    await act(async () => {
+      vi.advanceTimersByTime(120_000); // 2 ticks après unmount
+      await Promise.resolve();
+    });
+
+    expect(mark).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('tickMs custom raccourcit l’intervalle', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    renderHook(() => useMissedDoseWatcher(buildDeps({ tickMs: 10_000 })));
+
+    now = new Date('2026-04-22T09:00:00.000Z');
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+    expect(mark).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/sync/src/client/__tests__/useReminderScheduler.test.tsx
+++ b/packages/sync/src/client/__tests__/useReminderScheduler.test.tsx
@@ -1,0 +1,219 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useReminderScheduler } from '../useReminderScheduler.js';
+import type { KinhaleDoc, SignedEventRecord } from '../../doc/schema.js';
+import type { PlanUpdatedPayload, DoseAdministeredPayload } from '../../events/types.js';
+
+function planEvent(
+  payload: Partial<PlanUpdatedPayload> = {},
+  occurredAtMs = 1000,
+  id = 'evt-plan',
+): SignedEventRecord {
+  const p: PlanUpdatedPayload = {
+    planId: 'plan-1',
+    pumpId: 'pump-1',
+    scheduledHoursUtc: [8, 20],
+    startAtMs: 0,
+    endAtMs: null,
+    ...payload,
+  };
+  return {
+    id,
+    type: 'PlanUpdated',
+    payloadJson: JSON.stringify(p),
+    signerPublicKeyHex: 'a'.repeat(64),
+    signatureHex: 'b'.repeat(128),
+    deviceId: 'dev-1',
+    occurredAtMs,
+  };
+}
+
+function doseEvent(payload: Partial<DoseAdministeredPayload>): SignedEventRecord {
+  const p: DoseAdministeredPayload = {
+    doseId: 'dose-1',
+    pumpId: 'pump-1',
+    childId: 'child-1',
+    caregiverId: 'cg-1',
+    administeredAtMs: 0,
+    doseType: 'maintenance',
+    dosesAdministered: 1,
+    symptoms: [],
+    circumstances: [],
+    freeFormTag: null,
+    ...payload,
+  };
+  return {
+    id: `evt-${p.doseId}`,
+    type: 'DoseAdministered',
+    payloadJson: JSON.stringify(p),
+    signerPublicKeyHex: 'a'.repeat(64),
+    signatureHex: 'b'.repeat(128),
+    deviceId: 'dev-1',
+    occurredAtMs: p.administeredAtMs,
+  };
+}
+
+function makeDoc(events: SignedEventRecord[]): KinhaleDoc {
+  return { householdId: 'hh-1', events };
+}
+
+let doc: KinhaleDoc | null;
+let schedule: Mock;
+let cancel: Mock;
+let now: Date;
+
+function buildDeps() {
+  return {
+    useDoc: () => doc,
+    scheduleLocalNotification: schedule as unknown as (args: {
+      id: string;
+      triggerAtUtc: string;
+      title: string;
+      body: string;
+    }) => Promise<void>,
+    cancelLocalNotification: cancel as unknown as (id: string) => Promise<void>,
+    now: () => now,
+    reminderTitle: 'Kinhale',
+    reminderBody: 'Prise prévue',
+  };
+}
+
+beforeEach(() => {
+  doc = null;
+  schedule = vi.fn(async () => undefined);
+  cancel = vi.fn(async () => undefined);
+  now = new Date('2026-04-22T00:00:00.000Z');
+});
+
+describe('useReminderScheduler', () => {
+  it('no-op si le doc est null', async () => {
+    renderHook(() => useReminderScheduler(buildDeps()));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(schedule).not.toHaveBeenCalled();
+    expect(cancel).not.toHaveBeenCalled();
+  });
+
+  it('programme une notification par créneau projeté au premier rendu', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    renderHook(() => useReminderScheduler(buildDeps()));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // 48h × 1 créneau = 2 notifs programmées.
+    expect(schedule).toHaveBeenCalledTimes(2);
+    const first = schedule.mock.calls[0]?.[0] as {
+      id: string;
+      triggerAtUtc: string;
+      title: string;
+      body: string;
+    };
+    expect(first.id.startsWith('r:plan-1:')).toBe(true);
+    expect(first.triggerAtUtc).toBe('2026-04-22T08:00:00.000Z');
+    expect(first.title).toBe('Kinhale');
+    expect(first.body).toBe('Prise prévue');
+  });
+
+  it('ne reprogramme pas un rappel déjà connu quand le doc ne change pas', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    const { rerender } = renderHook(() => useReminderScheduler(buildDeps()));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(schedule).toHaveBeenCalledTimes(2);
+
+    // Rerender sans changer le doc → aucune nouvelle programmation.
+    await act(async () => {
+      rerender();
+      await Promise.resolve();
+    });
+    expect(schedule).toHaveBeenCalledTimes(2);
+  });
+
+  it('annule les rappels retirés du plan à la nouvelle projection', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8, 20] })]);
+    const { rerender } = renderHook(() => useReminderScheduler(buildDeps()));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // 48h × 2 créneaux = 4 notifs.
+    expect(schedule).toHaveBeenCalledTimes(4);
+
+    // Nouveau plan : seulement [8], même pompe. On retire les 20h.
+    doc = makeDoc([
+      planEvent({ scheduledHoursUtc: [8, 20] }, 1000, 'evt-old'),
+      planEvent({ scheduledHoursUtc: [8] }, 2000, 'evt-new'),
+    ]);
+    await act(async () => {
+      rerender();
+      await Promise.resolve();
+    });
+
+    // Annulation des 2 créneaux à 20h.
+    expect(cancel).toHaveBeenCalledTimes(2);
+    const cancelledIds = cancel.mock.calls.map((c) => c[0] as string);
+    expect(cancelledIds.every((id) => id.includes('T20:00:00'))).toBe(true);
+  });
+
+  it('annule un rappel devenu confirmé par une dose dans la fenêtre', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    const { rerender } = renderHook(() => useReminderScheduler(buildDeps()));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(schedule).toHaveBeenCalledTimes(2);
+
+    // Ajoute une dose dans la fenêtre du 2026-04-22T08:00.
+    doc = makeDoc([
+      planEvent({ scheduledHoursUtc: [8] }),
+      doseEvent({
+        doseId: 'dose-1',
+        administeredAtMs: new Date('2026-04-22T08:05:00.000Z').getTime(),
+      }),
+    ]);
+    await act(async () => {
+      rerender();
+      await Promise.resolve();
+    });
+
+    // Le rappel T=08:00 du 22 doit avoir été annulé.
+    expect(cancel).toHaveBeenCalledTimes(1);
+    const cancelledId = cancel.mock.calls[0]?.[0] as string;
+    expect(cancelledId).toContain('2026-04-22T08:00:00');
+  });
+
+  it('annule toutes les notifs programmées au démontage', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    const { unmount } = renderHook(() => useReminderScheduler(buildDeps()));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(schedule).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      unmount();
+    });
+
+    expect(cancel).toHaveBeenCalledTimes(2);
+  });
+
+  it('respecte horizonMs custom', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8, 20] })]);
+    renderHook(() =>
+      useReminderScheduler({
+        ...buildDeps(),
+        horizonMs: 24 * 60 * 60 * 1000, // 24h
+      }),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // Sur 24h : 08:00 + 20:00 = 2 créneaux.
+    expect(schedule).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/sync/src/client/__tests__/useReminderScheduler.test.tsx
+++ b/packages/sync/src/client/__tests__/useReminderScheduler.test.tsx
@@ -216,4 +216,51 @@ describe('useReminderScheduler', () => {
     // Sur 24h : 08:00 + 20:00 = 2 créneaux.
     expect(schedule).toHaveBeenCalledTimes(2);
   });
+
+  it('hydrate scheduledIds depuis l’OS au montage et ne reprogramme pas ces ids', async () => {
+    // Simule un remount : 2 des 3 ids projetés sont déjà programmés côté OS.
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    // Calcule les ids projetés manuellement pour pouvoir en pré-remplir l'OS.
+    const alreadyScheduled = ['r:plan-1:2026-04-22T08:00:00.000Z'];
+    const hydrate = vi.fn(async () => alreadyScheduled);
+
+    renderHook(() =>
+      useReminderScheduler({
+        ...buildDeps(),
+        hydrateScheduledIds: hydrate,
+      }),
+    );
+    // Laisse le Promise d'hydratation se résoudre + la prochaine passe de diff.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(hydrate).toHaveBeenCalledTimes(1);
+    // 48h × 1 créneau = 2 notifs projetées ; 1 déjà en OS → 1 seule à programmer.
+    expect(schedule).toHaveBeenCalledTimes(1);
+    const scheduledId = schedule.mock.calls[0]?.[0] as { id: string };
+    expect(scheduledId.id).toBe('r:plan-1:2026-04-23T08:00:00.000Z');
+  });
+
+  it('continue best-effort si hydrateScheduledIds rejette', async () => {
+    doc = makeDoc([planEvent({ scheduledHoursUtc: [8] })]);
+    const hydrate = vi.fn(async () => {
+      throw new Error('native module not ready');
+    });
+
+    renderHook(() =>
+      useReminderScheduler({
+        ...buildDeps(),
+        hydrateScheduledIds: hydrate,
+      }),
+    );
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Set vide en cas d'échec → toutes les notifs sont programmées (2 sur 48h).
+    expect(schedule).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/sync/src/client/index.ts
+++ b/packages/sync/src/client/index.ts
@@ -24,6 +24,11 @@ export type {
   ScheduleLocalNotificationArgs,
   UseReminderSchedulerDeps,
 } from './useReminderScheduler.js';
+export { useMissedDoseWatcher } from './useMissedDoseWatcher.js';
+export type {
+  NotifyMissedDoseArgs,
+  UseMissedDoseWatcherDeps,
+} from './useMissedDoseWatcher.js';
 export { classifyDecryptError, createDecryptFailedReporter } from './telemetry.js';
 export type {
   DecryptErrorClass,

--- a/packages/sync/src/client/index.ts
+++ b/packages/sync/src/client/index.ts
@@ -19,6 +19,11 @@ export type {
   CreateRelayClient,
   UseRelaySyncDeps,
 } from './useRelaySync.js';
+export { useReminderScheduler } from './useReminderScheduler.js';
+export type {
+  ScheduleLocalNotificationArgs,
+  UseReminderSchedulerDeps,
+} from './useReminderScheduler.js';
 export { classifyDecryptError, createDecryptFailedReporter } from './telemetry.js';
 export type {
   DecryptErrorClass,

--- a/packages/sync/src/client/index.ts
+++ b/packages/sync/src/client/index.ts
@@ -25,10 +25,7 @@ export type {
   UseReminderSchedulerDeps,
 } from './useReminderScheduler.js';
 export { useMissedDoseWatcher } from './useMissedDoseWatcher.js';
-export type {
-  NotifyMissedDoseArgs,
-  UseMissedDoseWatcherDeps,
-} from './useMissedDoseWatcher.js';
+export type { NotifyMissedDoseArgs, UseMissedDoseWatcherDeps } from './useMissedDoseWatcher.js';
 export { classifyDecryptError, createDecryptFailedReporter } from './telemetry.js';
 export type {
   DecryptErrorClass,

--- a/packages/sync/src/client/useMissedDoseWatcher.ts
+++ b/packages/sync/src/client/useMissedDoseWatcher.ts
@@ -7,6 +7,18 @@ import {
 } from '../projections/reminders.js';
 
 /**
+ * TTL d'un id de rappel dans `notifiedIdsRef`. Un rappel missed ne peut
+ * plus re-déclencher de notification 24 h après la fin de sa fenêtre : on
+ * purge les entrées pour éviter une croissance monotone du Set (mémoire
+ * session longue). 24 h > horizon de projection (48 h) n'est pas requis —
+ * seuls les rappels **déjà passés** sont dans le Set, donc 24 h de rétention
+ * post-fenêtre suffisent pour se prémunir d'un tick en retard.
+ *
+ * Refs: KIN-038 (kz-review M2, kz-securite m2).
+ */
+const NOTIFIED_IDS_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
  * Arguments d'émission d'une notification locale `missed_dose`. Même forme
  * que `ScheduleLocalNotificationArgs` (brique 4), mais sans `triggerAtUtc` —
  * on notifie immédiatement.
@@ -86,6 +98,10 @@ export interface UseMissedDoseWatcherDeps {
  */
 export function useMissedDoseWatcher(deps: UseMissedDoseWatcherDeps): void {
   const doc = deps.useDoc();
+  // Clé du foyer — déclenche un reset du Set de dédoublonnage quand elle
+  // change (switch post-invitation / logout-relog). Un rappel d'un autre
+  // foyer ne doit pas apparaître déjà « notifié » pour le nouveau.
+  const householdKey: string | null = doc?.householdId ?? null;
 
   // Latest-ref pattern : stabilise l'identité des callbacks.
   const markRef = React.useRef(deps.markReminderMissed);
@@ -108,8 +124,17 @@ export function useMissedDoseWatcher(deps: UseMissedDoseWatcherDeps): void {
   const horizonMs = deps.horizonMs ?? DEFAULT_REMINDER_HORIZON_MS;
 
   // Ids déjà notifiés — évite la répétition tant que la transition n'est
-  // pas persistée (v1.0).
-  const notifiedIdsRef = React.useRef<Set<string>>(new Set());
+  // pas persistée (v1.0). Map<id, windowEndMs> pour pouvoir purger au-delà
+  // du TTL (cf. `NOTIFIED_IDS_TTL_MS`).
+  const notifiedIdsRef = React.useRef<Map<string, number>>(new Map());
+
+  // Reset du dédoublonnage quand le foyer change. Sans ça, un re-login sur
+  // un autre household marque les nouveaux rappels comme déjà notifiés si
+  // leurs ids collisionnaient (improbable vu le format `r:<planId>:<iso>`
+  // mais défensif — aussi utile si un jour on rejoue un historique).
+  React.useEffect(() => {
+    notifiedIdsRef.current = new Map();
+  }, [householdKey]);
 
   React.useEffect(() => {
     let cancelled = false;
@@ -119,12 +144,27 @@ export function useMissedDoseWatcher(deps: UseMissedDoseWatcherDeps): void {
       const currentDoc = docRef.current;
       if (currentDoc === null) return;
 
-      const reminders = projectScheduledReminders(currentDoc, nowRef.current(), horizonMs);
-      const missed = detectMissedReminders(reminders, nowRef.current());
+      const nowDate = nowRef.current();
+      const reminders = projectScheduledReminders(currentDoc, nowDate, horizonMs);
+      const missed = detectMissedReminders(reminders, nowDate);
+
+      // Purge TTL : un rappel dont la fenêtre s'est fermée il y a plus de
+      // 24 h ne peut plus re-émettre (la projection ne le remontera plus
+      // non plus, vu le lookback par défaut de 2 h). Garde le Set borné.
+      const nowMs = nowDate.getTime();
+      for (const [id, windowEndMs] of notifiedIdsRef.current) {
+        if (windowEndMs + NOTIFIED_IDS_TTL_MS < nowMs) {
+          notifiedIdsRef.current.delete(id);
+        }
+      }
 
       for (const r of missed) {
         if (notifiedIdsRef.current.has(r.id)) continue;
-        notifiedIdsRef.current.add(r.id);
+        const endMs = Date.parse(r.windowEndUtc);
+        // Si `windowEndUtc` est non parsable, on mémorise avec `nowMs` —
+        // le rappel n'aurait pas dû franchir `detectMissedReminders`, mais
+        // on reste défensif sans crash.
+        notifiedIdsRef.current.set(r.id, Number.isNaN(endMs) ? nowMs : endMs);
         markRef.current(r.id);
         const notify = notifyRef.current;
         if (notify !== undefined) {
@@ -137,10 +177,11 @@ export function useMissedDoseWatcher(deps: UseMissedDoseWatcherDeps): void {
       }
     }
 
-    // On ne check pas au montage : le watcher est un *timer* — cohérent
-    // avec la signature « toutes les tickMs » et évite un double-fire à
-    // l'ouverture. Si on veut un check immédiat, on peut abaisser tickMs
-    // côté app (déconseillé en prod).
+    // Check immédiat au montage : si l'utilisateur ouvre l'app **juste
+    // après** qu'un rappel a dépassé sa fenêtre, on ne veut pas attendre
+    // jusqu'à `tickMs` pour notifier (O4 cible ≤ 60 s).
+    check();
+
     const handle = setInterval(check, tickMs);
 
     return () => {

--- a/packages/sync/src/client/useMissedDoseWatcher.ts
+++ b/packages/sync/src/client/useMissedDoseWatcher.ts
@@ -1,0 +1,151 @@
+import * as React from 'react';
+import { detectMissedReminders } from '@kinhale/domain';
+import type { KinhaleDoc } from '../doc/schema.js';
+import {
+  DEFAULT_REMINDER_HORIZON_MS,
+  projectScheduledReminders,
+} from '../projections/reminders.js';
+
+/**
+ * Arguments d'émission d'une notification locale `missed_dose`. Même forme
+ * que `ScheduleLocalNotificationArgs` (brique 4), mais sans `triggerAtUtc` —
+ * on notifie immédiatement.
+ */
+export interface NotifyMissedDoseArgs {
+  readonly id: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface UseMissedDoseWatcherDeps {
+  /** Hook plateforme : document Automerge courant. */
+  readonly useDoc: () => KinhaleDoc | null;
+  /**
+   * Callback invoqué pour chaque rappel qui vient de transitionner
+   * à `missed`. L'implémentation plateforme décide comment appliquer le
+   * change Automerge (ou laisse un no-op si la persistance du statut
+   * `missed` n'est pas encore branchée — v1.0 peut se contenter de la
+   * projection temps réel sans stocker la transition).
+   */
+  readonly markReminderMissed: (reminderId: string) => void;
+  /**
+   * Émet la notification locale `missed_dose`. **Chaînes déjà traduites**
+   * fournies par {@link UseMissedDoseWatcherDeps.missedDoseTitle} /
+   * `missedDoseBody`.
+   *
+   * Optionnel : si non fourni, le watcher ne fait que persister la
+   * transition via `markReminderMissed` (le push utilisateur sera émis
+   * par une autre couche, ex. e-mail fallback E5-S04).
+   */
+  readonly notifyMissedDose?: (args: NotifyMissedDoseArgs) => Promise<void>;
+  /** Horloge injectée — testable. */
+  readonly now: () => Date;
+  /** Intervalle du polling en ms (défaut 60_000 = 1 min). */
+  readonly tickMs?: number;
+  /** Horizon de projection, défaut 48 h (cohérent avec le scheduler). */
+  readonly horizonMs?: number;
+  /**
+   * Titre et corps **déjà traduits** du push `missed_dose`. Valeurs
+   * sobres recommandées :
+   * - title = "Kinhale"
+   * - body  = "Dose non confirmée"
+   *
+   * **Interdit** : recommandation, diagnostic, mention de dose ou
+   * pompe. Ligne rouge dispositif médical (CLAUDE.md, SPECS §7.4).
+   */
+  readonly missedDoseTitle: string;
+  readonly missedDoseBody: string;
+}
+
+/**
+ * Hook framework-agnostique : surveille le passage de rappels à `missed`
+ * par polling toutes les `tickMs` (défaut 60 s — aligné sur O4 délai cible
+ * ≤ 60 s).
+ *
+ * Fonctionnement à chaque tick :
+ * - Si `doc === null`, no-op.
+ * - Projette les rappels scheduled sur l'horizon.
+ * - Applique `detectMissedReminders(reminders, now)` (RM25).
+ * - Pour chaque rappel à transitionner :
+ *   1. Appelle `markReminderMissed(reminderId)`.
+ *   2. Si `notifyMissedDose` fourni, émet la notification locale.
+ * - Tient un set local des ids déjà notifiés pour éviter les doublons
+ *   si la projection continue à exposer le rappel (tant que la transition
+ *   n'est pas persistée dans le doc, le rappel reste `scheduled` dans la
+ *   prochaine projection — on s'appuie sur le set pour ne pas répéter).
+ *
+ * Choix de design : le watcher émet la notification `missed_dose` lui-même.
+ * Alternative envisagée : laisser le `useReminderScheduler` recalculer et
+ * émettre via la projection. Rejetée car (a) `Reminder.status` n'est pas
+ * persisté en v1.0 — le scheduler n'a aucun signal pour distinguer un
+ * rappel juste missed d'un rappel vraiment scheduled ; (b) séparer les
+ * deux hooks garde leur invariant clair : « scheduler = futur »,
+ * « watcher = transition courante ».
+ *
+ * Refs: KIN-038, E5-S03, SPECS §W4, §9, RM25.
+ */
+export function useMissedDoseWatcher(deps: UseMissedDoseWatcherDeps): void {
+  const doc = deps.useDoc();
+
+  // Latest-ref pattern : stabilise l'identité des callbacks.
+  const markRef = React.useRef(deps.markReminderMissed);
+  const notifyRef = React.useRef(deps.notifyMissedDose);
+  const nowRef = React.useRef(deps.now);
+  const titleRef = React.useRef(deps.missedDoseTitle);
+  const bodyRef = React.useRef(deps.missedDoseBody);
+  markRef.current = deps.markReminderMissed;
+  notifyRef.current = deps.notifyMissedDose;
+  nowRef.current = deps.now;
+  titleRef.current = deps.missedDoseTitle;
+  bodyRef.current = deps.missedDoseBody;
+
+  // Référence stable sur le doc (pour lecture dans l'intervalle sans
+  // recréer le timer à chaque mutation).
+  const docRef = React.useRef(doc);
+  docRef.current = doc;
+
+  const tickMs = deps.tickMs ?? 60_000;
+  const horizonMs = deps.horizonMs ?? DEFAULT_REMINDER_HORIZON_MS;
+
+  // Ids déjà notifiés — évite la répétition tant que la transition n'est
+  // pas persistée (v1.0).
+  const notifiedIdsRef = React.useRef<Set<string>>(new Set());
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    function check(): void {
+      if (cancelled) return;
+      const currentDoc = docRef.current;
+      if (currentDoc === null) return;
+
+      const reminders = projectScheduledReminders(currentDoc, nowRef.current(), horizonMs);
+      const missed = detectMissedReminders(reminders, nowRef.current());
+
+      for (const r of missed) {
+        if (notifiedIdsRef.current.has(r.id)) continue;
+        notifiedIdsRef.current.add(r.id);
+        markRef.current(r.id);
+        const notify = notifyRef.current;
+        if (notify !== undefined) {
+          void notify({
+            id: r.id,
+            title: titleRef.current,
+            body: bodyRef.current,
+          });
+        }
+      }
+    }
+
+    // On ne check pas au montage : le watcher est un *timer* — cohérent
+    // avec la signature « toutes les tickMs » et évite un double-fire à
+    // l'ouverture. Si on veut un check immédiat, on peut abaisser tickMs
+    // côté app (déconseillé en prod).
+    const handle = setInterval(check, tickMs);
+
+    return () => {
+      cancelled = true;
+      clearInterval(handle);
+    };
+  }, [tickMs, horizonMs]);
+}

--- a/packages/sync/src/client/useReminderScheduler.ts
+++ b/packages/sync/src/client/useReminderScheduler.ts
@@ -98,7 +98,13 @@ export function useReminderScheduler(deps: UseReminderSchedulerDeps): void {
   React.useEffect(() => {
     if (doc === null) return undefined;
 
-    const reminders = projectScheduledReminders(doc, nowRef.current(), horizonMs);
+    const nowDate = nowRef.current();
+    const nowMs = nowDate.getTime();
+    // Lookback 0 : le scheduler n'a pas besoin des créneaux passés. L'OS
+    // refuserait un trigger antérieur ; autant ne pas tenter.
+    const reminders = projectScheduledReminders(doc, nowDate, horizonMs, 0).filter(
+      (r) => Date.parse(r.targetAtUtc) >= nowMs,
+    );
     const desiredIds = new Set(reminders.map((r) => r.id));
     const currentIds = scheduledIdsRef.current;
 

--- a/packages/sync/src/client/useReminderScheduler.ts
+++ b/packages/sync/src/client/useReminderScheduler.ts
@@ -31,6 +31,24 @@ export interface UseReminderSchedulerDeps {
   /** Annule une notification locale précédemment programmée. No-op si inconnue. */
   readonly cancelLocalNotification: (id: string) => Promise<void>;
   /**
+   * Hydratation cross-session (optionnel, recommandé côté mobile) : au
+   * montage, réinjecte les identifiants des notifications **déjà
+   * programmées côté OS** par une session précédente. Permet d'éviter les
+   * doublons quand le process RN redémarre (scheduledIdsRef vide mais
+   * notifs persistantes iOS/Android). La plateforme filtre elle-même sur
+   * le préfixe `r:` pour ne pas capturer d'autres canaux de notifs.
+   *
+   * Non pertinent pour le web (Web Notifications API ne persiste pas les
+   * timers cross-session — un refresh de l'onglet repart de zéro, la
+   * programmation reprendra à la projection suivante).
+   *
+   * Si fourni, appelé une fois au montage ; le Set est peuplé avec les ids
+   * retournés avant la 1re passe de diff.
+   *
+   * Refs: KIN-038 (kz-securite M1).
+   */
+  readonly hydrateScheduledIds?: () => Promise<ReadonlyArray<string>>;
+  /**
    * Horloge injectée. Doit retourner un `Date` représentant le temps UTC
    * courant. Injectable pour tests.
    */
@@ -83,20 +101,58 @@ export function useReminderScheduler(deps: UseReminderSchedulerDeps): void {
   const nowRef = React.useRef(deps.now);
   const titleRef = React.useRef(deps.reminderTitle);
   const bodyRef = React.useRef(deps.reminderBody);
+  const hydrateRef = React.useRef(deps.hydrateScheduledIds);
   scheduleRef.current = deps.scheduleLocalNotification;
   cancelRef.current = deps.cancelLocalNotification;
   nowRef.current = deps.now;
   titleRef.current = deps.reminderTitle;
   bodyRef.current = deps.reminderBody;
+  hydrateRef.current = deps.hydrateScheduledIds;
 
   const horizonMs = deps.horizonMs ?? DEFAULT_REMINDER_HORIZON_MS;
 
   // État local persistant : ids de notifications programmées par ce hook.
   // Stocké dans une ref pour ne pas déclencher de re-render.
   const scheduledIdsRef = React.useRef<Set<string>>(new Set());
+  // Flag : true tant que l'hydratation cross-session n'est pas terminée.
+  // Bloque le diff tant qu'on n'a pas repeuplé `scheduledIdsRef` depuis
+  // l'OS ; sinon on (re)programmerait par-dessus des notifs déjà posées.
+  const hydratedRef = React.useRef<boolean>(deps.hydrateScheduledIds === undefined);
+  // Bump à chaque fin d'hydratation pour relancer le useEffect principal.
+  const [hydrationTick, setHydrationTick] = React.useState(0);
+
+  // Hydratation cross-session au montage : on appelle la plateforme UNE
+  // fois pour récupérer les ids déjà programmés côté OS (ex. Expo après
+  // redémarrage du process). Voir JSDoc de `hydrateScheduledIds`.
+  React.useEffect(() => {
+    const hydrate = hydrateRef.current;
+    if (hydrate === undefined) return undefined;
+    let cancelled = false;
+    void hydrate()
+      .then((ids) => {
+        if (cancelled) return;
+        for (const id of ids) scheduledIdsRef.current.add(id);
+        hydratedRef.current = true;
+        setHydrationTick((t) => t + 1);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        // L'hydratation est best-effort : si la plateforme échoue (OS
+        // indisponible, permissions perdues), on continue avec un Set
+        // vide — les éventuels doublons sont un moindre mal vs un refus
+        // total de programmer. Pas de log (contient pas de donnée santé,
+        // mais reste silencieux pour cohérence avec cancelLocalNotification).
+        hydratedRef.current = true;
+        setHydrationTick((t) => t + 1);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   React.useEffect(() => {
     if (doc === null) return undefined;
+    if (!hydratedRef.current) return undefined;
 
     const nowDate = nowRef.current();
     const nowMs = nowDate.getTime();
@@ -130,7 +186,7 @@ export function useReminderScheduler(deps: UseReminderSchedulerDeps): void {
     }
 
     return undefined;
-  }, [doc, horizonMs]);
+  }, [doc, horizonMs, hydrationTick]);
 
   // Au démontage, annule toutes les notifs programmées par ce hook. Évite
   // les notifs « orphelines » si l'utilisateur se déconnecte.

--- a/packages/sync/src/client/useReminderScheduler.ts
+++ b/packages/sync/src/client/useReminderScheduler.ts
@@ -1,0 +1,140 @@
+import * as React from 'react';
+import type { Reminder } from '@kinhale/domain';
+import type { KinhaleDoc } from '../doc/schema.js';
+import {
+  DEFAULT_REMINDER_HORIZON_MS,
+  projectScheduledReminders,
+} from '../projections/reminders.js';
+
+/**
+ * Arguments passés à `scheduleLocalNotification` côté plateforme.
+ *
+ * Le contrat est volontairement minimal :
+ * - `id` : identifiant stable pour annuler plus tard la notification.
+ * - `triggerAtUtc` : ISO 8601 UTC ; l'implémentation plateforme calcule
+ *   elle-même le délai par rapport à `Date.now()`.
+ * - `title` / `body` : **chaînes déjà traduites** (pas de clé i18n —
+ *   les wrappers apps résolvent i18n via leur hook `useTranslation`).
+ */
+export interface ScheduleLocalNotificationArgs {
+  readonly id: string;
+  readonly triggerAtUtc: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface UseReminderSchedulerDeps {
+  /** Hook plateforme : document Automerge courant (source de vérité). */
+  readonly useDoc: () => KinhaleDoc | null;
+  /** Programme une notification locale — contrat idempotent : (re)programme l'id donné. */
+  readonly scheduleLocalNotification: (args: ScheduleLocalNotificationArgs) => Promise<void>;
+  /** Annule une notification locale précédemment programmée. No-op si inconnue. */
+  readonly cancelLocalNotification: (id: string) => Promise<void>;
+  /**
+   * Horloge injectée. Doit retourner un `Date` représentant le temps UTC
+   * courant. Injectable pour tests.
+   */
+  readonly now: () => Date;
+  /**
+   * Horizon de matérialisation (défaut 48 h — aligné sur la projection).
+   * Si vous abaissez cette valeur, pensez à réduire le throttle côté OS.
+   */
+  readonly horizonMs?: number;
+  /**
+   * Titre et corps **déjà traduits** du push `reminder`.
+   * Valeurs sobres par défaut recommandées :
+   * - title = "Kinhale" (ou clé i18n `reminder.title`)
+   * - body  = "Prise prévue" (ou clé i18n `reminder.body`)
+   *
+   * **Interdit** : toute mention de dose, pompe, prénom, action
+   * thérapeutique ou médicale. La contrainte est opposable (non
+   * dispositif médical, SPECS §7.4).
+   */
+  readonly reminderTitle: string;
+  readonly reminderBody: string;
+}
+
+/**
+ * Hook framework-agnostique qui maintient l'alignement entre les rappels
+ * projetés depuis le doc Automerge et les notifications locales
+ * programmées côté OS.
+ *
+ * Fonctionnement :
+ * - À chaque changement du doc (ou de l'horloge via rerender), projette les
+ *   rappels `scheduled` sur l'horizon (48 h).
+ * - Diff avec l'état interne des notifications déjà programmées par ce hook.
+ * - Programme les nouveaux (`scheduleLocalNotification`).
+ * - Annule les obsolètes (`cancelLocalNotification`).
+ *
+ * Zéro donnée santé : le payload contient uniquement `title` + `body`
+ * sobres — jamais le nom de la pompe, la dose ou le prénom. Cette
+ * contrainte est portée par le contrat d'injection (`reminderTitle`,
+ * `reminderBody`) ; elle ne peut pas être contournée par le hook.
+ *
+ * Refs: KIN-038, SPECS §9 (canaux, RM16-like pour notif locale).
+ */
+export function useReminderScheduler(deps: UseReminderSchedulerDeps): void {
+  const doc = deps.useDoc();
+
+  // Latest-ref pattern : stabilise l'identité des callbacks plateforme pour
+  // que l'effet ne retrigger que sur changement de doc.
+  const scheduleRef = React.useRef(deps.scheduleLocalNotification);
+  const cancelRef = React.useRef(deps.cancelLocalNotification);
+  const nowRef = React.useRef(deps.now);
+  const titleRef = React.useRef(deps.reminderTitle);
+  const bodyRef = React.useRef(deps.reminderBody);
+  scheduleRef.current = deps.scheduleLocalNotification;
+  cancelRef.current = deps.cancelLocalNotification;
+  nowRef.current = deps.now;
+  titleRef.current = deps.reminderTitle;
+  bodyRef.current = deps.reminderBody;
+
+  const horizonMs = deps.horizonMs ?? DEFAULT_REMINDER_HORIZON_MS;
+
+  // État local persistant : ids de notifications programmées par ce hook.
+  // Stocké dans une ref pour ne pas déclencher de re-render.
+  const scheduledIdsRef = React.useRef<Set<string>>(new Set());
+
+  React.useEffect(() => {
+    if (doc === null) return undefined;
+
+    const reminders = projectScheduledReminders(doc, nowRef.current(), horizonMs);
+    const desiredIds = new Set(reminders.map((r) => r.id));
+    const currentIds = scheduledIdsRef.current;
+
+    const toSchedule: Reminder[] = reminders.filter((r) => !currentIds.has(r.id));
+    const toCancel: string[] = [];
+    for (const id of currentIds) {
+      if (!desiredIds.has(id)) toCancel.push(id);
+    }
+
+    // Applique les opérations en parallèle — le hook ne dépend pas du résultat.
+    for (const reminder of toSchedule) {
+      currentIds.add(reminder.id);
+      void scheduleRef.current({
+        id: reminder.id,
+        triggerAtUtc: reminder.targetAtUtc,
+        title: titleRef.current,
+        body: bodyRef.current,
+      });
+    }
+    for (const id of toCancel) {
+      currentIds.delete(id);
+      void cancelRef.current(id);
+    }
+
+    return undefined;
+  }, [doc, horizonMs]);
+
+  // Au démontage, annule toutes les notifs programmées par ce hook. Évite
+  // les notifs « orphelines » si l'utilisateur se déconnecte.
+  React.useEffect(() => {
+    return () => {
+      const ids = Array.from(scheduledIdsRef.current);
+      scheduledIdsRef.current.clear();
+      for (const id of ids) {
+        void cancelRef.current(id);
+      }
+    };
+  }, []);
+}

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -52,6 +52,7 @@ export type { ProjectedPump } from './projections/pumps.js';
 export { projectPumps } from './projections/pumps.js';
 export {
   DEFAULT_REMINDER_HORIZON_MS,
+  DEFAULT_REMINDER_LOOKBACK_MS,
   projectScheduledReminders,
   REMINDER_WINDOW_AFTER_MS,
   REMINDER_WINDOW_BEFORE_MS,

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -50,3 +50,9 @@ export type { ProjectedPlan } from './projections/plan.js';
 export { projectPlan } from './projections/plan.js';
 export type { ProjectedPump } from './projections/pumps.js';
 export { projectPumps } from './projections/pumps.js';
+export {
+  DEFAULT_REMINDER_HORIZON_MS,
+  projectScheduledReminders,
+  REMINDER_WINDOW_AFTER_MS,
+  REMINDER_WINDOW_BEFORE_MS,
+} from './projections/reminders.js';

--- a/packages/sync/src/projections/reminders.ts
+++ b/packages/sync/src/projections/reminders.ts
@@ -1,0 +1,169 @@
+import type { Reminder } from '@kinhale/domain';
+import type { KinhaleDoc } from '../doc/schema.js';
+import { projectPlan } from './plan.js';
+import { projectDoses } from './doses.js';
+
+/** Horizon par défaut pour la matérialisation des rappels (48 h). */
+export const DEFAULT_REMINDER_HORIZON_MS = 48 * 60 * 60 * 1000;
+
+/**
+ * Tolérance **amont** sur la fenêtre de confirmation : un aidant peut
+ * administrer la dose jusqu'à 5 min avant l'heure cible sans être pénalisé.
+ * Aligné sur SPECS §9 (tolérance de déclenchement) et W2.
+ */
+export const REMINDER_WINDOW_BEFORE_MS = 5 * 60 * 1000;
+
+/**
+ * Fenêtre **aval** : une dose reste confirmable jusqu'à target + 30 min
+ * (RM2, défaut X=30 min configurable par foyer entre 10 et 120 min).
+ * En v1.0 on garde la valeur par défaut, le paramétrage foyer sera
+ * ajouté en E5-S07.
+ */
+export const REMINDER_WINDOW_AFTER_MS = 30 * 60 * 1000;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Matérialise les rappels `scheduled` à venir dans l'horizon fourni.
+ *
+ * Algorithme (pur, sans effet de bord) :
+ * 1. Projette le plan actif le plus récent (`projectPlan`). Si aucun plan
+ *    ou plan expiré (`endAtMs < now`), retourne `[]`.
+ * 2. Pour chaque heure cible du plan (`scheduledHoursUtc`), parcourt les
+ *    jours UTC couverts par `[now, now + horizonMs]` et produit un créneau
+ *    `Date(Y-M-D, h:00Z)`.
+ * 3. Filtre les créneaux hors intervalle `[now, now + horizonMs]`.
+ * 4. Filtre les créneaux déjà confirmés par une dose `maintenance` dont
+ *    `administeredAtMs` tombe dans la fenêtre `[windowStart, windowEnd]`
+ *    ET dont la pompe correspond à celle du plan.
+ * 5. Retourne la liste triée par `targetAtUtc` croissant.
+ *
+ * Zero-knowledge : la projection ne lit que des événements déjà présents
+ * côté client (doc Automerge local), jamais depuis le relais. Elle ne
+ * produit aucune chaîne contenant de donnée santé.
+ *
+ * @param doc      Document Automerge du foyer.
+ * @param now      Horloge injectée pour permettre un test pur.
+ * @param horizonMs Fenêtre de matérialisation (défaut 48 h).
+ *
+ * Refs: KIN-038, SPECS §3.7 (Rappel), §9 (délais), §W4, RM2.
+ */
+export function projectScheduledReminders(
+  doc: KinhaleDoc,
+  now: Date,
+  horizonMs: number = DEFAULT_REMINDER_HORIZON_MS,
+): Reminder[] {
+  const plan = projectPlan(doc);
+  if (plan === null) return [];
+
+  const nowMs = now.getTime();
+  const horizonEndMs = nowMs + horizonMs;
+
+  // Plan expiré (endAt strictement antérieur à now) : aucun rappel à émettre.
+  if (plan.endAtMs !== null && plan.endAtMs < nowMs) {
+    return [];
+  }
+
+  // Plan qui démarre après l'horizon : aucun créneau à matérialiser.
+  if (plan.startAtMs > horizonEndMs) {
+    return [];
+  }
+
+  const planStartMs = Math.max(plan.startAtMs, 0);
+  // Effective start : max(plan.startAtMs, now - 1 jour) pour itérer les jours
+  // UTC pertinents sans produire une liste énorme pour les plans anciens.
+  const iterStartMs = Math.max(planStartMs, nowMs - DAY_MS);
+  // Effective end : min(plan.endAtMs, now + horizon).
+  const iterEndMs = plan.endAtMs !== null ? Math.min(plan.endAtMs, horizonEndMs) : horizonEndMs;
+
+  // Détermine la date UTC de départ et compte le nombre de jours à parcourir.
+  const startDate = new Date(iterStartMs);
+  const startDayUtcMs = Date.UTC(
+    startDate.getUTCFullYear(),
+    startDate.getUTCMonth(),
+    startDate.getUTCDate(),
+  );
+
+  // On itère au maximum sur 1 + ceil((iterEndMs - startDayUtcMs) / DAY_MS) jours.
+  const days = Math.max(0, Math.ceil((iterEndMs - startDayUtcMs) / DAY_MS) + 1);
+  const confirmedDoseIdsByTarget = buildConfirmedIndex(doc, plan.pumpId);
+
+  const reminders: Reminder[] = [];
+  for (let i = 0; i < days; i++) {
+    const dayMs = startDayUtcMs + i * DAY_MS;
+    for (const hour of plan.scheduledHoursUtc) {
+      if (!Number.isFinite(hour) || hour < 0 || hour > 23) continue;
+      const targetMs = dayMs + Math.floor(hour) * 60 * 60 * 1000;
+      if (targetMs < nowMs || targetMs > horizonEndMs) continue;
+      if (plan.endAtMs !== null && targetMs > plan.endAtMs) continue;
+
+      const windowStartMs = targetMs - REMINDER_WINDOW_BEFORE_MS;
+      const windowEndMs = targetMs + REMINDER_WINDOW_AFTER_MS;
+
+      const targetIso = new Date(targetMs).toISOString();
+      const confirmedDoseId = findConfirmingDose(
+        confirmedDoseIdsByTarget,
+        windowStartMs,
+        windowEndMs,
+      );
+      if (confirmedDoseId !== null) continue;
+
+      reminders.push({
+        id: makeReminderId(plan.planId, targetIso),
+        planId: plan.planId,
+        targetAtUtc: targetIso,
+        windowStartUtc: new Date(windowStartMs).toISOString(),
+        windowEndUtc: new Date(windowEndMs).toISOString(),
+        status: 'scheduled',
+      });
+    }
+  }
+
+  reminders.sort((a, b) => (a.targetAtUtc < b.targetAtUtc ? -1 : a.targetAtUtc > b.targetAtUtc ? 1 : 0));
+  return reminders;
+}
+
+/**
+ * Index minimaliste des doses `maintenance` confirmées pour la pompe du plan,
+ * trié par `administeredAtMs`. Permet une recherche linéaire rapide par
+ * fenêtre temporelle (on attend ≤ quelques centaines d'entrées par foyer sur
+ * l'horizon récent, pas de besoin d'index B-tree).
+ */
+interface ConfirmedDose {
+  readonly doseId: string;
+  readonly administeredAtMs: number;
+}
+
+function buildConfirmedIndex(doc: KinhaleDoc, pumpId: string): ConfirmedDose[] {
+  const out: ConfirmedDose[] = [];
+  for (const dose of projectDoses(doc)) {
+    if (dose.doseType !== 'maintenance') continue;
+    if (dose.pumpId !== pumpId) continue;
+    out.push({ doseId: dose.doseId, administeredAtMs: dose.administeredAtMs });
+  }
+  out.sort((a, b) => a.administeredAtMs - b.administeredAtMs);
+  return out;
+}
+
+function findConfirmingDose(
+  doses: ReadonlyArray<ConfirmedDose>,
+  windowStartMs: number,
+  windowEndMs: number,
+): string | null {
+  for (const dose of doses) {
+    if (dose.administeredAtMs < windowStartMs) continue;
+    if (dose.administeredAtMs > windowEndMs) break; // tri croissant
+    return dose.doseId;
+  }
+  return null;
+}
+
+/**
+ * ID déterministe du rappel : `r:<planId>:<targetIso>`.
+ * Le format est stable pour garantir l'idempotence côté scheduler (même
+ * rappel recalculé à chaque doc change doit retourner le même id pour
+ * éviter une programmation duplicate côté OS).
+ */
+function makeReminderId(planId: string, targetIso: string): string {
+  return `r:${planId}:${targetIso}`;
+}

--- a/packages/sync/src/projections/reminders.ts
+++ b/packages/sync/src/projections/reminders.ts
@@ -7,6 +7,19 @@ import { projectDoses } from './doses.js';
 export const DEFAULT_REMINDER_HORIZON_MS = 48 * 60 * 60 * 1000;
 
 /**
+ * Rétro-visibilité par défaut : la projection conserve les créneaux dont
+ * `targetAtUtc` est au plus 2 h dans le passé. Deux motivations :
+ * - **Scheduler** (brique 4) : filtre ensuite par `targetAtUtc >= now` côté
+ *   plateforme (l'OS refuserait un trigger passé de toute façon).
+ * - **Watcher dose manquée** (brique 5) : a besoin des créneaux dont la
+ *   fenêtre vient d'expirer pour détecter la transition → missed (RM25).
+ *
+ * 2 h couvre largement : fenêtre de confirmation = 30 min → un watcher
+ * qui tick toutes les 60 s rattrape n'importe quel missed dans la marge.
+ */
+export const DEFAULT_REMINDER_LOOKBACK_MS = 2 * 60 * 60 * 1000;
+
+/**
  * Tolérance **amont** sur la fenêtre de confirmation : un aidant peut
  * administrer la dose jusqu'à 5 min avant l'heure cible sans être pénalisé.
  * Aligné sur SPECS §9 (tolérance de déclenchement) et W2.
@@ -52,12 +65,14 @@ export function projectScheduledReminders(
   doc: KinhaleDoc,
   now: Date,
   horizonMs: number = DEFAULT_REMINDER_HORIZON_MS,
+  lookbackMs: number = DEFAULT_REMINDER_LOOKBACK_MS,
 ): Reminder[] {
   const plan = projectPlan(doc);
   if (plan === null) return [];
 
   const nowMs = now.getTime();
   const horizonEndMs = nowMs + horizonMs;
+  const lookbackStartMs = nowMs - lookbackMs;
 
   // Plan expiré (endAt strictement antérieur à now) : aucun rappel à émettre.
   if (plan.endAtMs !== null && plan.endAtMs < nowMs) {
@@ -70,9 +85,9 @@ export function projectScheduledReminders(
   }
 
   const planStartMs = Math.max(plan.startAtMs, 0);
-  // Effective start : max(plan.startAtMs, now - 1 jour) pour itérer les jours
+  // Effective start : max(plan.startAtMs, lookbackStart) pour itérer les jours
   // UTC pertinents sans produire une liste énorme pour les plans anciens.
-  const iterStartMs = Math.max(planStartMs, nowMs - DAY_MS);
+  const iterStartMs = Math.max(planStartMs, lookbackStartMs - DAY_MS);
   // Effective end : min(plan.endAtMs, now + horizon).
   const iterEndMs = plan.endAtMs !== null ? Math.min(plan.endAtMs, horizonEndMs) : horizonEndMs;
 
@@ -94,7 +109,7 @@ export function projectScheduledReminders(
     for (const hour of plan.scheduledHoursUtc) {
       if (!Number.isFinite(hour) || hour < 0 || hour > 23) continue;
       const targetMs = dayMs + Math.floor(hour) * 60 * 60 * 1000;
-      if (targetMs < nowMs || targetMs > horizonEndMs) continue;
+      if (targetMs < lookbackStartMs || targetMs > horizonEndMs) continue;
       if (plan.endAtMs !== null && targetMs > plan.endAtMs) continue;
 
       const windowStartMs = targetMs - REMINDER_WINDOW_BEFORE_MS;

--- a/packages/sync/src/projections/reminders.ts
+++ b/packages/sync/src/projections/reminders.ts
@@ -134,7 +134,9 @@ export function projectScheduledReminders(
     }
   }
 
-  reminders.sort((a, b) => (a.targetAtUtc < b.targetAtUtc ? -1 : a.targetAtUtc > b.targetAtUtc ? 1 : 0));
+  reminders.sort((a, b) =>
+    a.targetAtUtc < b.targetAtUtc ? -1 : a.targetAtUtc > b.targetAtUtc ? 1 : 0,
+  );
   return reminders;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -418,6 +418,9 @@ importers:
       '@kinhale/crypto':
         specifier: workspace:*
         version: link:../crypto
+      '@kinhale/domain':
+        specifier: workspace:*
+        version: link:../domain
     devDependencies:
       '@kinhale/eslint-config':
         specifier: workspace:*


### PR DESCRIPTION
## Contexte

Dernière brique de KIN-038 après PR A (#188 web) et PR B (#189 mobile). Couvre les **stories E5-S01, E5-S02, E5-S03** (cœur du workflow W4 « dose manquée »). Les stories E5-S04 (e-mail fallback) et E5-S05 (peer notification RM5 wiring UI) restent en tickets de suivi.

⚠️ **Ligne rouge dispositif médical** : aucune recommandation de dose, aucun message "appelez votre médecin", aucune alerte de crise. Toutes les chaînes ont été auditées par `kz-conformite`.

## Ce qui est livré

### Domaine (`packages/domain/`)
- **`entities/reminder.ts`** — nouveau type `Reminder` avec statuts `scheduled | sent | confirmed | missed | snoozed | cancelled`.
- **`rules/rm25-missed-dose.ts`** — règle de détection `detectMissedReminders(reminders, now)` avec **buffer de tolérance d'horloge `MISSED_DOSE_CLOCK_SKEW_BUFFER_MS = 120_000`** (protection contre dérive horloge device).

### Sync (`packages/sync/`)
- **`projections/reminders.ts`** — fonction pure `projectScheduledReminders(doc, now, horizonMs, lookbackMs)`. Itère les plans actifs, matérialise les créneaux, exclut ceux déjà confirmés par une dose dans la fenêtre.
- **`client/useReminderScheduler.ts`** — hook framework-agnostique via `UseReminderSchedulerDeps`. Diff entre rappels projetés et notifs déjà programmées côté OS. **Hydratation cross-session** via `hydrateScheduledIds()` pour éviter les doublons au redémarrage.
- **`client/useMissedDoseWatcher.ts`** — hook `setInterval 60s` qui détecte les transitions `missed`. Check immédiat au montage, `Map<string, number>` avec TTL 24h, reset au switch household.

### Apps (web + mobile)
- **`apps/mobile/src/lib/sync/index.ts`** — wrapper qui branche le scheduler sur `Notifications.scheduleNotificationAsync`, hydratation depuis `Notifications.getAllScheduledNotificationsAsync()` filtrée sur préfixe `r:`.
- **`apps/web/src/lib/sync/index.ts`** — wrapper Web Notifications API. **`enableWebReminders()` exporté** pour activation explicite via toggle UI (pas de `requestPermission()` intempestif).
- **`providers/index.tsx`** (web + mobile) — montage `RemindersBootstrap`.

### i18n
- **`packages/i18n/src/locales/{fr,en}/common.json`** — 4 nouvelles clés (`reminder.title`, `reminder.body`, `missed_dose.title`, `missed_dose.body`). Strings FR : "Kinhale" / "Prise prévue" / "Dose non confirmée". Strings EN : "Kinhale" / "Dose reminder" / "Dose not confirmed".

## Garanties zero-knowledge + non-DM

- **Payload notification** : aucune donnée santé. Juste les chaînes i18n génériques. Contrat d'injection TypeScript bloque structurellement l'ajout de données santé dans `title`/`body`.
- **Projection 100 % locale** depuis le doc Automerge (déjà en clair en mémoire après déchiffrement). Rien ne sort vers le relais ni vers APNs/FCM.
- **Permission Web** derrière toggle explicite (plus de demande intempestive).

## Revues préalables (3 axes)

### `kz-review` — OK merge après MINEURS
Tous les MINEURS pertinents corrigés (check immédiat montage, TTL 24h sur `notifiedIdsRef`, reset household). 

### `kz-securite` — 0 P0/P1 — **2 MAJEURS corrigés dans cette PR** :
- **M1** (idempotence Expo cross-session) : rebuild `scheduledIdsRef` depuis OS au montage via `getAllScheduledNotificationsAsync()` filtré sur préfixe `r:`. Commit `f723cc8`.
- **M2** (dérive d'horloge device) : buffer 120s dans `rm25-missed-dose.ts`. Commit `665129d`. Buffer porté dans la règle domain (invariant), pas dupliqué dans le watcher.

### `kz-conformite` — **CONFORME AVEC RÉSERVES non bloquantes**
- 8 strings i18n (FR + EN) auditées — toutes **factuelles et sobres**, aucune recommandation de dose, aucun diagnostic, aucun message d'alerte médicale.
- Projection locale → aucun transfert de donnée santé vers OS / relais.
- Réserves mineures déléguées en tickets de suivi (onboarding permission mobile, persistance événement Automerge pour statut `missed`).

Rapports archivés : `.agents/current-run/kz-review-KIN-038-prC.md`, `.agents/current-run/kz-securite-KIN-038-prC.md`, `.agents/current-run/kz-conformite-KIN-038-prC.md`.

## Diff-stat

**23 fichiers, +2012 / -3 lignes.** PR conséquente, justifiée par **3 stories P0 cohérentes fonctionnellement** (scheduler + détection forme un tout indivisible). Découper aurait forcé des PRs intermédiaires non fonctionnelles.

## Plan de test

- [x] `pnpm --filter @kinhale/domain test` — **654 tests verts** (17 nouveaux RM25)
- [x] `pnpm --filter @kinhale/sync test` — **133 tests verts** (scheduler + watcher + projection)
- [x] `pnpm --filter @kinhale/web test` — **91 tests verts**
- [x] `pnpm --filter @kinhale/mobile test` — **69 tests verts**
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm format:check`, `pnpm lint:root` — tous verts
- [ ] Test manuel post-merge : créer un plan journalier → notif locale déclenche à l'heure prévue → laisser expirer sans confirmer → 30 min après, notif `missed_dose` émise côté device. À faire sur un simulateur iOS + un Android + Chrome.

## Choix de design

1. **Buffer 120s dans la règle domain** (pas dans le watcher) — l'invariant est porté par RM25 elle-même. Toute couche amont hérite automatiquement.
2. **ID déterministe `r:<planId>:<targetIso>`** — idempotence garantie, pas de duplicata côté OS.
3. **`markReminderMissed = no-op` en v1.0** — la persistance de l'événement `ReminderStatusChanged` dans le doc Automerge est hors scope (ticket de suivi).
4. **Chaînes i18n injectées** (pas lues dans le hook) — contrat opposable contre le leak de donnée santé.

## Tickets de suivi à ouvrir après merge

- **ADR** : `markReminderMissed` no-op v1.0 — persistance événement Automerge en v1.1
- **Onboarding permission notifications** — demande contextuelle avec finalité + révocabilité (Loi 25)
- **Ticket UX** : toggle "Activer les rappels web" qui appelle `enableWebReminders()`
- **Ticket CI** : regex anti-recommandation sur les chaînes i18n (`/\d+\s*(puffs?|doses?|mg)/i`)
- **E5-S04** : e-mail fallback via Postmark pour `missed_dose`
- **E5-S05** : peer notification RM5 wiring UI/push (la logique `planPeerNotification` existe déjà dans le domain)

## Invariants préservés

- **Zero-knowledge** : aucune donnée santé n'atteint le relais, APNs/FCM, ou la Web Notifications API.
- **Non-dispositif-médical** : ligne rouge respectée (kz-conformite validé).
- **TypeScript strict** : pas de `any`, pas de `@ts-ignore`.
- **Aucune nouvelle dépendance npm**.

Refs: KIN-038

🤖 Generated with [Claude Code](https://claude.com/claude-code)