### PR TITLE
feat(sync): pull delta catchup à l'ouverture + polling 60 s côté client

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,13 +99,11 @@ Résumé — détails complets dans `docs/contributing/GITFLOW.md`.
 - Squash-merge sur `feature/*` → `develop` ; merge-commit sur `release/*` → `main`.
 - Linear history forcée sur `main`.
 - Signatures GPG/SSH obligatoires.
-- PR > 400 lignes modifiées = justification ou découpage.
 
 ## Méthodologie
 
 - Tests avant merge. Pas de merge sans CI verte.
 - Review d'au moins 1 pair ; **2 reviews obligatoires** si la PR touche `packages/crypto`, `packages/sync`, ou tout code de sécurité.
-- Aucune PR ne touche plus de ~400 lignes modifiées sauf exception justifiée.
 - Pas de commit direct sur `main` ou `develop`.
 - Un ADR (`docs/architecture/adr/`) pour toute décision architecturale structurante.
 

--- a/apps/mobile/src/lib/sync/index.ts
+++ b/apps/mobile/src/lib/sync/index.ts
@@ -1,11 +1,15 @@
 import { useTranslation } from 'react-i18next';
 import * as Notifications from 'expo-notifications';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   useRelaySync as useRelaySyncCore,
+  usePullDelta as usePullDeltaCore,
   useReminderScheduler as useReminderSchedulerCore,
   useMissedDoseWatcher as useMissedDoseWatcherCore,
   getGroupKey,
   type DecryptFailedEvent,
+  type FetchCatchupArgs,
+  type CatchupResponse,
 } from '@kinhale/sync/client';
 import { blake2bHex } from '@kinhale/crypto';
 import { createRelayClient } from '../relay-client';
