### PR TITLE
feat(sync): reconnexion WS avec backoff exponentiel côté client

### DIFF
--- a/apps/mobile/src/lib/relay-client.ts
+++ b/apps/mobile/src/lib/relay-client.ts
@@ -17,9 +17,24 @@ export interface RelayClient {
   close(): void;
 }
 
-export function createRelayClient(token: string, onMessage: RelayMessageHandler): RelayClient {
+export function createRelayClient(
+  token: string,
+  onMessage: RelayMessageHandler,
+  onClose?: () => void,
+): RelayClient {
   const url = `${toWsUrl(API_URL)}/relay?token=${encodeURIComponent(token)}`;
   const ws = new WebSocket(url);
+
+  // Garde-fou contre les doubles signaux : certaines piles WS émettent
+  // `error` puis `close` pour une même rupture. Un `client.close()` explicite
+  // doit également inhiber `onClose`, sinon le hook relancerait une boucle
+  // de reconnexion pour une fermeture voulue côté app.
+  let closedSignaled = false;
+  const signalClose = (): void => {
+    if (closedSignaled) return;
+    closedSignaled = true;
+    onClose?.();
+  };
 
   ws.addEventListener('message', (event) => {
     try {
@@ -37,6 +52,9 @@ export function createRelayClient(token: string, onMessage: RelayMessageHandler)
     }
   });
 
+  ws.addEventListener('close', signalClose);
+  ws.addEventListener('error', signalClose);
+
   return {
     send(blobJson: string): void {
       // 1 === WebSocket.OPEN — comparaison sur la constante numérique pour compatibilité test/mock
@@ -45,6 +63,9 @@ export function createRelayClient(token: string, onMessage: RelayMessageHandler)
       }
     },
     close(): void {
+      // Inhibe `onClose` avant d'appeler `ws.close()` : une fermeture
+      // volontaire n'est pas une déconnexion à réparer.
+      closedSignaled = true;
       ws.close();
     },
   };

--- a/apps/web/src/lib/__tests__/relay-client.test.ts
+++ b/apps/web/src/lib/__tests__/relay-client.test.ts
@@ -100,4 +100,46 @@ describe('createRelayClient', () => {
     client.close();
     expect(mockWs.closed).toBe(true);
   });
+
+  // ---------------------------------------------------------------------------
+  // Propagation du signal de déconnexion vers le hook (KIN-69 / E6-S03).
+  // ---------------------------------------------------------------------------
+
+  it("appelle onClose quand le WebSocket émet 'close'", () => {
+    const onClose = jest.fn();
+    createRelayClient('tok', jest.fn(), onClose);
+    mockWs.emit('close', '');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("appelle onClose quand le WebSocket émet 'error'", () => {
+    const onClose = jest.fn();
+    createRelayClient('tok', jest.fn(), onClose);
+    mockWs.emit('error', '');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("dédoublonne error puis close pour ne déclencher onClose qu'une fois", () => {
+    const onClose = jest.fn();
+    createRelayClient('tok', jest.fn(), onClose);
+    mockWs.emit('error', '');
+    mockWs.emit('close', '');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("n'appelle pas onClose après un close volontaire côté client", () => {
+    const onClose = jest.fn();
+    const client = createRelayClient('tok', jest.fn(), onClose);
+    client.close();
+    // Les stacks réelles émettent `close` après ws.close() — simulation.
+    mockWs.emit('close', '');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('fonctionne sans onClose (paramètre optionnel rétrocompatible)', () => {
+    expect(() => {
+      createRelayClient('tok', jest.fn());
+      mockWs.emit('close', '');
+    }).not.toThrow();
+  });
 });

--- a/apps/web/src/lib/relay-client.ts
+++ b/apps/web/src/lib/relay-client.ts
@@ -17,9 +17,24 @@ export interface RelayClient {
   close(): void;
 }
 
-export function createRelayClient(token: string, onMessage: RelayMessageHandler): RelayClient {
+export function createRelayClient(
+  token: string,
+  onMessage: RelayMessageHandler,
+  onClose?: () => void,
+): RelayClient {
   const url = `${toWsUrl(API_URL)}/relay?token=${encodeURIComponent(token)}`;
   const ws = new WebSocket(url);
+
+  // Garde-fou contre les doubles signaux : certains navigateurs émettent
+  // `error` puis `close` pour une même rupture. Un `client.close()` explicite
+  // doit également inhiber `onClose`, sinon le hook relancerait une boucle
+  // de reconnexion pour une fermeture voulue côté app.
+  let closedSignaled = false;
+  const signalClose = (): void => {
+    if (closedSignaled) return;
+    closedSignaled = true;
+    onClose?.();
+  };
 
   ws.addEventListener('message', (event) => {
     try {
@@ -37,6 +52,9 @@ export function createRelayClient(token: string, onMessage: RelayMessageHandler)
     }
   });
 
+  ws.addEventListener('close', signalClose);
+  ws.addEventListener('error', signalClose);
+
   return {
     send(blobJson: string): void {
       // 1 === WebSocket.OPEN — comparaison sur la constante numérique pour compatibilité test/mock
@@ -45,6 +63,9 @@ export function createRelayClient(token: string, onMessage: RelayMessageHandler)
       }
     },
     close(): void {
+      // Inhibe `onClose` avant d'appeler `ws.close()` : une fermeture
+      // volontaire n'est pas une déconnexion à réparer.
+      closedSignaled = true;
       ws.close();
     },
   };

--- a/packages/sync/src/client/__tests__/useRelaySync.test.tsx
+++ b/packages/sync/src/client/__tests__/useRelaySync.test.tsx
@@ -1,7 +1,7 @@
 /**
  * @vitest-environment jsdom
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import type { Mock } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import type { KinhaleDoc } from '../../doc/schema.js';
@@ -67,11 +67,15 @@ const mockRelayClient: RelayClient & { send: Mock; close: Mock } = {
 };
 
 let capturedOnMessage: RelayMessageHandler | null = null;
+let capturedOnClose: (() => void) | null = null;
 
-const mockCreateRelayClient = vi.fn((_token: string, onMessage: RelayMessageHandler) => {
-  capturedOnMessage = onMessage;
-  return mockRelayClient;
-});
+const mockCreateRelayClient = vi.fn(
+  (_token: string, onMessage: RelayMessageHandler, onClose?: () => void) => {
+    capturedOnMessage = onMessage;
+    capturedOnClose = onClose ?? null;
+    return mockRelayClient;
+  },
+);
 
 const mockDeriveGroupKey = vi.fn(async (_householdId: string) => new Uint8Array(32).fill(1));
 
@@ -130,6 +134,7 @@ describe('useRelaySync (package client)', () => {
     fakeDoc = null;
     fakeReceiveChanges = vi.fn();
     capturedOnMessage = null;
+    capturedOnClose = null;
     mockRelayClient.send.mockClear();
     mockRelayClient.close.mockClear();
     mockBuildSyncMessage.mockClear();
@@ -170,7 +175,11 @@ describe('useRelaySync (package client)', () => {
       await flushPromises();
     });
 
-    expect(mockCreateRelayClient).toHaveBeenCalledWith('tok-test', expect.any(Function));
+    expect(mockCreateRelayClient).toHaveBeenCalledWith(
+      'tok-test',
+      expect.any(Function),
+      expect.any(Function),
+    );
   });
 
   it('retourne connected:true après que la WS est ouverte', async () => {
@@ -403,5 +412,215 @@ describe('useRelaySync (package client)', () => {
 
     expect(mockReportDecryptFailed).not.toHaveBeenCalled();
     expect(fakeReceiveChanges).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Reconnexion avec backoff exponentiel (KIN-69 / E6-S03).
+  //
+  // Séquence des délais : 1s, 2s, 5s, 15s, 60s, puis 60s en boucle.
+  // Une connexion restée stable plus de 30s remet le compteur à zéro.
+  // ---------------------------------------------------------------------------
+  describe('reconnexion avec backoff exponentiel', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: false });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /**
+     * Avance les timers fake de `ms` millisecondes tout en laissant les
+     * micro-tâches (Promise.resolve) progresser. Wrappé dans `act` pour
+     * que React traite les effets déclenchés par la reconnexion.
+     */
+    async function advanceBy(ms: number): Promise<void> {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ms);
+      });
+    }
+
+    /**
+     * Ouvre une session synchronisée prête à encaisser un disconnect :
+     * renderHook + attente de la 1re connexion WS.
+     */
+    async function connectFully() {
+      setAuthenticated();
+      setDocLoaded();
+      const handle = renderHook(() => useRelaySync(buildDeps()));
+      await advanceBy(0);
+      return handle;
+    }
+
+    it('passe un callback onClose à createRelayClient pour que la factory puisse signaler la déconnexion', async () => {
+      await connectFully();
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(1);
+      const call = mockCreateRelayClient.mock.calls[0];
+      expect(call?.[2]).toEqual(expect.any(Function));
+    });
+
+    it('repasse connected:false dès que onClose est appelé', async () => {
+      setAuthenticated();
+      setDocLoaded();
+      const { result } = renderHook(() => useRelaySync(buildDeps()));
+      await advanceBy(0);
+
+      expect(result.current.connected).toBe(true);
+
+      act(() => {
+        capturedOnClose?.();
+      });
+
+      expect(result.current.connected).toBe(false);
+    });
+
+    it('reconnecte après 1s lors de la première déconnexion', async () => {
+      await connectFully();
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        capturedOnClose?.();
+      });
+
+      // 999 ms avant l'échéance : pas encore de reconnexion.
+      await advanceBy(999);
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(1);
+
+      // À 1000 ms exactement : nouvelle tentative.
+      await advanceBy(1);
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(2);
+    });
+
+    it('applique la séquence 1s, 2s, 5s, 15s, 60s sur des déconnexions successives', async () => {
+      await connectFully();
+      const delays = [1000, 2000, 5000, 15000, 60000];
+
+      for (let i = 0; i < delays.length; i++) {
+        const delayMs = delays[i] ?? 0;
+        act(() => {
+          capturedOnClose?.();
+        });
+        await advanceBy(delayMs - 1);
+        // Pas encore reconnecté.
+        expect(mockCreateRelayClient).toHaveBeenCalledTimes(i + 1);
+        await advanceBy(1);
+        // Reconnecté → nouvelle entrée dans mockCreateRelayClient.
+        expect(mockCreateRelayClient).toHaveBeenCalledTimes(i + 2);
+      }
+    });
+
+    it('plafonne les tentatives suivantes à 60s (boucle)', async () => {
+      await connectFully();
+      // Épuise la rampe : 5 déconnexions → on est au palier 60s.
+      const delays = [1000, 2000, 5000, 15000, 60000];
+      for (const d of delays) {
+        act(() => {
+          capturedOnClose?.();
+        });
+        await advanceBy(d);
+      }
+      const callsAfterRamp = mockCreateRelayClient.mock.calls.length;
+
+      // 6e déconnexion → doit aussi retenter après 60s (pas plus, pas moins).
+      act(() => {
+        capturedOnClose?.();
+      });
+      await advanceBy(59999);
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(callsAfterRamp);
+      await advanceBy(1);
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(callsAfterRamp + 1);
+    });
+
+    it('remet le compteur à zéro après une connexion restée stable plus de 30s', async () => {
+      await connectFully();
+
+      // 1re déconnexion → backoff 1s → reconnexion à t+1s.
+      act(() => {
+        capturedOnClose?.();
+      });
+      await advanceBy(1000);
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(2);
+
+      // 2e déconnexion immédiate → si le compteur n'était pas reset, on
+      // attendrait 2s. On laisse d'abord la connexion stable 30s pour
+      // déclencher le reset.
+      await advanceBy(30_000);
+
+      act(() => {
+        capturedOnClose?.();
+      });
+      // Après reset, on repart de 1s (pas 2s).
+      await advanceBy(999);
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(2);
+      await advanceBy(1);
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(3);
+    });
+
+    it('ne tente plus de reconnexion après unmount', async () => {
+      setAuthenticated();
+      setDocLoaded();
+      const { unmount } = renderHook(() => useRelaySync(buildDeps()));
+      await advanceBy(0);
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        capturedOnClose?.();
+      });
+
+      act(() => {
+        unmount();
+      });
+
+      // Laisse largement passer 60s — aucun reconnect ne doit survenir.
+      await advanceBy(120_000);
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(1);
+    });
+
+    it('abandonne après 15 tentatives consécutives (plafond anti-boucle sur JWT expiré)', async () => {
+      await connectFully();
+
+      // Scénario modélisé : le handshake échoue immédiatement à chaque
+      // reconnexion (cas JWT expiré rejeté en 401 HTTP par le serveur,
+      // indistinguable d'un flap réseau côté browser). On avance strictement
+      // du délai de backoff — jamais plus — pour que le timer de stabilité
+      // (30 s) ne tire jamais et que le compteur progresse sans reset.
+      const backoffSteps = [1000, 2000, 5000, 15000];
+      for (let i = 0; i < 15; i++) {
+        act(() => {
+          capturedOnClose?.();
+        });
+        const delay = i < backoffSteps.length ? (backoffSteps[i] ?? 60000) : 60000;
+        await advanceBy(delay);
+      }
+
+      // 1 connexion initiale + 15 reconnexions = 16 appels à createRelayClient.
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(16);
+
+      // 16e déconnexion → le plafond est atteint, aucune nouvelle tentative
+      // ne doit être schedulée, même après plusieurs minutes d'attente.
+      act(() => {
+        capturedOnClose?.();
+      });
+      await advanceBy(10 * 60_000);
+
+      expect(mockCreateRelayClient).toHaveBeenCalledTimes(16);
+    });
+
+    it('ferme le client courant à chaque tentative pour éviter les fuites de handles', async () => {
+      await connectFully();
+
+      act(() => {
+        capturedOnClose?.();
+      });
+      await advanceBy(1000);
+
+      act(() => {
+        capturedOnClose?.();
+      });
+      await advanceBy(2000);
+
+      // 2 déconnexions → 2 close() accumulés (hors démontage final).
+      expect(mockRelayClient.close).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/sync/src/client/useRelaySync.ts
+++ b/packages/sync/src/client/useRelaySync.ts
@@ -39,8 +39,46 @@ export interface RelayClient {
   close(): void;
 }
 
-/** Factory plateforme qui ouvre une connexion WS et renvoie un client relai. */
-export type CreateRelayClient = (token: string, onMessage: RelayMessageHandler) => RelayClient;
+/**
+ * Factory plateforme qui ouvre une connexion WS et renvoie un client relai.
+ *
+ * `onClose` est optionnel pour compatibilité ascendante ; quand il est fourni,
+ * la factory doit l'invoquer dès que la connexion est fermée ou en erreur,
+ * afin que le hook puisse déclencher une reconnexion avec backoff (E6-S03).
+ */
+export type CreateRelayClient = (
+  token: string,
+  onMessage: RelayMessageHandler,
+  onClose?: () => void,
+) => RelayClient;
+
+/**
+ * Séquence des délais de reconnexion (ms) : 1s, 2s, 5s, 15s, puis 60s
+ * répétés pour toutes les tentatives suivantes. Plafonner à 60s évite
+ * de noyer un relai déjà en difficulté. Refs: E6-S03.
+ */
+const BACKOFF_DELAYS_MS = [1000, 2000, 5000, 15000, 60000];
+
+/**
+ * Plafond absolu du nombre de tentatives consécutives. Atteint, le hook
+ * abandonne la reconnexion et laisse `connected:false` jusqu'à la prochaine
+ * bascule d'auth ou de doc (qui recrée l'effet et redémarre le compteur).
+ *
+ * Dimensionnement : 15 tentatives ≈ 1+2+5+15 + 60×11 = 683s ≈ 11 min,
+ * proche du TTL du JWT d'accès (15 min). Protège contre une boucle infinie
+ * si le handshake échoue durablement (token expiré rejeté en 401 HTTP,
+ * invisible comme close code côté client). Le palliatif est minimal — une
+ * propagation propre des close codes 4401/4403 est suivie dans un ticket
+ * dédié (voir PR body et `kz-securite-KIN-069.md` §M1).
+ */
+const MAX_RECONNECT_ATTEMPTS = 15;
+
+/**
+ * Durée pendant laquelle une connexion doit rester stable avant que le
+ * compteur de tentatives soit remis à zéro. Empêche un flap
+ * connect/disconnect rapide de consommer toute la rampe de backoff.
+ */
+const STABILITY_RESET_MS = 30000;
 
 /**
  * Dépendances injectées du hook `useRelaySync`.
@@ -119,6 +157,11 @@ export function useRelaySync(deps: UseRelaySyncDeps): { connected: boolean } {
   const cursorRef = React.useRef<SyncCursor>(createCursor());
   const seqRef = React.useRef(0);
   const keyRef = React.useRef<Uint8Array | null>(null);
+  // Compteur de déconnexions consécutives. Reset à 0 après
+  // STABILITY_RESET_MS de connexion stable. Refs: E6-S03.
+  const failuresCountRef = React.useRef(0);
+  const reconnectTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stabilityTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Reporter de télémétrie `sync.decrypt_failed` (KIN-040). Stable pour la
   // durée de vie du hook — le rate-limiter vit dans la closure du reporter.
@@ -159,6 +202,10 @@ export function useRelaySync(deps: UseRelaySyncDeps): { connected: boolean } {
   getDocSnapshotRef.current = deps.getDocSnapshot;
 
   // 1. Ouvre la WS quand l'utilisateur est authentifié et que le doc est chargé.
+  //    Gère aussi la reconnexion automatique avec backoff exponentiel (E6-S03)
+  //    via le callback `onClose` injecté à la factory plateforme. La séquence
+  //    de délais est 1s, 2s, 5s, 15s, 60s puis 60s en boucle. Une connexion
+  //    restée stable plus de STABILITY_RESET_MS remet le compteur à zéro.
   React.useEffect(() => {
     if (accessToken === null || deviceId === null || householdId === null || !docReady) {
       return undefined;
@@ -166,49 +213,123 @@ export function useRelaySync(deps: UseRelaySyncDeps): { connected: boolean } {
 
     let cancelled = false;
 
-    void (async () => {
-      const groupKey = await deriveGroupKeyRef.current(householdId);
+    const clearReconnectTimer = (): void => {
+      if (reconnectTimerRef.current !== null) {
+        clearTimeout(reconnectTimerRef.current);
+        reconnectTimerRef.current = null;
+      }
+    };
+    const clearStabilityTimer = (): void => {
+      if (stabilityTimerRef.current !== null) {
+        clearTimeout(stabilityTimerRef.current);
+        stabilityTimerRef.current = null;
+      }
+    };
+
+    const handleDisconnect = (): void => {
       if (cancelled) return;
 
-      keyRef.current = groupKey;
+      setConnected(false);
+      clearStabilityTimer();
 
-      const client = createRelayClientRef.current(accessToken, async (msg) => {
-        if (keyRef.current === null) return;
-        const currentDoc = getDocSnapshotRef.current();
-        if (currentDoc === null) return;
+      // Toujours fermer le client courant avant d'en recréer un :
+      // évite d'accumuler des handles WS en cas de déconnexions répétées.
+      clientRef.current?.close();
+      clientRef.current = null;
 
-        try {
-          const newDoc = await consumeSyncMessage(currentDoc, msg.blobJson, keyRef.current);
-          // Extraire uniquement le delta pour éviter de re-persister des
-          // changements déjà présents dans le doc local.
-          const deltaChanges = getDocChanges(currentDoc, newDoc);
-          if (deltaChanges.length > 0) {
-            receiveChanges(deltaChanges);
-            cursorRef.current = recordReceived(cursorRef.current, deltaChanges);
+      const attempt = failuresCountRef.current;
+
+      // Stop après MAX_RECONNECT_ATTEMPTS : évite une boucle infinie si la
+      // cause racine est non-résolvable côté client (ex. JWT expiré rejeté
+      // en 401 HTTP au handshake, indistinguable d'un flap réseau côté
+      // browser). Une bascule d'auth/doc recréera l'effet et remettra le
+      // compteur à zéro.
+      if (attempt >= MAX_RECONNECT_ATTEMPTS) {
+        clearReconnectTimer();
+        return;
+      }
+
+      failuresCountRef.current = attempt + 1;
+      const delay = BACKOFF_DELAYS_MS[Math.min(attempt, BACKOFF_DELAYS_MS.length - 1)] ?? 60000;
+
+      clearReconnectTimer();
+      reconnectTimerRef.current = setTimeout(() => {
+        reconnectTimerRef.current = null;
+        void connect();
+      }, delay);
+    };
+
+    const connect = async (): Promise<void> => {
+      if (cancelled) return;
+
+      // La groupKey est Argon2id-dérivée (coûteux, ~100ms) : on la garde
+      // entre deux tentatives pour que la reconnexion soit quasi immédiate.
+      if (keyRef.current === null) {
+        const groupKey = await deriveGroupKeyRef.current(householdId);
+        if (cancelled) return;
+        keyRef.current = groupKey;
+      }
+
+      const client = createRelayClientRef.current(
+        accessToken,
+        async (msg) => {
+          if (keyRef.current === null) return;
+          const currentDoc = getDocSnapshotRef.current();
+          if (currentDoc === null) return;
+
+          try {
+            const newDoc = await consumeSyncMessage(currentDoc, msg.blobJson, keyRef.current);
+            // Extraire uniquement le delta pour éviter de re-persister des
+            // changements déjà présents dans le doc local.
+            const deltaChanges = getDocChanges(currentDoc, newDoc);
+            if (deltaChanges.length > 0) {
+              receiveChanges(deltaChanges);
+              cursorRef.current = recordReceived(cursorRef.current, deltaChanges);
+            }
+          } catch (err: unknown) {
+            // Message invalide, corrompu ou clé incorrecte — la sync continue.
+            // Aucune donnée santé n'est loggée : on n'émet qu'un événement de
+            // télémétrie pseudonymisé (payload figé par `DecryptFailedEvent`),
+            // jamais `err.message` ni `err.stack`.
+            // Refs: KIN-040, kz-securite-KIN-038.md §M2.
+            telemetryReporterRef.current?.track({
+              householdId,
+              errorClass: classifyDecryptError(err),
+              seq: msg.seq,
+            });
           }
-        } catch (err: unknown) {
-          // Message invalide, corrompu ou clé incorrecte — la sync continue.
-          // Aucune donnée santé n'est loggée : on n'émet qu'un événement de
-          // télémétrie pseudonymisé (payload figé par `DecryptFailedEvent`),
-          // jamais `err.message` ni `err.stack`.
-          // Refs: KIN-040, kz-securite-KIN-038.md §M2.
-          telemetryReporterRef.current?.track({
-            householdId,
-            errorClass: classifyDecryptError(err),
-            seq: msg.seq,
-          });
-        }
-      });
+        },
+        handleDisconnect,
+      );
+
+      if (cancelled) {
+        client.close();
+        return;
+      }
 
       clientRef.current = client;
       setConnected(true);
-    })();
+
+      // Reset du compteur si la connexion reste stable ≥ STABILITY_RESET_MS.
+      // Un flap avant cette échéance laisse le compteur intact → la rampe
+      // de backoff continue de s'appliquer.
+      clearStabilityTimer();
+      stabilityTimerRef.current = setTimeout(() => {
+        stabilityTimerRef.current = null;
+        failuresCountRef.current = 0;
+      }, STABILITY_RESET_MS);
+    };
+
+    void connect();
 
     return () => {
       cancelled = true;
+      clearReconnectTimer();
+      clearStabilityTimer();
       clientRef.current?.close();
       clientRef.current = null;
       keyRef.current = null;
+      failuresCountRef.current = 0;
       setConnected(false);
       // Flush le storm en cours avant de perdre la fenêtre rate-limit.
       telemetryReporterRef.current?.flush();


### PR DESCRIPTION
Closes #69

## Contexte

Le hook mutualisé `useRelaySync` (livré via KIN-038 PR A/B puis mutualisé par KIN-039) ouvre la WebSocket E2EE au relai mais **n'a aucune logique de reconnexion**. Une simple coupure réseau ou un redémarrage relai laisse la synchronisation temps réel muette jusqu'à un remount complet de l'app.

Cette PR couvre la story **E6-S03 — Reconnexion WS avec backoff exponentiel**. Le scope est intentionnellement resserré au client : le pull delta `/sync/since` évoqué dans les critères d'acceptation relève de **KIN-70 / E6-S04** (endpoint backend pas encore posé).

## Changements côté hook (`packages/sync/src/client/useRelaySync.ts`)

- Signature `CreateRelayClient` étendue d'un 3e paramètre optionnel `onClose: () => void` que la factory plateforme doit invoquer à chaque rupture.
- Séquence de backoff **1 s → 2 s → 5 s → 15 s → 60 s** puis 60 s répétés.
- **Plafond `MAX_RECONNECT_ATTEMPTS = 15`** tentatives consécutives (~11 min, proche du TTL JWT de 15 min). Dépasser le plafond laisse `connected:false` ; un refresh d'auth ou un rechargement du doc recrée l'effet et remet le compteur à zéro.
- Compteur **remis à zéro après 30 s** de connexion stable, via un timer démarré à la réussite de `connect()`.
- La `groupKey` (Argon2id) est conservée en mémoire entre tentatives : pas d'écriture disque, pas de dérivation répétée coûteuse.
- Cleanup au démontage : annulation des timers, fermeture du client, reset du compteur.

## Changements côté factories apps (`apps/{web,mobile}/src/lib/relay-client.ts`)

- Nouvelle signature `createRelayClient(token, onMessage, onClose?)`, **rétrocompatible**.
- Branchement de `onClose` sur les events natifs `close` et `error`.
- Garde-fou `closedSignaled` qui :
  - dédoublonne `error` → `close` consécutifs (certains navigateurs émettent les deux pour une même rupture),
  - inhibe `onClose` lorsque la fermeture vient d'un `client.close()` volontaire (sinon le hook relancerait une boucle pour une fermeture voulue).

## Tests

- `packages/sync/src/client/__tests__/useRelaySync.test.tsx` — 8 tests avec fake timers : présence du callback `onClose`, passage à `connected:false`, reconnexion à 1 s, séquence complète `[1, 2, 5, 15, 60]`, plafond à 60 s en boucle, reset après 30 s stable, **abandon après 15 tentatives (scénario JWT expiré)**, absence de reconnexion après unmount, fermeture du client courant à chaque tentative.
- `apps/web/src/lib/__tests__/relay-client.test.ts` — 5 tests additionnels : émission sur `close`, émission sur `error`, dédoublonnage `error+close`, inhibition après `client.close()`, rétrocompatibilité sans `onClose`.
- Suite globale : **sync 142/142, web 96/96, lint + typecheck verts**.

## Revues préalables (workflow Kinhale obligatoire zone `packages/sync` → 2 revues)

- **kz-review** : GO avec 0 bloquant / 0 majeur / 6 mineurs (commentaires clarifiés en amont). Rapport : `.agents/current-run/kz-review-KIN-069.md`.
- **kz-securite** : GO après correction du seul MAJEUR remonté — **boucle de reconnexion infinie sur JWT expiré** — résolu par le plafond `MAX_RECONNECT_ATTEMPTS = 15`. La propagation propre des close codes `4401`/`4403` reste ouverte comme raffinement pour un ticket de suivi. Rapport : `.agents/current-run/kz-securite-KIN-069.md`.

## Limitations connues (tickets de suivi à ouvrir)

- **Pas de jitter aléatoire** sur les délais → risque de thundering herd si un redémarrage relai fait retomber simultanément des milliers de clients. À ajouter avec `crypto.getRandomValues` (jamais `Math.random`) quand le relai montera en charge.
- **Pas de test unitaire côté mobile** (`apps/mobile/src/lib/__tests__/relay-client.test.ts` absent avant cette PR — pas aggravé mais l'occasion n'est pas saisie ici).
- **Pas de télémétrie** sur les cycles de reconnexion : volontaire pour ne pas élargir le scope, mais constitue un gap d'observabilité à couvrir dans l'épique E11.
- **Pull delta `/sync/since`** à la reconnexion cité par l'AC de la story → réservé à **KIN-70 / E6-S04** (endpoint backend pas encore posé).

## Test plan

- [ ] CI `Lint · Typecheck · Test` vert
- [ ] CI `Docker · node:20-alpine (musl)` vert
- [ ] CI `playwright` vert (non-régression)
- [ ] QA manuel recommandé avant merge : tuer le conteneur `api` pendant que le web est connecté, vérifier que le web retente à 1 s puis 2 s puis 5 s et retrouve la sync une fois l'api redémarrée

Refs: KIN-69, ADR-D9

🤖 Generated with [Claude Code](https://claude.com/claude-code)