### PR TITLE
feat(ui): badge statut sync + guards offline sur actions réseau

### DIFF
--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -1,10 +1,13 @@
 import React, { type JSX } from 'react';
+import { View } from 'react-native';
 import { Stack } from 'expo-router';
 import { I18nextProvider } from 'react-i18next';
 import { TamaguiProvider } from 'tamagui';
 import i18n from '../src/lib/i18n';
 import config from '../src/lib/tamagui.config';
 import { usePushRegistration } from '../src/hooks/use-push-registration';
+import { SyncStatusBadge } from '../src/components/SyncStatusBadge';
+import { RelaySyncBootstrap, RemindersBootstrap } from '../src/lib/sync';
 
 export default function RootLayout(): JSX.Element {
   usePushRegistration();
@@ -12,7 +15,17 @@ export default function RootLayout(): JSX.Element {
   return (
     <I18nextProvider i18n={i18n}>
       <TamaguiProvider config={config} defaultTheme="light">
-        <Stack screenOptions={{ headerShown: false }} />
+        {/* Sync WS E2EE bidirectionnelle + rattrapage delta (KIN-38/70). Leur
+            absence ici faisait que le store `sync-status` restait figé offline
+            côté mobile — révélé par la revue de KIN-75. */}
+        <RelaySyncBootstrap />
+        {/* Scheduler rappels + watcher doses manquées (KIN-38). */}
+        <RemindersBootstrap />
+        {/* Badge statut de sync affiché au-dessus du stack de navigation. E7-S05 */}
+        <SyncStatusBadge />
+        <View style={{ flex: 1 }}>
+          <Stack screenOptions={{ headerShown: false }} />
+        </View>
       </TamaguiProvider>
     </I18nextProvider>
   );

--- a/apps/mobile/app/caregivers/__tests__/invite.test.tsx
+++ b/apps/mobile/app/caregivers/__tests__/invite.test.tsx
@@ -33,6 +33,15 @@ jest.mock('../../../src/lib/invitations/client', () => ({
   }),
 }));
 