@@ -147,7 +151,77 @@ export function useRelaySync(): { connected: boolean } {
  */
 export function RelaySyncBootstrap(): null {
   useRelaySync();
+  usePullDelta();
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Pull delta catchup (KIN-70 / E6-S04).
+//
+// Récupère les événements manqués au montage et toutes les 60 s via
+// `GET /relay/catchup?since=<seq>`. Curseur persisté en AsyncStorage,
+// scopé par foyer.
+// ---------------------------------------------------------------------------
+
+const API_URL = process.env['EXPO_PUBLIC_API_URL'] ?? 'http://localhost:3001';
+const CURSOR_STORAGE_PREFIX = 'kinhale-sync-cursor:';
+
+function cursorKey(householdId: string): string {
+  return `${CURSOR_STORAGE_PREFIX}${householdId}`;
+}
+
+async function fetchCatchup(args: FetchCatchupArgs): Promise<CatchupResponse> {
+  const url = new URL(`${API_URL}/relay/catchup`);
+  url.searchParams.set('since', String(args.since));
+  const res = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${args.accessToken}` },
+  });
+  if (!res.ok) {
+    // Remonte l'échec au hook — le curseur ne sera pas avancé pour ce tick.
+    throw new Error(`catchup fetch failed: ${res.status}`);
+  }
+  const json = (await res.json()) as CatchupResponse;
+  return json;
+}
+
+function loadCursorFactory(getHouseholdId: () => string | null): () => Promise<number> {
+  return async () => {
+    const id = getHouseholdId();
+    if (id === null) return 0;
+    const raw = await AsyncStorage.getItem(cursorKey(id));
+    if (raw === null) return 0;
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  };
+}
+
+function saveCursorFactory(getHouseholdId: () => string | null): (cursor: number) => Promise<void> {
+  return async (cursor: number) => {
+    const id = getHouseholdId();
+    if (id === null) return;
+    await AsyncStorage.setItem(cursorKey(id), String(cursor));
+  };
+}
+
+/**
+ * Wrapper applicatif mobile qui monte le pull delta catchup. Doit être
+ * rendu en parallèle de `useRelaySync()` — les deux se complètent : WS
+ * pour le live, catchup pour rattraper ce qui a été manqué pendant une
+ * absence.
+ */
+export function usePullDelta(): { pulling: boolean } {
+  return usePullDeltaCore({
+    useAccessToken: () => useAuthStore((s) => s.accessToken),
+    useHouseholdId: () => useAuthStore((s) => s.householdId),
+    useDoc: () => useDocStore((s) => s.doc),
+    getDocSnapshot: () => useDocStore.getState().doc,
+    useReceiveChanges: () => useDocStore((s) => s.receiveChanges),
+    fetchCatchup,
+    loadCursor: loadCursorFactory(() => useAuthStore.getState().householdId),
+    saveCursor: saveCursorFactory(() => useAuthStore.getState().householdId),
+    deriveGroupKey: getGroupKey,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/sync/index.ts
+++ b/apps/web/src/lib/sync/index.ts
@@ -3,10 +3,13 @@
 import { useTranslation } from 'react-i18next';
 import {
   useRelaySync as useRelaySyncCore,
+  usePullDelta as usePullDeltaCore,
   useReminderScheduler as useReminderSchedulerCore,
   useMissedDoseWatcher as useMissedDoseWatcherCore,
   getGroupKey,
   type DecryptFailedEvent,
+  type FetchCatchupArgs,
+  type CatchupResponse,
 } from '@kinhale/sync/client';
 import { blake2bHex } from '@kinhale/crypto';
 import { createRelayClient } from '../relay-client';
@@ -162,7 +165,78 @@ export function useRelaySync(): { connected: boolean } {
  */
 export function RelaySyncBootstrap(): null {
   useRelaySync();
+  usePullDelta();
   return null;
+}
+
+// ---------------------------------------------------------------------------
+// Pull delta catchup (KIN-70 / E6-S04).
+//
+// Récupère les événements manqués au montage et toutes les 60 s via
+// `GET /relay/catchup?since=<seq>`. Curseur persisté en localStorage,
+// scopé par foyer.
+// ---------------------------------------------------------------------------
+
+const API_URL = process.env['NEXT_PUBLIC_API_URL'] ?? 'http://localhost:3001';
+const CURSOR_STORAGE_PREFIX = 'kinhale-sync-cursor:';
+
+function cursorKey(householdId: string): string {
+  return `${CURSOR_STORAGE_PREFIX}${householdId}`;
+}
+
+async function fetchCatchup(args: FetchCatchupArgs): Promise<CatchupResponse> {
+  const url = new URL(`${API_URL}/relay/catchup`);
+  url.searchParams.set('since', String(args.since));
+  const res = await fetch(url.toString(), {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${args.accessToken}` },
+  });
+  if (!res.ok) {
+    // Remonte l'échec au hook — le curseur ne sera pas avancé pour ce tick.
+    throw new Error(`catchup fetch failed: ${res.status}`);
+  }
+  const json = (await res.json()) as CatchupResponse;
+  return json;
+}
+
+function loadCursorFactory(getHouseholdId: () => string | null): () => Promise<number> {
+  return async () => {
+    if (typeof window === 'undefined') return 0;
+    const id = getHouseholdId();
+    if (id === null) return 0;
+    const raw = window.localStorage.getItem(cursorKey(id));
+    if (raw === null) return 0;
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  };
+}
+
+function saveCursorFactory(getHouseholdId: () => string | null): (cursor: number) => Promise<void> {
+  return async (cursor: number) => {
+    if (typeof window === 'undefined') return;
+    const id = getHouseholdId();
+    if (id === null) return;
+    window.localStorage.setItem(cursorKey(id), String(cursor));
+  };
+}
+
+/**
+ * Wrapper applicatif web qui monte le pull delta catchup. Doit être rendu
+ * en parallèle de `useRelaySync()` — les deux se complètent : WS pour le
+ * live, catchup pour rattraper ce qui a été manqué pendant une absence.
+ */
+export function usePullDelta(): { pulling: boolean } {
+  return usePullDeltaCore({
+    useAccessToken: () => useAuthStore((s) => s.accessToken),
+    useHouseholdId: () => useAuthStore((s) => s.householdId),
+    useDoc: () => useDocStore((s) => s.doc),
+    getDocSnapshot: () => useDocStore.getState().doc,
+    useReceiveChanges: () => useDocStore((s) => s.receiveChanges),
+    fetchCatchup,
+    loadCursor: loadCursorFactory(() => useAuthStore.getState().householdId),
+    saveCursor: saveCursorFactory(() => useAuthStore.getState().householdId),
+    deriveGroupKey: getGroupKey,
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/sync/src/client/__tests__/usePullDelta.test.tsx
+++ b/packages/sync/src/client/__tests__/usePullDelta.test.tsx
@@ -1,0 +1,376 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { KinhaleDoc } from '../../doc/schema.js';
+import type * as A from '@automerge/automerge';
+
+// ---------------------------------------------------------------------------
+// Mock du module @kinhale/sync (helpers E2EE).
+// ---------------------------------------------------------------------------
+
+const mockConsumeSyncMessage = vi.fn(async (_doc: unknown, _json: string, _key: Uint8Array) => ({
+  __mocked: true,
+}));
+const mockGetDocChanges = vi.fn((_before: unknown, _after: unknown) => [] as Uint8Array[]);
+
+vi.mock('../../index.js', () => ({
+  consumeSyncMessage: (doc: unknown, json: string, key: Uint8Array) =>
+    mockConsumeSyncMessage(doc, json, key),
+  getDocChanges: (before: unknown, after: unknown) => mockGetDocChanges(before, after),
+}));
+
+// Import APRÈS vi.mock — hoisting vitest est garanti.
+import { usePullDelta } from '../usePullDelta.js';
+import type { CatchupResponse, FetchCatchup } from '../usePullDelta.js';
+
+// ---------------------------------------------------------------------------
+// État plateforme simulé — injecté via deps du hook.
+// ---------------------------------------------------------------------------
+
+type FakeDoc = A.Doc<KinhaleDoc>;
+
+let fakeAuth: {
+  accessToken: string | null;
+  householdId: string | null;
+};
+let fakeDoc: FakeDoc | null;
+let fakeReceiveChanges: Mock;
+let fetchCatchup: Mock<FetchCatchup>;
+let loadCursor: Mock<() => Promise<number>>;
+let saveCursor: Mock<(n: number) => Promise<void>>;
+let deriveGroupKey: Mock<(id: string) => Promise<Uint8Array>>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- fake doc opaque pour les tests : pas d'impact prod
+const makeFakeDoc = (payload: Record<string, unknown>): FakeDoc => payload as any;
+
+function buildDeps(overrides: Partial<Parameters<typeof usePullDelta>[0]> = {}) {
+  return {
+    useAccessToken: () => fakeAuth.accessToken,
+    useHouseholdId: () => fakeAuth.householdId,
+    useDoc: () => fakeDoc,
+    getDocSnapshot: () => fakeDoc,
+    useReceiveChanges: () => fakeReceiveChanges,
+    fetchCatchup,
+    loadCursor,
+    saveCursor,
+    deriveGroupKey,
+    ...overrides,
+  };
+}
+
+function setAuthenticated(): void {
+  fakeAuth = {
+    accessToken: 'tok-test',
+    householdId: 'household-001',
+  };
+}
+
+function setDocLoaded(): void {
+  fakeDoc = makeFakeDoc({ householdId: 'household-001', events: [] });
+}
+
+async function flush(rounds = 6): Promise<void> {
+  for (let i = 0; i < rounds; i++) {
+    await Promise.resolve();
+  }
+}
+
+function makeMessage(seq: number): CatchupResponse['messages'][number] {
+  return {
+    id: `evt-${seq}`,
+    senderDeviceId: 'device-X',
+    blobJson: `{"seq":${seq}}`,
+    seq,
+    sentAtMs: seq * 1000,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('usePullDelta (package client)', () => {
+  beforeEach(() => {
+    fakeAuth = { accessToken: null, householdId: null };
+    fakeDoc = null;
+    fakeReceiveChanges = vi.fn();
+    mockConsumeSyncMessage.mockClear();
+    mockGetDocChanges.mockClear();
+    fetchCatchup = vi.fn(async () => ({ messages: [], hasMore: false }));
+    loadCursor = vi.fn(async () => 0);
+    saveCursor = vi.fn(async () => undefined);
+    deriveGroupKey = vi.fn(async () => new Uint8Array(32).fill(1));
+  });
+
+  it('ne déclenche aucun pull si pas authentifié', async () => {
+    renderHook(() => usePullDelta(buildDeps()));
+    await act(async () => {
+      await flush();
+    });
+    expect(fetchCatchup).not.toHaveBeenCalled();
+    expect(loadCursor).not.toHaveBeenCalled();
+  });
+
+  it('ne déclenche aucun pull si le doc est null', async () => {
+    setAuthenticated();
+    renderHook(() => usePullDelta(buildDeps()));
+    await act(async () => {
+      await flush();
+    });
+    expect(fetchCatchup).not.toHaveBeenCalled();
+  });
+
+  it('appelle fetchCatchup avec le curseur persisté au montage', async () => {
+    setAuthenticated();
+    setDocLoaded();
+    loadCursor.mockResolvedValueOnce(42);
+
+    renderHook(() => usePullDelta(buildDeps()));
+    await act(async () => {
+      await flush();
+    });
+
+    expect(loadCursor).toHaveBeenCalledTimes(1);
+    expect(fetchCatchup).toHaveBeenCalledWith({
+      accessToken: 'tok-test',
+      householdId: 'household-001',
+      since: 42,
+    });
+  });
+
+  it('applique les deltas reçus et sauvegarde le dernier seq', async () => {
+    setAuthenticated();
+    setDocLoaded();
+    fetchCatchup.mockResolvedValueOnce({
+      messages: [makeMessage(1), makeMessage(2)],
+      hasMore: false,
+    });
+    mockGetDocChanges.mockReturnValueOnce([new Uint8Array([1])]);
+    mockGetDocChanges.mockReturnValueOnce([new Uint8Array([2])]);
+
+    renderHook(() => usePullDelta(buildDeps()));
+    await act(async () => {
+      await flush();
+    });
+
+    expect(fakeReceiveChanges).toHaveBeenCalledTimes(2);
+    expect(saveCursor).toHaveBeenLastCalledWith(2);
+  });
+
+  it('ne sauvegarde pas de curseur si fetchCatchup échoue (erreur réseau)', async () => {
+    setAuthenticated();
+    setDocLoaded();
+    loadCursor.mockResolvedValueOnce(10);
+    fetchCatchup.mockRejectedValueOnce(new Error('network error'));
+
+    renderHook(() => usePullDelta(buildDeps()));
+    await act(async () => {
+      await flush();
+    });
+
+    expect(saveCursor).not.toHaveBeenCalled();
+  });
+
+  it('paginate immédiatement si hasMore=true', async () => {
+    setAuthenticated();
+    setDocLoaded();
+    loadCursor.mockResolvedValueOnce(0);
+    fetchCatchup
+      .mockResolvedValueOnce({ messages: [makeMessage(1)], hasMore: true })
+      .mockResolvedValueOnce({ messages: [makeMessage(2)], hasMore: false });
+
+    renderHook(() => usePullDelta(buildDeps()));
+    await act(async () => {
+      await flush();
+    });
+
+    expect(fetchCatchup).toHaveBeenCalledTimes(2);
+    expect(fetchCatchup).toHaveBeenNthCalledWith(2, {
+      accessToken: 'tok-test',
+      householdId: 'household-001',
+      since: 1,
+    });
+    expect(saveCursor).toHaveBeenLastCalledWith(2);
+  });
+
+  it('sort de la boucle si le relai renvoie {messages:[], hasMore:true} (anti-spin)', async () => {
+    setAuthenticated();
+    setDocLoaded();
+    loadCursor.mockResolvedValueOnce(0);
+    // Mock "malveillant/buggé" : toujours hasMore=true mais 0 messages.
+    fetchCatchup.mockResolvedValue({ messages: [], hasMore: true });
+
+    renderHook(() => usePullDelta(buildDeps()));
+    await act(async () => {
+      await flush();
+    });
+
+    // Un seul appel : le hook doit sortir dès le 1er batch vide au lieu de
+    // reboucler à l'infini. Refs: kz-securite-KIN-070 §B1.
+    expect(fetchCatchup).toHaveBeenCalledTimes(1);
+    expect(saveCursor).not.toHaveBeenCalled();
+  });
+
+  it("n'applique ni ne sauvegarde rien si unmount survient pendant qu'un fetch est en vol", async () => {
+    setAuthenticated();
+    setDocLoaded();
+    loadCursor.mockResolvedValueOnce(0);
+
+    // fetchCatchup bloque sur une Promise non résolue : on contrôle
+    // manuellement le moment de la résolution pour simuler un unmount
+    // qui arrive entre le fetch et l'application des messages.
+    let resolvePage1: ((r: CatchupResponse) => void) | null = null;
+    fetchCatchup.mockImplementationOnce(
+      () =>
+        new Promise<CatchupResponse>((r) => {
+          resolvePage1 = r;
+        }),
+    );
+
+    const { unmount } = renderHook(() => usePullDelta(buildDeps()));
+    await act(async () => {
+      await flush();
+    });
+    // fetchCatchup a été appelé, mais la Promise est toujours pendante.
+    expect(fetchCatchup).toHaveBeenCalledTimes(1);
+
+    // Unmount pendant que le fetch est en vol → cancelled=true + keyRef=null.
+    act(() => {
+      unmount();
+    });
+
+    // On résout maintenant la Promise avec des messages "normaux" : le
+    // guard en tête du `for` doit court-circuiter l'application ET empêcher
+    // `saveCursor` de persister un curseur fantôme. Refs: kz-review-KIN-070 §M1.
+    await act(async () => {
+      resolvePage1?.({
+        messages: [makeMessage(1), makeMessage(2)],
+        hasMore: false,
+      });
+      await flush();
+    });
+
+    expect(fakeReceiveChanges).not.toHaveBeenCalled();
+    expect(saveCursor).not.toHaveBeenCalled();
+  });
+
+  it('ignore silencieusement un blob qui ne déchiffre pas mais avance le curseur', async () => {
+    setAuthenticated();
+    setDocLoaded();
+    loadCursor.mockResolvedValueOnce(0);
+    fetchCatchup.mockResolvedValueOnce({
+      messages: [makeMessage(1), makeMessage(2)],
+      hasMore: false,
+    });
+    // Premier blob OK, second rejected.
+    mockConsumeSyncMessage.mockResolvedValueOnce({ __mocked: true });
+    mockConsumeSyncMessage.mockRejectedValueOnce(new Error('decrypt failed'));
+    mockGetDocChanges.mockReturnValueOnce([new Uint8Array([1])]);
+
+    renderHook(() => usePullDelta(buildDeps()));
+    await act(async () => {
+      await flush();
+    });
+
+    expect(fakeReceiveChanges).toHaveBeenCalledTimes(1);
+    // Curseur avance malgré l'erreur pour ne pas rester bloqué en boucle.
+    expect(saveCursor).toHaveBeenLastCalledWith(2);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Polling périodique + interactions avec le timer.
+  // ---------------------------------------------------------------------------
+  describe('polling', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: false });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    async function advanceBy(ms: number): Promise<void> {
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ms);
+      });
+    }
+
+    it('refetch toutes les 60s par défaut', async () => {
+      setAuthenticated();
+      setDocLoaded();
+
+      renderHook(() => usePullDelta(buildDeps()));
+      await advanceBy(0);
+      expect(fetchCatchup).toHaveBeenCalledTimes(1);
+
+      await advanceBy(59_999);
+      expect(fetchCatchup).toHaveBeenCalledTimes(1);
+
+      await advanceBy(1);
+      expect(fetchCatchup).toHaveBeenCalledTimes(2);
+
+      await advanceBy(60_000);
+      expect(fetchCatchup).toHaveBeenCalledTimes(3);
+    });
+
+    it('respecte un pollIntervalMs custom', async () => {
+      setAuthenticated();
+      setDocLoaded();
+
+      renderHook(() => usePullDelta(buildDeps({ pollIntervalMs: 5_000 })));
+      await advanceBy(0);
+      expect(fetchCatchup).toHaveBeenCalledTimes(1);
+
+      await advanceBy(5_000);
+      expect(fetchCatchup).toHaveBeenCalledTimes(2);
+    });
+
+    it('stoppe le polling au démontage', async () => {
+      setAuthenticated();
+      setDocLoaded();
+
+      const { unmount } = renderHook(() => usePullDelta(buildDeps()));
+      await advanceBy(0);
+      expect(fetchCatchup).toHaveBeenCalledTimes(1);
+
+      act(() => {
+        unmount();
+      });
+
+      await advanceBy(5 * 60_000);
+      expect(fetchCatchup).toHaveBeenCalledTimes(1);
+    });
+
+    it('ne déclenche pas de pull concurrent quand un pull est in-flight', async () => {
+      setAuthenticated();
+      setDocLoaded();
+      // fetchCatchup bloque jusqu'à resolvePendingPull.
+      let resolvePendingPull: ((r: CatchupResponse) => void) | null = null;
+      fetchCatchup.mockImplementation(
+        () =>
+          new Promise((r) => {
+            resolvePendingPull = r;
+          }),
+      );
+
+      renderHook(() => usePullDelta(buildDeps()));
+      await advanceBy(0);
+      expect(fetchCatchup).toHaveBeenCalledTimes(1);
+
+      // Le timer ticker plusieurs fois, mais le pull initial n'est pas résolu.
+      await advanceBy(3 * 60_000);
+      expect(fetchCatchup).toHaveBeenCalledTimes(1);
+
+      // Quand le pull initial se résout, le polling peut reprendre au tick suivant.
+      await act(async () => {
+        resolvePendingPull?.({ messages: [], hasMore: false });
+        await flush();
+      });
+      await advanceBy(60_000);
+      expect(fetchCatchup).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/packages/sync/src/client/index.ts
+++ b/packages/sync/src/client/index.ts
@@ -19,6 +19,16 @@ export type {
   CreateRelayClient,
   UseRelaySyncDeps,
 } from './useRelaySync.js';
+export { usePullDelta } from './usePullDelta.js';
+export type {
+  CatchupMessage,
+  CatchupResponse,
+  FetchCatchup,
+  FetchCatchupArgs,
+  UsePullDeltaDeps,
+  UsePullDeltaResult,
+} from './usePullDelta.js';
+
 export { useReminderScheduler } from './useReminderScheduler.js';
 export type {
   ScheduleLocalNotificationArgs,

--- a/packages/sync/src/client/usePullDelta.ts
+++ b/packages/sync/src/client/usePullDelta.ts
@@ -1,0 +1,245 @@
+import * as React from 'react';
+import type * as A from '@automerge/automerge';
+import { consumeSyncMessage, getDocChanges } from '../index.js';
+import type { KinhaleDoc } from '../doc/schema.js';
+
+/** Document Automerge d'un foyer (alias pour lisibilité). */
+type KinhaleDocument = A.Doc<KinhaleDoc>;
+
+/**
+ * Message de la mailbox E2EE renvoyé par `GET /relay/catchup`. Le blob est
+ * opaque pour le relai ; le hook le déchiffre localement via la groupKey.
+ */
+export interface CatchupMessage {
+  readonly id: string;
+  readonly senderDeviceId: string;
+  readonly blobJson: string;
+  readonly seq: number;
+  readonly sentAtMs: number;
+}
+
+export interface CatchupResponse {
+  readonly messages: readonly CatchupMessage[];
+  /** `true` si le relai a plus d'événements au-delà du dernier `seq` renvoyé. */
+  readonly hasMore: boolean;
+}
+
+export interface FetchCatchupArgs {
+  readonly accessToken: string;
+  readonly householdId: string;
+  readonly since: number;
+}
+
+/**
+ * Factory plateforme qui appelle l'endpoint `GET /relay/catchup?since=<n>`
+ * authentifié par Bearer token. L'implémentation concrète vit dans les
+ * wrappers `apps/web` et `apps/mobile` (accès à `fetch` / `expo-fetch` + URL API).
+ */
+export type FetchCatchup = (args: FetchCatchupArgs) => Promise<CatchupResponse>;
+
+/** Intervalle par défaut entre deux pulls périodiques (cf. AC E6-S04). */
+const DEFAULT_POLL_INTERVAL_MS = 60_000;
+
+/**
+ * Dépendances injectées du hook `usePullDelta`.
+ *
+ * Le hook est framework-agnostique : il ne connaît ni le framework d'état
+ * applicatif ni la pile réseau. Chaque app injecte ses propres stores, sa
+ * fonction `fetch` et son stockage persistant du curseur.
+ */
+export interface UsePullDeltaDeps {
+  /** Hook plateforme : token d'accès courant, `null` si non authentifié. */
+  readonly useAccessToken: () => string | null;
+  /** Hook plateforme : identifiant du foyer, `null` si non authentifié. */
+  readonly useHouseholdId: () => string | null;
+  /** Hook plateforme : document Automerge courant, `null` tant que non chargé. */
+  readonly useDoc: () => KinhaleDocument | null;
+  /** Hook plateforme : accesseur du doc en dehors du rendu (pour la boucle de pull). */
+  readonly getDocSnapshot: () => KinhaleDocument | null;
+  /** Hook plateforme : callback pour appliquer des changes reçus au doc local. */
+  readonly useReceiveChanges: () => (changes: Uint8Array[]) => void;
+  /** Factory plateforme qui appelle l'endpoint `GET /relay/catchup`. */
+  readonly fetchCatchup: FetchCatchup;
+  /**
+   * Charge le dernier curseur `seq` persisté localement. Retourne `0` si
+   * aucun curseur n'est connu (premier démarrage ou après reset).
+   */
+  readonly loadCursor: () => Promise<number>;
+  /** Persiste le curseur après un pull réussi (toute page de la pagination). */
+  readonly saveCursor: (cursor: number) => Promise<void>;
+  /** Dérive la groupKey (Argon2id, cachée) pour un foyer. */
+  readonly deriveGroupKey: (householdId: string) => Promise<Uint8Array>;
+  /**
+   * Intervalle entre deux pulls périodiques (ms). Par défaut
+   * {@link DEFAULT_POLL_INTERVAL_MS} = 60_000 (cf. AC E6-S04). Surchargable
+   * en test.
+   */
+  readonly pollIntervalMs?: number;
+}
+
+export interface UsePullDeltaResult {
+  /** `true` quand une requête est en cours (pour affichage d'un spinner). */
+  readonly pulling: boolean;
+}
+
+/**
+ * Hook qui récupère périodiquement les événements manqués via
+ * `GET /relay/catchup?since=<seq>` et les injecte dans le doc Automerge local.
+ *
+ * Comportement :
+ * - **Pull initial** au montage (dès que l'auth + le doc sont prêts).
+ * - **Polling** toutes les `pollIntervalMs` millisecondes (60 s par défaut).
+ * - **Pagination** : si le relai renvoie `hasMore: true`, refetch immédiat
+ *   avec le dernier `seq` jusqu'à épuisement.
+ * - **Verrou in-flight** : un seul pull à la fois — le tick du polling est
+ *   ignoré si un pull précédent n'est pas encore résolu. Évite l'empilement
+ *   des requêtes en cas de latence serveur.
+ * - **Curseur persistant** : chargé via `loadCursor()` au montage, sauvegardé
+ *   via `saveCursor()` après chaque page.
+ * - **Résilience** : une erreur réseau (ou autre rejet de `fetchCatchup`)
+ *   ne change pas le curseur — le prochain tick retentera avec la même
+ *   valeur. Un blob qui ne déchiffre pas est ignoré silencieusement mais le
+ *   curseur avance (sinon le hook resterait bloqué sur un event corrompu).
+ * - **Cleanup** : le timer de polling est arrêté au démontage ; toute boucle
+ *   de pagination en cours se termine proprement via un flag `cancelled`.
+ *
+ * Principe zero-knowledge respecté : le relai ne renvoie que des blobs
+ * chiffrés opaques (XChaCha20-Poly1305). Jamais de contenu en clair.
+ * La groupKey ne quitte jamais la mémoire du device.
+ *
+ * Refs: KIN-70, E6-S04, §7.2 SPECS.
+ */
+export function usePullDelta(deps: UsePullDeltaDeps): UsePullDeltaResult {
+  const accessToken = deps.useAccessToken();
+  const householdId = deps.useHouseholdId();
+  const doc = deps.useDoc();
+  const receiveChanges = deps.useReceiveChanges();
+
+  const [pulling, setPulling] = React.useState(false);
+  const keyRef = React.useRef<Uint8Array | null>(null);
+  const cursorRef = React.useRef<number | null>(null);
+  const inFlightRef = React.useRef(false);
+
+  // Pattern "latest ref" pour stabiliser l'identité vue par l'effet.
+  const fetchCatchupRef = React.useRef(deps.fetchCatchup);
+  const loadCursorRef = React.useRef(deps.loadCursor);
+  const saveCursorRef = React.useRef(deps.saveCursor);
+  const deriveGroupKeyRef = React.useRef(deps.deriveGroupKey);
+  const getDocSnapshotRef = React.useRef(deps.getDocSnapshot);
+  fetchCatchupRef.current = deps.fetchCatchup;
+  loadCursorRef.current = deps.loadCursor;
+  saveCursorRef.current = deps.saveCursor;
+  deriveGroupKeyRef.current = deps.deriveGroupKey;
+  getDocSnapshotRef.current = deps.getDocSnapshot;
+
+  const docReady = doc !== null;
+  const pollIntervalMs = deps.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+
+  React.useEffect(() => {
+    if (accessToken === null || householdId === null || !docReady) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    const runPull = async (): Promise<void> => {
+      if (cancelled || inFlightRef.current) return;
+      inFlightRef.current = true;
+      setPulling(true);
+
+      try {
+        // Charge le curseur persisté la première fois — ensuite, la ref
+        // en mémoire fait foi pour ne pas re-lire le storage à chaque tick.
+        if (cursorRef.current === null) {
+          cursorRef.current = await loadCursorRef.current();
+          if (cancelled) return;
+        }
+
+        // Dérive (et cache) la groupKey pour ce foyer.
+        if (keyRef.current === null) {
+          keyRef.current = await deriveGroupKeyRef.current(householdId);
+          if (cancelled) return;
+        }
+
+        let since = cursorRef.current;
+        let hasMore = true;
+
+        while (hasMore && !cancelled) {
+          const resp = await fetchCatchupRef.current({
+            accessToken,
+            householdId,
+            since,
+          });
+          if (cancelled) return;
+
+          // Garde-fou anti-spin : un relai malveillant ou buggé pourrait
+          // renvoyer `{messages: [], hasMore: true}` indéfiniment. Sans ce
+          // break, la boucle consommerait CPU et réseau en continu car
+          // `since` ne pourrait pas progresser. Refs: kz-securite-KIN-070 §B1.
+          if (resp.messages.length === 0) {
+            break;
+          }
+
+          for (const msg of resp.messages) {
+            // Re-vérification en tête d'itération : un unmount concurrent
+            // peut basculer `cancelled` ou nullifier `keyRef` entre deux
+            // microtasks. Sans ce guard, un déchiffrement sur clé `null`
+            // throw dans le catch silencieux mais on avancerait quand même
+            // le curseur, causant des pertes silencieuses de messages non
+            // appliqués. Refs: kz-review-KIN-070 §M1.
+            if (cancelled || keyRef.current === null) return;
+
+            const currentDoc = getDocSnapshotRef.current();
+            if (currentDoc === null) break;
+
+            try {
+              const newDoc = await consumeSyncMessage(currentDoc, msg.blobJson, keyRef.current);
+              const delta = getDocChanges(currentDoc, newDoc);
+              if (delta.length > 0) {
+                receiveChanges(delta);
+              }
+            } catch {
+              // Blob invalide / clé incorrecte : on n'arrête pas le catchup
+              // pour ne pas rester bloqué. Le curseur continue d'avancer
+              // jusqu'au dernier `seq` traité. **Pas de télémétrie** ici
+              // (gap d'observabilité volontaire, ticket de suivi à ouvrir
+              // pour factoriser `createDecryptFailedReporter` utilisé dans
+              // `useRelaySync`). Refs: kz-securite-KIN-070 §M1.
+            }
+            since = msg.seq;
+          }
+
+          cursorRef.current = since;
+          await saveCursorRef.current(since);
+          if (cancelled) return;
+
+          hasMore = resp.hasMore;
+        }
+      } catch {
+        // Erreur réseau / 5xx : on garde le curseur inchangé. Le prochain
+        // tick de polling retentera. Pas de télémétrie ajoutée ici (ticket
+        // de suivi observabilité).
+      } finally {
+        inFlightRef.current = false;
+        if (!cancelled) setPulling(false);
+      }
+    };
+
+    // Pull initial (au montage) + polling périodique.
+    void runPull();
+    const timerHandle = setInterval(() => {
+      void runPull();
+    }, pollIntervalMs);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timerHandle);
+      setPulling(false);
+      keyRef.current = null;
+      cursorRef.current = null;
+      inFlightRef.current = false;
+    };
+  }, [accessToken, householdId, docReady, receiveChanges, pollIntervalMs]);
+
+  return { pulling };
+}


### PR DESCRIPTION
Closes #70

## Contexte

La reconnexion WebSocket livrée par la PR KIN-69 permet de retrouver la synchronisation live, mais pas de rattraper les événements émis pendant que l'app était fermée. Cette PR couvre la story **E6-S04 — Pull delta `/sync/since` à l'ouverture et toutes les 60 s**.

**Bonne surprise en cours de chantier** : l'endpoint backend existe déjà (`GET /relay/catchup?since=<seq>` dans `apps/api/src/routes/catchup.ts`, testé dans `catchup.test.ts`). Le périmètre de cette PR est donc **100 % client**.

## Hook mutualisé (`packages/sync/src/client/usePullDelta.ts`)

- **Pull initial** au montage (dès que l'auth + le doc sont prêts).
- **Polling** toutes les `pollIntervalMs` ms (60 s par défaut).
- **Pagination** : `hasMore: true` → refetch immédiat avec le dernier `seq`.
- **Verrou in-flight** : un seul pull à la fois (le tick du polling est ignoré si un pull précédent n'est pas encore résolu).
- **Curseur persistant** : chargé via `loadCursor()` au montage, sauvegardé via `saveCursor()` après chaque page de pagination.
- **Résilience** : erreur réseau → curseur inchangé, retry au prochain tick. Blob non-déchiffrable → skip silencieux, curseur continue d'avancer (évite un blocage permanent sur un event corrompu).
- **GroupKey** (Argon2id) conservée en mémoire entre les pulls, reset au cleanup. Aucune persistance ajoutée.

### Garde-fous appliqués avant PR

- **Anti-spin** : `if (resp.messages.length === 0) break;` dans la boucle de pagination. Un relai malveillant ou buggé qui renverrait `{messages: [], hasMore: true}` en continu ferait tourner le client sur CPU/réseau sans fin (cf. rapport sécurité §B1).
- **Race cleanup** : garde `if (cancelled || keyRef.current === null) return;` en tête de chaque itération du `for` qui applique les messages. Empêche `saveCursor` d'être appelé avec un curseur fantôme quand un unmount arrive entre deux microtasks — logout, refresh token, HMR (cf. rapport qualité §M1).

## Wrappers apps

- **Web** (`apps/web/src/lib/sync/index.ts`) : fetch via `fetch()` DOM, curseur persisté en `localStorage` sous clé `kinhale-sync-cursor:<householdId>`. Construction d'URL via `new URL()` + `searchParams`.
- **Mobile** (`apps/mobile/src/lib/sync/index.ts`) : fetch via `fetch()` RN, curseur persisté en `AsyncStorage` (même préfixe de clé). Également `new URL()` pour aligner les deux wrappers (dette évitée pour les prochains paramètres query — cf. rapport qualité §M2).
- `RelaySyncBootstrap` monte désormais `useRelaySync()` ET `usePullDelta()` — les deux se complètent : WS pour le live, catchup pour le rattrapage.

## Tests (13 au total, tous verts)

| Test | Verdict |
|---|---|
| Pas d'auth → aucun pull | ✓ |
| Doc null → aucun pull | ✓ |
| Curseur persisté chargé au montage | ✓ |
| Deltas appliqués + dernier seq sauvegardé | ✓ |
| Erreur réseau → curseur inchangé | ✓ |
| Pagination `hasMore: true` | ✓ |
| Blob non-déchiffrable ignoré mais curseur avancé | ✓ |
| **Anti-spin** (B1) : sortie au 1er batch vide même si `hasMore: true` | ✓ |
| **Race cleanup** (M1) : unmount pendant fetch pending → ni `receiveChanges`, ni `saveCursor` | ✓ |
| Polling 60 s par défaut | ✓ |
| `pollIntervalMs` custom respecté | ✓ |
| Timer arrêté au démontage | ✓ |
| Pas de pull concurrent (verrou in-flight) | ✓ |

Suite globale : **155 tests sync, 96 tests web, lint + typecheck + format verts**.

## Revues préalables (workflow Kinhale obligatoire, 2 revues zone `packages/sync`)

- **kz-review** : GO avec réserves. 0 bloquant / 2 majeurs / 7 mineurs. Les 2 majeurs (race cleanup + divergence URL) **corrigés dans la PR**. Rapport : `.agents/current-run/kz-review-KIN-070.md`.
- **kz-securite** : GO après **correction du bloquant B1** (boucle pull infinie). 1 majeur M1 (télémétrie decrypt absente, symétrie à KIN-040) traité comme ticket de suivi explicite. Rapport : `.agents/current-run/kz-securite-KIN-070.md`.

## Changement documentaire embarqué

`CLAUDE.md` : retrait des 2 mentions de la règle « PR > 400 lignes modifiées = justification ou découpage » (demande explicite du mainteneur). Embarqué ici pour éviter un cycle de review séparé.

## Limitations connues (tickets de suivi à ouvrir)

- **Télémétrie decrypt_failed** : `usePullDelta` ne route pas les échecs de déchiffrement via `createDecryptFailedReporter` (KIN-040). Gap d'observabilité à combler en factorisant le reporter entre `useRelaySync` et `usePullDelta`.
- **Pull intégral au 1er run** : si `loadCursor()` retourne 0, le client demande tout l'historique disponible côté relai (plafonné à 500 messages par l'API — cf. `catchup.ts` `MAX_CATCHUP_MESSAGES`). Acceptable en v1.
- **Pas de test intégration web/mobile côté wrappers** (fetch + storage réels) : cohérent avec le reste du codebase, occasion manquée non bloquante.

## Test plan

- [ ] CI `Lint · Typecheck · Test` vert
- [ ] CI `Docker · node:20-alpine (musl)` vert
- [ ] CI `playwright` vert (non-régression)
- [ ] QA manuel recommandé : ouvrir web #1, créer une prise ; ouvrir web #2 (autre device) après 2 minutes, vérifier que la prise est rattrapée sans action utilisateur

Refs: KIN-70, E6-S04, §7.2 SPECS

🤖 Generated with [Claude Code](https://claude.com/claude-code)