### PR TITLE
ci(install): durcit pnpm install contre les lenteurs de registre

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   lint-typecheck-test:
     name: Lint · Typecheck · Test
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,8 +30,27 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
+      - name: Get pnpm store directory
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-${{ runner.os }}-
+
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        timeout-minutes: 8
+        run: pnpm install --frozen-lockfile --prefer-offline
+        env:
+          NPM_CONFIG_FETCH_RETRIES: '5'
+          NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: '15000'
+          NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: '120000'
+          NPM_CONFIG_NETWORK_CONCURRENCY: '16'
 
       - name: Format check
         run: pnpm format:check
@@ -57,9 +76,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Cache pnpm store (Alpine)
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/pnpm-store
+          key: pnpm-store-alpine-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-store-alpine-
+
       - name: Verify scaffold on Alpine (musl libc)
+        timeout-minutes: 8
         run: |
+          mkdir -p "${RUNNER_TEMP}/pnpm-store"
           docker run --rm \
+            -v "${RUNNER_TEMP}/pnpm-store:/root/.local/share/pnpm/store" \
             -v "$GITHUB_WORKSPACE:/ws:ro" \
             node:20-alpine sh -c '
               set -eu
@@ -67,7 +97,7 @@ jobs:
               cd /tmp/work
               corepack enable
               corepack prepare pnpm@10.33.0 --activate
-              pnpm install --frozen-lockfile
+              pnpm install --frozen-lockfile --prefer-offline
               pnpm format:check
               pnpm lint:root
               pnpm typecheck


### PR DESCRIPTION
## Contexte

Le job `Lint · Typecheck · Test` de la PR #194 (KIN-038 PR C) a été **annulé par timeout après 15 min 15 s**, bloqué intégralement sur `pnpm install --frozen-lockfile`.

Diagnostic complet dans `.agents/current-run/kz-devops-KIN-038-ci-timeout.md` :

- Cache pnpm froid : `pnpm-lock.yaml` modifié → clé hashée par `actions/setup-node` invalide → cache miss total (`reused 0`, téléchargement de 1720 paquets).
- Registre npm lent sur Azure east US 2 cette nuit-là : pics de 6 min sans progression, warnings `Tarball download average speed < 50 KiB/s`, 1 `ECONNRESET`.
- Au kill : **1719 / 1721 tarballs ajoutés** — l'install était à une poignée de paquets près.

Aucun code applicatif n'avait été exécuté. C'est un incident d'infrastructure / registre, pas un bug produit.

## Correctifs appliqués

### Job `lint-typecheck-test`

- `timeout-minutes` du job : **15 → 20 min** (budget après un install lent mais non-pathologique).
- Nouvelle étape `Cache pnpm store` via `actions/cache@v4` avec `restore-keys: pnpm-store-${runner.os}-` → un lockfile modifié retombe sur une clé proche au lieu d'un cache miss complet.
- Étape `Install dependencies` durcie :
  - `timeout-minutes: 8` (échoue vite au lieu de brûler les 15 min du job)
  - `pnpm install --frozen-lockfile --prefer-offline`
  - `NPM_CONFIG_FETCH_RETRIES=5`, `NPM_CONFIG_FETCH_RETRY_MINTIMEOUT=15000`, `NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT=120000`, `NPM_CONFIG_NETWORK_CONCURRENCY=16`

### Job `docker-alpine-verify`

- `timeout-minutes: 8` sur le `docker run`.
- Bind-mount `${RUNNER_TEMP}/pnpm-store:/root/.local/share/pnpm/store` pour persister le store pnpm entre runs, enveloppé par un `actions/cache@v4` dédié (clé `pnpm-store-alpine-<hash(lockfile)>`).
- `pnpm install --frozen-lockfile --prefer-offline` dans le conteneur.
- `mkdir -p "${RUNNER_TEMP}/pnpm-store"` avant `docker run` pour garantir l'existence du point de montage au premier run.

### Ce qui n'a **pas** été touché

- `cache: pnpm` de `setup-node@v4` conservé en **superposition**, pas en remplacement — objectif court terme : filet de sécurité, pas changement de stratégie.
- Workflow `e2e-web.yml` hors scope — ticket de suivi possible si même pattern souhaité.
- Aucun code applicatif, aucune dépendance ajoutée.

## Revues préalables (workflow obligatoire Kinhale)

- **kz-review** : GO avec réserves mineures (0 bloquant, 0 majeur, 6 mineurs — tous hors scope ou observations). Rapport : `.agents/current-run/kz-review-ci-harden.md`.
- **kz-securite** : GO sans réserve bloquante (0 bloquant, 0 majeur, 2 mineurs). Analyse : actions officielles pinnées major conforme à la politique repo, cache isolé par ref GitHub, déclencheur `pull_request` sans secrets exposés, bind-mount éphémère, `--frozen-lockfile` garantit l'intégrité des tarballs, aucune donnée santé / PII dans le diff. Rapport : `.agents/current-run/kz-securite-ci-harden.md`.

## Résultat attendu côté CI

- **1er run (cold cache)** : `Install dependencies` doit terminer en < 8 min. Si le registre npm est exceptionnellement lent, l'étape échoue vite et un rerun suffit — le cache est alors repeuplé pour les runs suivants.
- **2e run (cache chaud, même lockfile)** : install en < 30 s avec `Progress: resolved … reused > 1500`.

## Test plan

- [ ] CI `Lint · Typecheck · Test` passe au vert en < 20 min
- [ ] CI `Docker · node:20-alpine (musl)` passe au vert en < 10 min
- [ ] CI `playwright` passe au vert (hors scope du diff, vérification de non-régression)
- [ ] Logs d'install montrent le chemin `actions/cache` activé (hit ou miss explicite)
- [ ] Après merge, un 2e run sur `develop` doit bénéficier du cache pour confirmer le gain

Refs: KIN-038

🤖 Generated with [Claude Code](https://claude.com/claude-code)