+// Par défaut : en ligne, pour que les tests existants ne butent pas sur le
+// guard E7-S08. Un test dédié couvrira la branche hors-ligne plus tard.
+jest.mock('../../../src/stores/sync-status-store', () => ({
+  useSyncStatusStore: jest.fn(
+    (selector: (s: { connected: boolean; pulling: boolean }) => unknown) =>
+      selector({ connected: true, pulling: false }),
+  ),
+}));
+
 const mockCreateInvitation = createInvitation as jest.MockedFunction<typeof createInvitation>;
 
 describe('InviteCaregiverScreen', () => {

--- a/apps/mobile/app/caregivers/invite.tsx
+++ b/apps/mobile/app/caregivers/invite.tsx
@@ -4,11 +4,13 @@ import * as Clipboard from 'expo-clipboard';
 import { YStack, Text, Button, Input } from 'tamagui';
 import QRCode from 'react-native-qrcode-svg';
 import { createInvitation, type CreatedInvitation } from '../../src/lib/invitations/client';
+import { useOnlineGuard } from '../../src/hooks/useOnlineGuard';
 
 type TargetRole = 'contributor' | 'restricted_contributor';
 
 export default function InviteCaregiverScreen(): React.JSX.Element {
   const { t } = useTranslation('common');
+  const { online } = useOnlineGuard();
   const [role, setRole] = React.useState<TargetRole>('restricted_contributor');
   const [displayName, setDisplayName] = React.useState('');
   const [created, setCreated] = React.useState<CreatedInvitation | null>(null);
@@ -26,6 +28,8 @@ export default function InviteCaregiverScreen(): React.JSX.Element {
   const qrPayload = created !== null ? `kinhale://accept/${created.token}?pin=${created.pin}` : '';
 
   const handleSubmit = async (): Promise<void> => {
+    // Défense en profondeur : cf. kz-securite-075-078 §m1.
+    if (!online) return;
     setError(null);
     try {
       const result = await createInvitation({ targetRole: role, displayName });
@@ -110,13 +114,19 @@ export default function InviteCaregiverScreen(): React.JSX.Element {
 
       <Button
         onPress={() => void handleSubmit()}
-        disabled={displayName.trim().length === 0}
+        disabled={displayName.trim().length === 0 || !online}
         theme="active"
         accessibilityRole="button"
         accessibilityLabel={t('invitation.generateCta')}
       >
         {t('invitation.generateCta')}
       </Button>
+
+      {!online ? (
+        <Text color="$orange10" testID="offline-guard-message">
+          {t('offlineGuard.message')}
+        </Text>
+      ) : null}
 
       {error !== null ? <Text color="$red10">{error}</Text> : null}
     </YStack>

--- a/apps/mobile/app/onboarding/__tests__/child.test.tsx
+++ b/apps/mobile/app/onboarding/__tests__/child.test.tsx
@@ -36,6 +36,15 @@ jest.mock('../../../src/lib/device', () => ({
   getOrCreateDevice: (...args: unknown[]) => mockGetOrCreateDevice(...args),
 }));
 
+// Par défaut : en ligne, pour que les tests existants ne butent pas sur le
+// guard E7-S08. Un test dédié couvrira la branche hors-ligne plus tard.
+jest.mock('../../../src/stores/sync-status-store', () => ({
+  useSyncStatusStore: jest.fn(
+    (selector: (s: { connected: boolean; pulling: boolean }) => unknown) =>
+      selector({ connected: true, pulling: false }),
+  ),
+}));
+
 describe('OnboardingChildScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/apps/mobile/app/onboarding/__tests__/plan.test.tsx
+++ b/apps/mobile/app/onboarding/__tests__/plan.test.tsx
@@ -68,6 +68,15 @@ jest.mock('../../../src/lib/device', () => ({
   getOrCreateDevice: (...args: unknown[]) => mockGetOrCreateDevice(...args),
 }));
 
+// Par défaut : en ligne, pour que les tests existants ne butent pas sur le
+// guard E7-S08. Un test dédié couvrira la branche hors-ligne plus tard.
+jest.mock('../../../src/stores/sync-status-store', () => ({
+  useSyncStatusStore: jest.fn(
+    (selector: (s: { connected: boolean; pulling: boolean }) => unknown) =>
+      selector({ connected: true, pulling: false }),
+  ),
+}));
+
 describe('OnboardingPlanScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/apps/mobile/app/onboarding/child.tsx
+++ b/apps/mobile/app/onboarding/child.tsx
@@ -5,10 +5,12 @@ import { YStack, H1, Button, Text, Input } from 'tamagui';
 import { useAuthStore } from '../../src/stores/auth-store';
 import { useDocStore } from '../../src/stores/doc-store';
 import { getOrCreateDevice } from '../../src/lib/device';
+import { useOnlineGuard } from '../../src/hooks/useOnlineGuard';
 
 export default function OnboardingChildScreen(): JSX.Element {
   const { t } = useTranslation('common');
   const router = useRouter();
+  const { online } = useOnlineGuard();
   const deviceId = useAuthStore((s) => s.deviceId) ?? '';
   const appendChild = useDocStore((s) => s.appendChild);
 
@@ -18,6 +20,8 @@ export default function OnboardingChildScreen(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
 
   const handleSave = async (): Promise<void> => {
+    // Défense en profondeur : cf. kz-securite-075-078 §m1.
+    if (!online) return;
     setError(null);
     const birthYear = parseInt(birthYearStr, 10);
     if (firstName.trim() === '' || isNaN(birthYear)) {
@@ -65,9 +69,14 @@ export default function OnboardingChildScreen(): JSX.Element {
           {error}
         </Text>
       )}
+      {!online ? (
+        <Text color="$orange10" testID="offline-guard-message">
+          {t('offlineGuard.message')}
+        </Text>
+      ) : null}
       <Button
         onPress={() => void handleSave()}
-        disabled={loading}
+        disabled={loading || !online}
         marginTop="$2"
         accessible
         accessibilityRole="button"

--- a/apps/mobile/app/onboarding/plan.tsx
+++ b/apps/mobile/app/onboarding/plan.tsx
@@ -6,10 +6,12 @@ import { projectPumps } from '@kinhale/sync';
 import { useAuthStore } from '../../src/stores/auth-store';
 import { useDocStore } from '../../src/stores/doc-store';
 import { getOrCreateDevice } from '../../src/lib/device';
+import { useOnlineGuard } from '../../src/hooks/useOnlineGuard';
 
 export default function OnboardingPlanScreen(): JSX.Element {
   const { t } = useTranslation('common');
   const router = useRouter();
+  const { online } = useOnlineGuard();
   const deviceId = useAuthStore((s) => s.deviceId) ?? '';
   const appendPlan = useDocStore((s) => s.appendPlan);
   const doc = useDocStore((s) => s.doc);
@@ -25,6 +27,8 @@ export default function OnboardingPlanScreen(): JSX.Element {
   const [error, setError] = useState<string | null>(null);
 
   const handleSave = async (): Promise<void> => {
+    // Défense en profondeur : cf. kz-securite-075-078 §m1.
+    if (!online) return;
     setError(null);
     if (selectedPumpId === null) {
       setError(t('onboarding.plan.saveError'));
@@ -95,9 +99,14 @@ export default function OnboardingPlanScreen(): JSX.Element {
           {error}
         </Text>
       )}
+      {!online ? (
+        <Text color="$orange10" testID="offline-guard-message">
+          {t('offlineGuard.message')}
+        </Text>
+      ) : null}
       <Button
         onPress={() => void handleSave()}
-        disabled={loading || maintenancePumps.length === 0}
+        disabled={loading || maintenancePumps.length === 0 || !online}
         marginTop="$2"
         accessible
         accessibilityRole="button"

--- a/apps/mobile/src/__tests__/layout-push.test.tsx
+++ b/apps/mobile/src/__tests__/layout-push.test.tsx
@@ -23,6 +23,21 @@ jest.mock('react-i18next', () => ({
   I18nextProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+// Mock le badge de statut : ce test ne teste pas son rendu mais monte
+// RootLayout qui l'instancie ; le badge importe `tamagui` et `react-i18next`
+// qui ne sont que partiellement mockés ici.
+jest.mock('../components/SyncStatusBadge', () => ({
+  SyncStatusBadge: () => null,
+}));
+
+// Mock des bootstraps sync/rappels : pareil, hors scope du test (qui ne
+// vérifie que l'appel à usePushRegistration), et ces composants tirent
+// des imports natifs (WebSocket, expo-notifications).
+jest.mock('../lib/sync', () => ({
+  RelaySyncBootstrap: () => null,
+  RemindersBootstrap: () => null,
+}));
+
 describe('RootLayout — push integration', () => {
   it('appelle usePushRegistration au montage', () => {
     const { usePushRegistration } = require('../hooks/use-push-registration') as {

--- a/apps/mobile/src/components/SyncStatusBadge.tsx
+++ b/apps/mobile/src/components/SyncStatusBadge.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { XStack, Text } from 'tamagui';
+import { useSyncStatusStore } from '../stores/sync-status-store';
+
+/**
+ * Badge de statut de synchronisation affiché en haut de l'app mobile.
+ *
+ * États :
+ * - `!connected` → badge rouge "Hors-ligne" (E7-S05 AC 1)
+ * - `connected && pulling` → badge discret "Synchronisation…" (E7-S05 AC 2)
+ * - `connected && !pulling` → aucun rendu (UI calme quand tout va bien)
+ *
+ * Refs: KIN-75 / E7-S05.
+ */
+export function SyncStatusBadge(): React.JSX.Element | null {
+  const { t } = useTranslation('common');
+  const connected = useSyncStatusStore((s) => s.connected);
+  const pulling = useSyncStatusStore((s) => s.pulling);
+
+  if (!connected) {
+    return (
+      <XStack
+        backgroundColor="$red5"
+        paddingHorizontal="$3"
+        paddingVertical="$2"
+        alignItems="center"
+        gap="$2"
+        testID="sync-status-badge-offline"
+        accessibilityRole="text"
+        accessibilityLiveRegion="polite"
+      >
+        <Text color="$red11" fontWeight="bold">
+          {t('sync.offline')}
+        </Text>
+      </XStack>
+    );
+  }
+
+  if (pulling) {
+    return (
+      <XStack
+        backgroundColor="$blue3"
+        paddingHorizontal="$3"
+        paddingVertical="$2"
+        alignItems="center"
+        gap="$2"
+        testID="sync-status-badge-pulling"
+        accessibilityRole="text"
+        accessibilityLiveRegion="polite"
+      >
+        <Text color="$blue11">{t('sync.syncing')}</Text>
+      </XStack>
+    );
+  }
+
+  return null;
+}

--- a/apps/mobile/src/hooks/useOnlineGuard.ts
+++ b/apps/mobile/src/hooks/useOnlineGuard.ts
@@ -1,0 +1,12 @@
+import { useSyncStatusStore } from '../stores/sync-status-store';
+
+/**
+ * Garde-fou offline : retourne `{ online }` pour que les écrans qui
+ * nécessitent obligatoirement une connexion (invitation aidant, création
+ * plan, édition enfant) puissent désactiver leurs CTA et afficher un
+ * message explicatif. Refs: KIN-78 / E7-S08.
+ */
+export function useOnlineGuard(): { online: boolean } {
+  const online = useSyncStatusStore((s) => s.connected);
+  return { online };
+}

--- a/apps/mobile/src/lib/sync/index.ts
+++ b/apps/mobile/src/lib/sync/index.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import * as Notifications from 'expo-notifications';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -15,6 +16,7 @@ import { blake2bHex } from '@kinhale/crypto';
 import { createRelayClient } from '../relay-client';
 import { useAuthStore } from '../../stores/auth-store';
 import { useDocStore } from '../../stores/doc-store';
+import { useSyncStatusStore } from '../../stores/sync-status-store';
 
 /**
  * Sel applicatif utilisé pour pseudonymiser les `householdId` dans les
@@ -124,7 +126,7 @@ function reportDecryptFailed(event: DecryptFailedEvent): void {
  * Refs: KIN-039, KIN-040
  */
 export function useRelaySync(): { connected: boolean } {
-  return useRelaySyncCore({
+  const result = useRelaySyncCore({
     useAccessToken: () => useAuthStore((s) => s.accessToken),
     useDeviceId: () => useAuthStore((s) => s.deviceId),
     useHouseholdId: () => useAuthStore((s) => s.householdId),
@@ -137,6 +139,13 @@ export function useRelaySync(): { connected: boolean } {
     hashHousehold,
     reportDecryptFailed,
   });
+  // Miroir du statut dans un store applicatif pour que les composants UI
+  // (badge offline, guards) puissent le lire. Refs: KIN-75 / E7-S05.
+  const setConnected = useSyncStatusStore((s) => s.setConnected);
+  React.useEffect(() => {
+    setConnected(result.connected);
+  }, [result.connected, setConnected]);
+  return result;
 }
 
 // Composant shell applicatif (3 lignes). Intentionnellement dupliqué web/mobile
@@ -211,7 +220,7 @@ function saveCursorFactory(getHouseholdId: () => string | null): (cursor: number
  * absence.
  */
 export function usePullDelta(): { pulling: boolean } {
-  return usePullDeltaCore({
+  const result = usePullDeltaCore({
     useAccessToken: () => useAuthStore((s) => s.accessToken),
     useHouseholdId: () => useAuthStore((s) => s.householdId),
     useDoc: () => useDocStore((s) => s.doc),
@@ -222,6 +231,12 @@ export function usePullDelta(): { pulling: boolean } {
     saveCursor: saveCursorFactory(() => useAuthStore.getState().householdId),
     deriveGroupKey: getGroupKey,
   });
+  // Miroir du statut pulling dans le store pour l'UI. Refs: KIN-75 / E7-S05.
+  const setPulling = useSyncStatusStore((s) => s.setPulling);
+  React.useEffect(() => {
+    setPulling(result.pulling);
+  }, [result.pulling, setPulling]);
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/mobile/src/stores/sync-status-store.ts
+++ b/apps/mobile/src/stores/sync-status-store.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+
+/**
+ * Statut courant de la synchronisation côté client mobile. Alimenté par les
+ * wrappers `useRelaySync()` et `usePullDelta()` via `useEffect` — aucune
+ * persistance (l'état redevient `connected=false, pulling=false` à chaque
+ * chargement, les hooks reprennent la main en quelques ms).
+ *
+ * Consommé par les composants UI (badge de statut, guards offline) qui ne
+ * peuvent pas monter `useRelaySync()` eux-mêmes sans dupliquer la connexion
+ * WebSocket.
+ */
+interface SyncStatusState {
+  connected: boolean;
+  pulling: boolean;
+  setConnected: (connected: boolean) => void;
+  setPulling: (pulling: boolean) => void;
+}
+
+export const useSyncStatusStore = create<SyncStatusState>((set) => ({
+  connected: false,
+  pulling: false,
+  setConnected: (connected) => set({ connected }),
+  setPulling: (pulling) => set({ pulling }),
+}));

--- a/apps/web/src/app/caregivers/invite/__tests__/page.test.tsx
+++ b/apps/web/src/app/caregivers/invite/__tests__/page.test.tsx
@@ -21,6 +21,15 @@ jest.mock('../../../../stores/auth-store', () => ({
   ),
 }));
 
+// Par défaut : en ligne, pour que les tests existants ne butent pas sur le
+// guard E7-S08 (disabled quand hors-ligne). Un test dédié vérifie le guard.
+jest.mock('../../../../stores/sync-status-store', () => ({
+  useSyncStatusStore: jest.fn(
+    (selector: (s: { connected: boolean; pulling: boolean }) => unknown) =>
+      selector({ connected: true, pulling: false }),
+  ),
+}));
+
 const mockCreateInvitation = jest.fn().mockResolvedValue({
   token: 'tok-abc',
   pin: '123456',

--- a/apps/web/src/app/caregivers/invite/__tests__/page.test.tsx
+++ b/apps/web/src/app/caregivers/invite/__tests__/page.test.tsx
@@ -21,12 +21,14 @@ jest.mock('../../../../stores/auth-store', () => ({
   ),
 }));
 
-// Par défaut : en ligne, pour que les tests existants ne butent pas sur le
-// guard E7-S08 (disabled quand hors-ligne). Un test dédié vérifie le guard.
+// Statut sync — mutable pour que les tests du guard E7-S08 puissent le
+// basculer. Par défaut : en ligne, pour que les tests existants ne butent
+// pas sur le `disabled` du bouton.
+let mockConnected = true;
 jest.mock('../../../../stores/sync-status-store', () => ({
   useSyncStatusStore: jest.fn(
     (selector: (s: { connected: boolean; pulling: boolean }) => unknown) =>
-      selector({ connected: true, pulling: false }),
+      selector({ connected: mockConnected, pulling: false }),
   ),
 }));
 
@@ -47,6 +49,7 @@ describe('InviteCaregiverPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockAccessToken = 'tok-valid';
+    mockConnected = true;
     mockCreateInvitation.mockResolvedValue({
       token: 'tok-abc',
       pin: '123456',
@@ -180,6 +183,40 @@ describe('InviteCaregiverPage', () => {
 
       // Message d'erreur quota
       expect(screen.getByText(/limite.*10|active invitations limit/i)).toBeTruthy();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('hors-ligne : affiche le message du guard et ne déclenche pas createInvitation', async () => {
+    jest.useFakeTimers();
+    try {
+      mockConnected = false;
+      renderWithProviders(<InviteCaregiverPage />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      // Message explicatif visible (testID dédié sur la page).
+      expect(screen.getByTestId('offline-guard-message')).toBeTruthy();
+
+      // Même si l'utilisateur réussissait à cliquer (ex. réactivation DOM),
+      // le handler est protégé par `if (!online) return;` — createInvitation
+      // ne doit pas être appelé.
+      const input = screen.getByPlaceholderText(/maman|mom|garderie|daycare/i);
+      fireEvent.change(input, { target: { value: 'Maman' } });
+      fireEvent.click(screen.getByText(/générer|generate/i));
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockCreateInvitation).not.toHaveBeenCalled();
     } finally {
       jest.clearAllTimers();
       jest.useRealTimers();

--- a/apps/web/src/app/caregivers/invite/page.tsx
+++ b/apps/web/src/app/caregivers/invite/page.tsx
@@ -6,12 +6,14 @@ import QRCode from 'qrcode';
 import { YStack, XStack, Text, Button, Input } from 'tamagui';
 import { createInvitation, type CreatedInvitation } from '../../../lib/invitations/client';
 import { useRequireAuth } from '../../../lib/useRequireAuth';
+import { useOnlineGuard } from '../../../hooks/useOnlineGuard';
 
 type TargetRole = 'contributor' | 'restricted_contributor';
 
 export default function InviteCaregiverPage(): React.JSX.Element | null {
   const { t } = useTranslation('common');
   const authenticated = useRequireAuth();
+  const { online } = useOnlineGuard();
   const [role, setRole] = React.useState<TargetRole>('restricted_contributor');
   const [displayName, setDisplayName] = React.useState('');
   const [created, setCreated] = React.useState<CreatedInvitation | null>(null);
@@ -30,6 +32,10 @@ export default function InviteCaregiverPage(): React.JSX.Element | null {
   }, [created]);
 
   const handleSubmit = async (): Promise<void> => {
+    // Défense en profondeur : même si le bouton est `disabled` quand !online,
+    // un utilisateur qui réactiverait le DOM via DevTools ne doit pas réussir
+    // à déclencher un appel réseau voué à l'échec. Refs: kz-securite-075-078 §m1.
+    if (!online) return;
     setError(null);
     try {
       const result = await createInvitation({ targetRole: role, displayName });
@@ -124,7 +130,7 @@ export default function InviteCaregiverPage(): React.JSX.Element | null {
 
       <Button
         onPress={() => void handleSubmit()}
-        disabled={displayName.trim().length === 0}
+        disabled={displayName.trim().length === 0 || !online}
         backgroundColor="$blue9"
         color="white"
         borderColor="$blue10"
@@ -133,6 +139,12 @@ export default function InviteCaregiverPage(): React.JSX.Element | null {
       >
         {t('invitation.generateCta')}
       </Button>
+
+      {!online ? (
+        <Text color="$orange10" testID="offline-guard-message" role="status">
+          {t('offlineGuard.message')}
+        </Text>
+      ) : null}
 
       {error !== null ? <Text color="$red10">{error}</Text> : null}
     </YStack>

--- a/apps/web/src/app/onboarding/child/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/child/__tests__/page.test.tsx
@@ -40,12 +40,13 @@ jest.mock('../../../../lib/device', () => ({
   getOrCreateDevice: (...args: unknown[]) => mockGetOrCreateDevice(...args),
 }));
 
-// Par défaut : en ligne, pour que les tests existants ne butent pas sur le
-// guard E7-S08 (disabled quand hors-ligne). Un test dédié vérifie le guard.
+// Statut sync — mutable pour que les tests du guard E7-S08 puissent le
+// basculer. Par défaut : en ligne.
+let mockConnected = true;
 jest.mock('../../../../stores/sync-status-store', () => ({
   useSyncStatusStore: jest.fn(
     (selector: (s: { connected: boolean; pulling: boolean }) => unknown) =>
-      selector({ connected: true, pulling: false }),
+      selector({ connected: mockConnected, pulling: false }),
   ),
 }));
 
@@ -53,6 +54,7 @@ describe('OnboardingChildPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockAccessToken = 'tok-1';
+    mockConnected = true;
     mockAppendChild.mockResolvedValue([new Uint8Array([1])]);
   });
 
@@ -124,6 +126,40 @@ describe('OnboardingChildPage', () => {
       });
       expect(screen.getByRole('alert')).toBeTruthy();
       expect(mockPush).not.toHaveBeenCalled();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('hors-ligne : affiche le message du guard et ne déclenche pas appendChild', async () => {
+    jest.useFakeTimers();
+    try {
+      mockConnected = false;
+      renderWithProviders(<OnboardingChildPage />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(screen.getByTestId('offline-guard-message')).toBeTruthy();
+
+      // Même si l'utilisateur clique malgré le disabled : le handler
+      // `if (!online) return` doit empêcher appendChild d'être appelé.
+      const input = screen.getByPlaceholderText(/prénom|first/i);
+      fireEvent.change(input, { target: { value: 'Emma' } });
+      const yearInput = screen.getByPlaceholderText(/2020|year/i);
+      fireEvent.change(yearInput, { target: { value: '2020' } });
+      fireEvent.click(screen.getByText(/enregistrer|save/i));
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockAppendChild).not.toHaveBeenCalled();
     } finally {
       jest.clearAllTimers();
       jest.useRealTimers();

--- a/apps/web/src/app/onboarding/child/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/child/__tests__/page.test.tsx
@@ -40,6 +40,15 @@ jest.mock('../../../../lib/device', () => ({
   getOrCreateDevice: (...args: unknown[]) => mockGetOrCreateDevice(...args),
 }));
 
+// Par défaut : en ligne, pour que les tests existants ne butent pas sur le
+// guard E7-S08 (disabled quand hors-ligne). Un test dédié vérifie le guard.
+jest.mock('../../../../stores/sync-status-store', () => ({
+  useSyncStatusStore: jest.fn(
+    (selector: (s: { connected: boolean; pulling: boolean }) => unknown) =>
+      selector({ connected: true, pulling: false }),
+  ),
+}));
+
 describe('OnboardingChildPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/apps/web/src/app/onboarding/child/page.tsx
+++ b/apps/web/src/app/onboarding/child/page.tsx
@@ -8,11 +8,13 @@ import { useAuthStore } from '../../../stores/auth-store';
 import { useDocStore } from '../../../stores/doc-store';
 import { getOrCreateDevice } from '../../../lib/device';
 import { useRequireAuth } from '../../../lib/useRequireAuth';
+import { useOnlineGuard } from '../../../hooks/useOnlineGuard';
 
 export default function OnboardingChildPage(): React.JSX.Element | null {
   const { t } = useTranslation('common');
   const router = useRouter();
   const authenticated = useRequireAuth();
+  const { online } = useOnlineGuard();
   const deviceId = useAuthStore((s) => s.deviceId) ?? '';
   const appendChild = useDocStore((s) => s.appendChild);
 
@@ -22,6 +24,8 @@ export default function OnboardingChildPage(): React.JSX.Element | null {
   const [error, setError] = useState<string | null>(null);
 
   const handleSave = async (): Promise<void> => {
+    // Défense en profondeur : cf. kz-securite-075-078 §m1.
+    if (!online) return;
     setError(null);
     const birthYear = parseInt(birthYearStr, 10);
     if (firstName.trim() === '' || isNaN(birthYear)) {
@@ -66,7 +70,12 @@ export default function OnboardingChildPage(): React.JSX.Element | null {
           {error}
         </Text>
       )}
-      <Button onPress={() => void handleSave()} disabled={loading} marginTop="$2">
+      {!online ? (
+        <Text color="$orange10" testID="offline-guard-message" role="status">
+          {t('offlineGuard.message')}
+        </Text>
+      ) : null}
+      <Button onPress={() => void handleSave()} disabled={loading || !online} marginTop="$2">
         {loading ? t('onboarding.child.saving') : t('onboarding.child.save')}
       </Button>
     </YStack>

--- a/apps/web/src/app/onboarding/plan/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/plan/__tests__/page.test.tsx
@@ -75,12 +75,13 @@ jest.mock('../../../../lib/device', () => ({
   getOrCreateDevice: (...args: unknown[]) => mockGetOrCreateDevice(...args),
 }));
 
-// Par défaut : en ligne, pour que les tests existants ne butent pas sur le
-// guard E7-S08 (disabled quand hors-ligne). Un test dédié vérifie le guard.
+// Statut sync — mutable pour que les tests du guard E7-S08 puissent le
+// basculer. Par défaut : en ligne.
+let mockConnected = true;
 jest.mock('../../../../stores/sync-status-store', () => ({
   useSyncStatusStore: jest.fn(
     (selector: (s: { connected: boolean; pulling: boolean }) => unknown) =>
-      selector({ connected: true, pulling: false }),
+      selector({ connected: mockConnected, pulling: false }),
   ),
 }));
 
@@ -88,6 +89,7 @@ describe('OnboardingPlanPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockAccessToken = 'tok-1';
+    mockConnected = true;
     mockAppendPlan.mockResolvedValue([new Uint8Array([1])]);
     mockProjectPumps.mockReturnValue([
       {
@@ -169,6 +171,37 @@ describe('OnboardingPlanPage', () => {
       renderWithProviders(<OnboardingPlanPage />);
       fireEvent.click(screen.getByText(/ajouter une pompe|add a pump/i));
       expect(mockPush).toHaveBeenCalledWith('/onboarding/pump');
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('hors-ligne : affiche le message du guard et ne déclenche pas appendPlan', async () => {
+    jest.useFakeTimers();
+    try {
+      mockConnected = false;
+      renderWithProviders(<OnboardingPlanPage />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(screen.getByTestId('offline-guard-message')).toBeTruthy();
+
+      // Tenter de cliquer malgré le disabled : le handler `if (!online) return`
+      // doit empêcher appendPlan d'être appelé.
+      const saveBtn = screen.getByText(/enregistrer|save/i);
+      fireEvent.click(saveBtn);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockAppendPlan).not.toHaveBeenCalled();
     } finally {
       jest.clearAllTimers();
       jest.useRealTimers();

--- a/apps/web/src/app/onboarding/plan/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/plan/__tests__/page.test.tsx
@@ -75,6 +75,15 @@ jest.mock('../../../../lib/device', () => ({
   getOrCreateDevice: (...args: unknown[]) => mockGetOrCreateDevice(...args),
 }));
 
+// Par défaut : en ligne, pour que les tests existants ne butent pas sur le
+// guard E7-S08 (disabled quand hors-ligne). Un test dédié vérifie le guard.
+jest.mock('../../../../stores/sync-status-store', () => ({
+  useSyncStatusStore: jest.fn(
+    (selector: (s: { connected: boolean; pulling: boolean }) => unknown) =>
+      selector({ connected: true, pulling: false }),
+  ),
+}));
+
 describe('OnboardingPlanPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/apps/web/src/app/onboarding/plan/page.tsx
+++ b/apps/web/src/app/onboarding/plan/page.tsx
@@ -9,11 +9,13 @@ import { useAuthStore } from '../../../stores/auth-store';
 import { useDocStore } from '../../../stores/doc-store';
 import { getOrCreateDevice } from '../../../lib/device';
 import { useRequireAuth } from '../../../lib/useRequireAuth';
+import { useOnlineGuard } from '../../../hooks/useOnlineGuard';
 
 export default function OnboardingPlanPage(): React.JSX.Element | null {
   const { t } = useTranslation('common');
   const router = useRouter();
   const authenticated = useRequireAuth();
+  const { online } = useOnlineGuard();
   const deviceId = useAuthStore((s) => s.deviceId) ?? '';
   const appendPlan = useDocStore((s) => s.appendPlan);
   const doc = useDocStore((s) => s.doc);
@@ -31,6 +33,8 @@ export default function OnboardingPlanPage(): React.JSX.Element | null {
   const [error, setError] = useState<string | null>(null);
 
   const handleSave = async (): Promise<void> => {
+    // Défense en profondeur : cf. kz-securite-075-078 §m1.
+    if (!online) return;
     setError(null);
     if (selectedPumpId === null) {
       setError(t('onboarding.plan.saveError'));
@@ -130,7 +134,13 @@ export default function OnboardingPlanPage(): React.JSX.Element | null {
         </Text>
       )}
 
-      <Button onPress={() => void handleSave()} disabled={loading} marginTop="$2">
+      {!online ? (
+        <Text color="$orange10" testID="offline-guard-message" role="status">
+          {t('offlineGuard.message')}
+        </Text>
+      ) : null}
+
+      <Button onPress={() => void handleSave()} disabled={loading || !online} marginTop="$2">
         {loading ? t('onboarding.plan.saving') : t('onboarding.plan.save')}
       </Button>
     </YStack>

--- a/apps/web/src/components/SyncStatusBadge.tsx
+++ b/apps/web/src/components/SyncStatusBadge.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { XStack, Text } from 'tamagui';
+import { useSyncStatusStore } from '../stores/sync-status-store';
+
+/**
+ * Badge de statut de synchronisation affiché en haut de l'app.
+ *
+ * États :
+ * - `!connected` → badge rouge "Hors-ligne" (E7-S05 AC 1)
+ * - `connected && pulling` → badge discret "Synchronisation…" (E7-S05 AC 2)
+ * - `connected && !pulling` → aucun rendu (UI calme quand tout va bien)
+ *
+ * Refs: KIN-75 / E7-S05.
+ */
+export function SyncStatusBadge(): React.JSX.Element | null {
+  const { t } = useTranslation('common');
+  const connected = useSyncStatusStore((s) => s.connected);
+  const pulling = useSyncStatusStore((s) => s.pulling);
+
+  if (!connected) {
+    return (
+      <XStack
+        backgroundColor="$red5"
+        paddingHorizontal="$3"
+        paddingVertical="$2"
+        alignItems="center"
+        gap="$2"
+        testID="sync-status-badge-offline"
+        role="status"
+        aria-live="polite"
+      >
+        <Text color="$red11" fontWeight="bold">
+          {t('sync.offline')}
+        </Text>
+      </XStack>
+    );
+  }
+
+  if (pulling) {
+    return (
+      <XStack
+        backgroundColor="$blue3"
+        paddingHorizontal="$3"
+        paddingVertical="$2"
+        alignItems="center"
+        gap="$2"
+        testID="sync-status-badge-pulling"
+        role="status"
+        aria-live="polite"
+      >
+        <Text color="$blue11">{t('sync.syncing')}</Text>
+      </XStack>
+    );
+  }
+
+  return null;
+}

--- a/apps/web/src/components/__tests__/SyncStatusBadge.test.tsx
+++ b/apps/web/src/components/__tests__/SyncStatusBadge.test.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { screen, act } from '@testing-library/react';
+import { SyncStatusBadge } from '../SyncStatusBadge';
+import { renderWithProviders } from '../../test-utils/render';
+
+// État du store — ré-assigné par chaque test avant renderWithProviders.
+let mockConnected = false;
+let mockPulling = false;
+
+jest.mock('../../stores/sync-status-store', () => ({
+  useSyncStatusStore: jest.fn(
+    (selector: (s: { connected: boolean; pulling: boolean }) => unknown) =>
+      selector({ connected: mockConnected, pulling: mockPulling }),
+  ),
+}));
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('SyncStatusBadge', () => {
+  jest.setTimeout(15000);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockConnected = false;
+    mockPulling = false;
+  });
+
+  it('affiche le badge "Hors-ligne" quand déconnecté', async () => {
+    jest.useFakeTimers();
+    try {
+      mockConnected = false;
+      mockPulling = false;
+      renderWithProviders(<SyncStatusBadge />);
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(screen.getByTestId('sync-status-badge-offline')).toBeTruthy();
+      expect(screen.getByText(/hors.ligne|offline/i)).toBeTruthy();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('affiche le badge "Synchronisation…" quand connecté et en cours de pull', async () => {
+    jest.useFakeTimers();
+    try {
+      mockConnected = true;
+      mockPulling = true;
+      renderWithProviders(<SyncStatusBadge />);
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(screen.getByTestId('sync-status-badge-pulling')).toBeTruthy();
+      expect(screen.getByText(/synchronisation|syncing/i)).toBeTruthy();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it("n'affiche rien quand connecté et calme (pas de pull en cours)", async () => {
+    jest.useFakeTimers();
+    try {
+      mockConnected = true;
+      mockPulling = false;
+      renderWithProviders(<SyncStatusBadge />);
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(screen.queryByTestId('sync-status-badge-offline')).toBeNull();
+      expect(screen.queryByTestId('sync-status-badge-pulling')).toBeNull();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/hooks/useOnlineGuard.ts
+++ b/apps/web/src/hooks/useOnlineGuard.ts
@@ -1,0 +1,14 @@
+'use client';
+
+import { useSyncStatusStore } from '../stores/sync-status-store';
+
+/**
+ * Garde-fou offline : retourne `{ online }` pour que les écrans qui
+ * nécessitent obligatoirement une connexion (invitation aidant, création
+ * plan, édition enfant) puissent désactiver leurs CTA et afficher un
+ * message explicatif. Refs: KIN-78 / E7-S08.
+ */
+export function useOnlineGuard(): { online: boolean } {
+  const online = useSyncStatusStore((s) => s.connected);
+  return { online };
+}

--- a/apps/web/src/lib/sync/index.ts
+++ b/apps/web/src/lib/sync/index.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   useRelaySync as useRelaySyncCore,
@@ -15,6 +16,7 @@ import { blake2bHex } from '@kinhale/crypto';
 import { createRelayClient } from '../relay-client';
 import { useAuthStore } from '../../stores/auth-store';
 import { useDocStore } from '../../stores/doc-store';
+import { useSyncStatusStore } from '../../stores/sync-status-store';
 
 /**
  * Sel applicatif utilisé pour pseudonymiser les `householdId` dans les
@@ -137,7 +139,7 @@ function reportDecryptFailed(event: DecryptFailedEvent): void {
  * Refs: KIN-039, KIN-040
  */
 export function useRelaySync(): { connected: boolean } {
-  return useRelaySyncCore({
+  const result = useRelaySyncCore({
     useAccessToken: () => useAuthStore((s) => s.accessToken),
     useDeviceId: () => useAuthStore((s) => s.deviceId),
     useHouseholdId: () => useAuthStore((s) => s.householdId),
@@ -150,6 +152,14 @@ export function useRelaySync(): { connected: boolean } {
     hashHousehold,
     reportDecryptFailed,
   });
+  // Miroir du statut dans un store applicatif pour que les composants UI
+  // (badge offline, guards) puissent le lire sans monter eux-mêmes une
+  // 2e connexion WebSocket. Refs: KIN-75 / E7-S05.
+  const setConnected = useSyncStatusStore((s) => s.setConnected);
+  React.useEffect(() => {
+    setConnected(result.connected);
+  }, [result.connected, setConnected]);
+  return result;
 }
 
 // Composant shell applicatif (3 lignes). Intentionnellement dupliqué web/mobile
@@ -226,7 +236,7 @@ function saveCursorFactory(getHouseholdId: () => string | null): (cursor: number
  * live, catchup pour rattraper ce qui a été manqué pendant une absence.
  */
 export function usePullDelta(): { pulling: boolean } {
-  return usePullDeltaCore({
+  const result = usePullDeltaCore({
     useAccessToken: () => useAuthStore((s) => s.accessToken),
     useHouseholdId: () => useAuthStore((s) => s.householdId),
     useDoc: () => useDocStore((s) => s.doc),
@@ -237,6 +247,12 @@ export function usePullDelta(): { pulling: boolean } {
     saveCursor: saveCursorFactory(() => useAuthStore.getState().householdId),
     deriveGroupKey: getGroupKey,
   });
+  // Miroir du statut pulling dans le store pour l'UI. Refs: KIN-75 / E7-S05.
+  const setPulling = useSyncStatusStore((s) => s.setPulling);
+  React.useEffect(() => {
+    setPulling(result.pulling);
+  }, [result.pulling, setPulling]);
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/providers/index.tsx
+++ b/apps/web/src/providers/index.tsx
@@ -7,6 +7,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import config from '../lib/tamagui.config';
 import i18n from '../lib/i18n';
 import { RelaySyncBootstrap, RemindersBootstrap } from '../lib/sync';
+import { SyncStatusBadge } from '../components/SyncStatusBadge';
 
 export function Providers({ children }: { children: ReactNode }): JSX.Element {
   const [queryClient] = useState(() => new QueryClient());
@@ -19,6 +20,8 @@ export function Providers({ children }: { children: ReactNode }): JSX.Element {
           <RelaySyncBootstrap />
           {/* Programme les rappels de dose + surveille les doses manquées */}
           <RemindersBootstrap />
+          {/* Badge statut de sync (hors-ligne / en synchronisation) — E7-S05 */}
+          <SyncStatusBadge />
           {children}
         </TamaguiProvider>
       </I18nextProvider>

--- a/apps/web/src/stores/sync-status-store.ts
+++ b/apps/web/src/stores/sync-status-store.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+
+/**
+ * Statut courant de la synchronisation côté client. Alimenté par les wrappers
+ * `useRelaySync()` et `usePullDelta()` via `useEffect` — aucune persistance
+ * (l'état redevient `connected=false, pulling=false` à chaque chargement,
+ * les hooks reprennent la main en quelques ms).
+ *
+ * Consommé par les composants UI (badge de statut, guards offline) qui ne
+ * peuvent pas monter `useRelaySync()` eux-mêmes sans dupliquer la connexion
+ * WebSocket.
+ */
+interface SyncStatusState {
+  connected: boolean;
+  pulling: boolean;
+  setConnected: (connected: boolean) => void;
+  setPulling: (pulling: boolean) => void;
+}
+
+export const useSyncStatusStore = create<SyncStatusState>((set) => ({
+  connected: false,
+  pulling: false,
+  setConnected: (connected) => set({ connected }),
+  setPulling: (pulling) => set({ pulling }),
+}));

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -138,5 +138,12 @@
     "errorConsent": "Please accept sharing to continue.",
     "cameraPermissionDenied": "Camera permission denied. Enable it in settings.",
     "backToAuth": "Back to login"
+  },
+  "sync": {
+    "offline": "Offline",
+    "syncing": "Syncing…"
+  },
+  "offlineGuard": {
+    "message": "This action requires an internet connection. It will be available again once you are back online."
   }
 }

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -138,5 +138,12 @@
     "errorConsent": "Merci d'accepter le partage pour continuer.",
     "cameraPermissionDenied": "Permission caméra refusée. Active-la dans les réglages.",
     "backToAuth": "Retour à la connexion"
+  },
+  "sync": {
+    "offline": "Hors-ligne",
+    "syncing": "Synchronisation…"
+  },
+  "offlineGuard": {
+    "message": "Cette action nécessite une connexion internet. Elle sera disponible dès que vous serez de nouveau en ligne."
   }
 }


### PR DESCRIPTION
Closes #75
Closes #78

Couvre **2 stories du backlog hors-ligne** dans une même PR :

- **E7-S05 (#75)** — Badge affiché en haut de l'app : « Hors-ligne » quand la WebSocket au relai est coupée, « Synchronisation… » pendant un pull delta, invisible sinon.
- **E7-S08 (#78)** — Les 3 pages **invitation aidant**, **création plan** et **édition enfant** (web + mobile) désactivent leur CTA et affichent un message d'information quand l'app est hors-ligne.

## Architecture

- **Store Zustand léger** (`sync-status-store`) côté web et mobile : porte `{connected, pulling}`, non persisté.
- Les **wrappers applicatifs** `useRelaySync()` et `usePullDelta()` pushent leur statut dans le store via `useEffect`. Les composants UI lisent depuis le store — ils n'ont pas à monter eux-mêmes de connexion WebSocket.
- Hook **`useOnlineGuard()`** (web + mobile) : retourne `{ online }`. Les pages l'utilisent pour désactiver le bouton et afficher le message d'aide.
- Côté handler : `if (!online) return;` en début de `handleSubmit`/`handleSave` pour la défense en profondeur (un DevTools qui réactiverait le bouton désactivé ne déclencherait pas l'appel).

## Bug bloquant détecté et corrigé en cours de revue

Le fichier `apps/mobile/src/providers/index.tsx` était défini mais **jamais consommé** par `app/_layout.tsx` depuis le merge de KIN-039 / KIN-70. Résultat : `RelaySyncBootstrap` et `RemindersBootstrap` ne s'exécutaient pas en production mobile — la sync WebSocket et le rattrapage catchup étaient muets.

Ce bug aurait fait que le badge restait figé sur « Hors-ligne » en permanence côté mobile. Corrigé dans `_layout.tsx` en montant directement les deux bootstraps (approche minimale, pas de refactor vers `<Providers>` pour limiter l'impact sur cette PR).

## Revues préalables (workflow Kinhale obligatoire)

- **kz-review** : GO avec réserves. **1 bloquant corrigé dans la PR** (B1 : bootstraps mobile non montés), **1 majeur corrigé** (défense en profondeur dans les handlers), **1 majeur en ticket de suivi** (guard sur `scan.tsx` acceptation invitation, hors AC explicite de la story). 6 mineurs documentés. Rapport : `.agents/current-run/kz-review-KIN-075-078.md`.
- **kz-securite** : GO avec 3 mineurs. Le **m1 (défense en profondeur)** est corrigé dans la PR. Les m2/m3 (couverture tests mobile, tests de la branche offline) vont en tickets de suivi. Aucun impact sur la crypto, le zero-knowledge, ou les données santé. Rapport : `.agents/current-run/kz-securite-KIN-075-078.md`.

## Tests

- 3 tests unitaires du `SyncStatusBadge` web : offline, pulling, calme.
- Les 6 tests des pages existantes (3 web + 3 mobile) ont été ajustés pour mocker `sync-status-store` avec `connected: true` par défaut — sans quoi le guard désactiverait leur CTA et les cas nominaux échoueraient.
- Suite globale verte : **99 web + 69 mobile + 155 sync**, lint + typecheck + format.

## Hors scope — tickets de suivi à ouvrir

- Tests unitaires mobile pour `SyncStatusBadge` + `useOnlineGuard` (parité web).
- Tests des branches offline sur les 6 pages (cas `connected: false`).
- Guard sur `scan.tsx` / `accept-invitation` (mobile) — acceptation d'invitation, hors AC de la story E7-S08.
- Spinner réel pendant l'état pulling (v1 : badge texte seul).
- Accessibilité : `accessibilityLiveRegion` sur badge mobile + sur les messages offline-guard.

## Test plan

- [ ] CI `Lint · Typecheck · Test` vert
- [ ] CI `Docker · node:20-alpine (musl)` vert
- [ ] CI `playwright` vert (non-régression, notamment sur `invite/page.test.tsx`)
- [ ] QA manuel recommandé (web) :
  - Activer le mode offline dans DevTools → le badge "Hors-ligne" doit apparaître en haut, le bouton "Générer" de `/caregivers/invite` doit être désactivé et le message affiché
  - Réactiver la connexion → le badge disparaît, le bouton se réactive

Refs: KIN-75, KIN-78, E7-S05, E7-S08

🤖 Generated with [Claude Code](https://claude.com/claude-code)