### PR TITLE
feat(sync): détection RM6 double saisie + événement DoseReviewFlagged

### DIFF
--- a/apps/mobile/src/lib/sync/index.ts
+++ b/apps/mobile/src/lib/sync/index.ts
@@ -8,15 +8,19 @@ import {
   useSyncBatchFallback as useSyncBatchFallbackCore,
   useReminderScheduler as useReminderSchedulerCore,
   useMissedDoseWatcher as useMissedDoseWatcherCore,
+  useDuplicateDetectionWatcher as useDuplicateDetectionWatcherCore,
   getGroupKey,
   type DecryptFailedEvent,
   type FetchCatchupArgs,
   type CatchupResponse,
   type FetchBatchArgs,
   type FetchBatchResult,
+  type DuplicateDosePair,
+  type NotifyDuplicateArgs,
 } from '@kinhale/sync/client';
 import { blake2bHex } from '@kinhale/crypto';
 import { createRelayClient } from '../relay-client';
+import { getOrCreateDevice } from '../device';
 import { useAuthStore } from '../../stores/auth-store';
 import { useDocStore } from '../../stores/doc-store';
 import { useSyncStatusStore } from '../../stores/sync-status-store';
@@ -375,6 +379,33 @@ async function notifyMissedDoseNow(args: {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Détection doublons (KIN-73 / E7-S03, RM6).
+// ---------------------------------------------------------------------------
+
+async function flagDuplicatePairMobile(pair: DuplicateDosePair): Promise<void> {
+  const { deviceId } = useAuthStore.getState();
+  if (deviceId === null) return;
+  const kp = await getOrCreateDevice();
+  await useDocStore.getState().appendDoseFlag(
+    {
+      flagId: crypto.randomUUID(),
+      doseIds: pair.doseIds,
+      detectedAtMs: pair.detectedAtMs,
+    },
+    deviceId,
+    kp.secretKey,
+  );
+}
+
+async function notifyDuplicateNowMobile(args: NotifyDuplicateArgs): Promise<void> {
+  await Notifications.scheduleNotificationAsync({
+    identifier: args.id,
+    content: { title: args.title, body: args.body },
+    trigger: null, // immédiat
+  });
+}
+
 /**
  * Monte le scheduler de rappels (E5-S01 + E5-S02) et le watcher de doses
  * manquées (E5-S03) en arrière-plan. Dépend de i18next pour les chaînes —
@@ -404,6 +435,17 @@ export function RemindersBootstrap(): null {
     now: () => new Date(),
     missedDoseTitle: t('missed_dose.title'),
     missedDoseBody: t('missed_dose.body'),
+  });
+
+  // Watcher RM6 (KIN-73 / E7-S03) : détecte les doubles saisies et émet
+  // un événement `DoseReviewFlagged` + notification locale.
+  useDuplicateDetectionWatcherCore({
+    useDoc: () => useDocStore((s) => s.doc),
+    flagDuplicatePair: flagDuplicatePairMobile,
+    notifyDuplicate: notifyDuplicateNowMobile,
+    now: () => new Date(),
+    duplicateTitle: t('duplicate.title'),
+    duplicateBody: t('duplicate.body'),
   });
 
   return null;

--- a/apps/mobile/src/stores/doc-store.ts
+++ b/apps/mobile/src/stores/doc-store.ts
@@ -13,6 +13,7 @@ import {
 import type {
   KinhaleDoc,
   DoseAdministeredPayload,
+  DoseReviewFlaggedPayload,
   ChildRegisteredPayload,
   PumpReplacedPayload,
   PlanUpdatedPayload,
@@ -56,6 +57,11 @@ interface DocState {
   ) => Promise<Uint8Array[]>;
   appendPlan: (
     payload: PlanUpdatedPayload,
+    deviceId: string,
+    secretKey: Uint8Array,
+  ) => Promise<Uint8Array[]>;
+  appendDoseFlag: (
+    payload: DoseReviewFlaggedPayload,
     deviceId: string,
     secretKey: Uint8Array,
   ) => Promise<Uint8Array[]>;
@@ -181,6 +187,26 @@ export const useDocStore = create<DocState>()((set, get) => ({
       deviceId,
       occurredAtMs: Date.now(),
       event: { type: 'PlanUpdated', payload },
+    };
+    const record = await signEvent(unsigned, secretKey);
+    const newDoc = appendEvent(doc, record);
+    const changes = getDocChanges(doc, newDoc);
+
+    void persistDoc(newDoc);
+    set({ doc: newDoc });
+    return changes;
+  },
+
+  async appendDoseFlag(payload, deviceId, secretKey) {
+    const currentDoc = get().doc;
+    const hid = (currentDoc as KinhaleDoc | null)?.householdId ?? deviceId;
+    const doc = currentDoc ?? createDoc(hid);
+
+    const unsigned: UnsignedEvent = {
+      id: crypto.randomUUID(),
+      deviceId,
+      occurredAtMs: Date.now(),
+      event: { type: 'DoseReviewFlagged', payload },
     };
     const record = await signEvent(unsigned, secretKey);
     const newDoc = appendEvent(doc, record);

--- a/apps/web/src/app/journal/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/__tests__/page.test.tsx
@@ -61,6 +61,7 @@ describe('JournalPage', () => {
       symptoms: [],
       circumstances: [],
       freeFormTag: null,
+      status: 'recorded',
     };
 
     mockProjectDoses.mockReturnValueOnce([fakeDose]);

--- a/apps/web/src/lib/sync/index.ts
+++ b/apps/web/src/lib/sync/index.ts
@@ -8,15 +8,19 @@ import {
   useSyncBatchFallback as useSyncBatchFallbackCore,
   useReminderScheduler as useReminderSchedulerCore,
   useMissedDoseWatcher as useMissedDoseWatcherCore,
+  useDuplicateDetectionWatcher as useDuplicateDetectionWatcherCore,
   getGroupKey,
   type DecryptFailedEvent,
   type FetchCatchupArgs,
   type CatchupResponse,
   type FetchBatchArgs,
   type FetchBatchResult,
+  type DuplicateDosePair,
+  type NotifyDuplicateArgs,
 } from '@kinhale/sync/client';
 import { blake2bHex } from '@kinhale/crypto';
 import { createRelayClient } from '../relay-client';
+import { getOrCreateDevice } from '../device';
 import { useAuthStore } from '../../stores/auth-store';
 import { useDocStore } from '../../stores/doc-store';
 import { useSyncStatusStore } from '../../stores/sync-status-store';
@@ -410,6 +414,30 @@ async function notifyMissedDoseNowWeb(args: {
   new Notification(args.title, { body: args.body, tag: args.id });
 }
 
+// ---------------------------------------------------------------------------
+// Détection doublons (KIN-73 / E7-S03, RM6) : flag côté doc + notification.
+// ---------------------------------------------------------------------------
+
+async function flagDuplicatePairWeb(pair: DuplicateDosePair): Promise<void> {
+  const { deviceId } = useAuthStore.getState();
+  if (deviceId === null) return;
+  const kp = await getOrCreateDevice();
+  await useDocStore.getState().appendDoseFlag(
+    {
+      flagId: crypto.randomUUID(),
+      doseIds: pair.doseIds,
+      detectedAtMs: pair.detectedAtMs,
+    },
+    deviceId,
+    kp.secretKey,
+  );
+}
+
+async function notifyDuplicateNowWeb(args: NotifyDuplicateArgs): Promise<void> {
+  if (!isWebNotificationPermissionGranted()) return;
+  new Notification(args.title, { body: args.body, tag: args.id });
+}
+
 /**
  * Monte le scheduler de rappels (E5-S01 + E5-S02, best-effort côté web) et
  * le watcher de doses manquées (E5-S03). Le web utilise l'API Web
@@ -439,6 +467,17 @@ export function RemindersBootstrap(): null {
     now: () => new Date(),
     missedDoseTitle: t('missed_dose.title'),
     missedDoseBody: t('missed_dose.body'),
+  });
+
+  // Watcher RM6 (KIN-73 / E7-S03) : détecte les doubles saisies et émet
+  // un événement `DoseReviewFlagged` + notification locale.
+  useDuplicateDetectionWatcherCore({
+    useDoc: () => useDocStore((s) => s.doc),
+    flagDuplicatePair: flagDuplicatePairWeb,
+    notifyDuplicate: notifyDuplicateNowWeb,
+    now: () => new Date(),
+    duplicateTitle: t('duplicate.title'),
+    duplicateBody: t('duplicate.body'),
   });
 
   return null;

--- a/apps/web/src/stores/doc-store.ts
+++ b/apps/web/src/stores/doc-store.ts
@@ -11,6 +11,7 @@ import {
 import type {
   KinhaleDoc,
   DoseAdministeredPayload,
+  DoseReviewFlaggedPayload,
   ChildRegisteredPayload,
   PumpReplacedPayload,
   PlanUpdatedPayload,
@@ -52,6 +53,11 @@ interface DocState {
   ) => Promise<Uint8Array[]>;
   appendPlan: (
     payload: PlanUpdatedPayload,
+    deviceId: string,
+    secretKey: Uint8Array,
+  ) => Promise<Uint8Array[]>;
+  appendDoseFlag: (
+    payload: DoseReviewFlaggedPayload,
     deviceId: string,
     secretKey: Uint8Array,
   ) => Promise<Uint8Array[]>;
@@ -176,6 +182,26 @@ export const useDocStore = create<DocState>()((set, get) => ({
       deviceId,
       occurredAtMs: Date.now(),
       event: { type: 'PlanUpdated', payload },
+    };
+    const record = await signEvent(unsigned, secretKey);
+    const newDoc = appendEvent(doc, record);
+    const changes = getDocChanges(doc, newDoc);
+
+    void persistDoc(newDoc);
+    set({ doc: newDoc });
+    return changes;
+  },
+
+  async appendDoseFlag(payload, deviceId, secretKey) {
+    const currentDoc = get().doc;
+    const hid = (currentDoc as KinhaleDoc | null)?.householdId ?? deviceId;
+    const doc = currentDoc ?? createDoc(hid);
+
+    const unsigned: UnsignedEvent = {
+      id: crypto.randomUUID(),
+      deviceId,
+      occurredAtMs: Date.now(),
+      event: { type: 'DoseReviewFlagged', payload },
     };
     const record = await signEvent(unsigned, secretKey);
     const newDoc = appendEvent(doc, record);

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -143,6 +143,10 @@
     "offline": "Offline",
     "syncing": "Syncing…"
   },
+  "duplicate": {
+    "title": "Kinhale",
+    "body": "Possible duplicate entry detected"
+  },
   "offlineGuard": {
     "message": "This action requires an internet connection. It will be available again once you are back online."
   }

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -143,6 +143,10 @@
     "offline": "Hors-ligne",
     "syncing": "Synchronisation…"
   },
+  "duplicate": {
+    "title": "Kinhale",
+    "body": "Double saisie détectée"
+  },
   "offlineGuard": {
     "message": "Cette action nécessite une connexion internet. Elle sera disponible dès que vous serez de nouveau en ligne."
   }

--- a/packages/sync/src/__tests__/projections/doses.test.ts
+++ b/packages/sync/src/__tests__/projections/doses.test.ts
@@ -114,4 +114,133 @@ describe('projectDoses', () => {
     };
     expect(projectDoses(doc)).toEqual([]);
   });
+
+  // ---------------------------------------------------------------------------
+  // Statut — RM6 DoseReviewFlagged (KIN-73 / E7-S03).
+  // ---------------------------------------------------------------------------
+
+  it("expose un statut 'recorded' par défaut (aucun flag)", () => {
+    const d = dose({ doseId: 'dose-1' });
+    const result = projectDoses(makeDoc([{ payload: d }]));
+    expect(result[0]?.status).toBe('recorded');
+  });
+
+  it("marque les deux doses d'une paire DoseReviewFlagged comme 'pending_review'", () => {
+    const d1 = dose({ doseId: 'dose-A', administeredAtMs: 1_000 });
+    const d2 = dose({ doseId: 'dose-B', administeredAtMs: 1_060_000 });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        {
+          id: 'evt-1',
+          type: 'DoseAdministered',
+          payloadJson: JSON.stringify(d1),
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 1_000,
+        },
+        {
+          id: 'evt-2',
+          type: 'DoseAdministered',
+          payloadJson: JSON.stringify(d2),
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 1_060_000,
+        },
+        {
+          id: 'evt-flag',
+          type: 'DoseReviewFlagged',
+          payloadJson: JSON.stringify({
+            flagId: 'flag-1',
+            doseIds: ['dose-A', 'dose-B'],
+            detectedAtMs: 1_060_000,
+          }),
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 1_060_100,
+        },
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result).toHaveLength(2);
+    expect(result.every((r) => r.status === 'pending_review')).toBe(true);
+  });
+
+  it("conserve 'recorded' pour une dose non référencée par un flag", () => {
+    const flagged = dose({ doseId: 'dose-flagged' });
+    const normal = dose({ doseId: 'dose-normal', administeredAtMs: 2_000 });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        {
+          id: 'evt-1',
+          type: 'DoseAdministered',
+          payloadJson: JSON.stringify(flagged),
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 1_000,
+        },
+        {
+          id: 'evt-2',
+          type: 'DoseAdministered',
+          payloadJson: JSON.stringify(normal),
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 2_000,
+        },
+        {
+          id: 'evt-flag',
+          type: 'DoseReviewFlagged',
+          payloadJson: JSON.stringify({
+            flagId: 'flag-1',
+            doseIds: ['dose-flagged', 'dose-other'],
+            detectedAtMs: 2_500,
+          }),
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 2_500,
+        },
+      ],
+    };
+    const result = projectDoses(doc);
+    const flaggedDose = result.find((r) => r.doseId === 'dose-flagged');
+    const normalDose = result.find((r) => r.doseId === 'dose-normal');
+    expect(flaggedDose?.status).toBe('pending_review');
+    expect(normalDose?.status).toBe('recorded');
+  });
+
+  it('ignore un DoseReviewFlagged avec JSON invalide', () => {
+    const d = dose({ doseId: 'dose-1' });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        {
+          id: 'evt-1',
+          type: 'DoseAdministered',
+          payloadJson: JSON.stringify(d),
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 1_000,
+        },
+        {
+          id: 'evt-flag',
+          type: 'DoseReviewFlagged',
+          payloadJson: 'garbage{{{',
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 2_000,
+        },
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result[0]?.status).toBe('recorded');
+  });
 });

--- a/packages/sync/src/client/__tests__/useDuplicateDetectionWatcher.test.tsx
+++ b/packages/sync/src/client/__tests__/useDuplicateDetectionWatcher.test.tsx
@@ -1,0 +1,261 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { Mock } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import type { KinhaleDoc, SignedEventRecord } from '../../doc/schema.js';
+import type { DoseAdministeredPayload } from '../../events/types.js';
+import { useDuplicateDetectionWatcher } from '../useDuplicateDetectionWatcher.js';
+
+// ---------------------------------------------------------------------------
+// Fakes plateforme
+// ---------------------------------------------------------------------------
+
+let fakeDoc: KinhaleDoc | null;
+let flagDuplicatePair: Mock;
+let notifyDuplicate: Mock;
+
+function buildDeps() {
+  return {
+    useDoc: () => fakeDoc,
+    flagDuplicatePair,
+    notifyDuplicate,
+    now: () => new Date('2026-04-24T10:00:00Z'),
+    duplicateTitle: 'Kinhale',
+    duplicateBody: 'Double saisie détectée',
+  };
+}
+
+function signedDoseEvent(
+  id: string,
+  payload: Partial<DoseAdministeredPayload> & { doseId: string },
+  occurredAtMs = 1_000_000,
+): SignedEventRecord {
+  const fullPayload: DoseAdministeredPayload = {
+    doseId: payload.doseId,
+    pumpId: payload.pumpId ?? 'pump-1',
+    childId: payload.childId ?? 'child-1',
+    caregiverId: payload.caregiverId ?? 'dev-1',
+    administeredAtMs: payload.administeredAtMs ?? occurredAtMs,
+    doseType: payload.doseType ?? 'maintenance',
+    dosesAdministered: payload.dosesAdministered ?? 1,
+    symptoms: payload.symptoms ?? [],
+    circumstances: payload.circumstances ?? [],
+    freeFormTag: payload.freeFormTag ?? null,
+  };
+  return {
+    id,
+    type: 'DoseAdministered',
+    payloadJson: JSON.stringify(fullPayload),
+    signerPublicKeyHex: 'a'.repeat(64),
+    signatureHex: 'b'.repeat(128),
+    deviceId: 'dev-1',
+    occurredAtMs,
+  };
+}
+
+function signedFlagEvent(
+  id: string,
+  doseIds: [string, string],
+  occurredAtMs = 1_100_000,
+): SignedEventRecord {
+  return {
+    id,
+    type: 'DoseReviewFlagged',
+    payloadJson: JSON.stringify({
+      flagId: 'flag-' + id,
+      doseIds,
+      detectedAtMs: occurredAtMs,
+    }),
+    signerPublicKeyHex: 'a'.repeat(64),
+    signatureHex: 'b'.repeat(128),
+    deviceId: 'dev-1',
+    occurredAtMs,
+  };
+}
+
+describe('useDuplicateDetectionWatcher', () => {
+  beforeEach(() => {
+    fakeDoc = null;
+    flagDuplicatePair = vi.fn(async () => undefined);
+    notifyDuplicate = vi.fn(async () => undefined);
+  });
+
+  async function flush(): Promise<void> {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('ne fait rien si le doc est null', async () => {
+    renderHook(() => useDuplicateDetectionWatcher(buildDeps()));
+    await flush();
+    expect(flagDuplicatePair).not.toHaveBeenCalled();
+    expect(notifyDuplicate).not.toHaveBeenCalled();
+  });
+
+  it('ne flag rien avec une seule dose', async () => {
+    fakeDoc = {
+      householdId: 'hh-1',
+      events: [signedDoseEvent('evt-1', { doseId: 'd-1' }, 1_000_000)],
+    };
+    renderHook(() => useDuplicateDetectionWatcher(buildDeps()));
+    await flush();
+    expect(flagDuplicatePair).not.toHaveBeenCalled();
+  });
+
+  it('ne flag rien si les 2 doses sont séparées de plus de 2 min', async () => {
+    fakeDoc = {
+      householdId: 'hh-1',
+      events: [
+        signedDoseEvent('evt-1', { doseId: 'd-A' }, 1_000_000),
+        signedDoseEvent('evt-2', { doseId: 'd-B' }, 1_000_000 + 3 * 60_000),
+      ],
+    };
+    renderHook(() => useDuplicateDetectionWatcher(buildDeps()));
+    await flush();
+    expect(flagDuplicatePair).not.toHaveBeenCalled();
+    expect(notifyDuplicate).not.toHaveBeenCalled();
+  });
+
+  it("flag et notifie quand 2 doses sur la même pompe < 2 min s'enchaînent", async () => {
+    fakeDoc = {
+      householdId: 'hh-1',
+      events: [
+        signedDoseEvent(
+          'evt-1',
+          { doseId: 'd-A', pumpId: 'pump-1', doseType: 'maintenance' },
+          1_000_000,
+        ),
+        signedDoseEvent(
+          'evt-2',
+          { doseId: 'd-B', pumpId: 'pump-1', doseType: 'maintenance' },
+          1_000_000 + 30_000, // 30 s plus tard
+        ),
+      ],
+    };
+    renderHook(() => useDuplicateDetectionWatcher(buildDeps()));
+    await flush();
+
+    expect(flagDuplicatePair).toHaveBeenCalledTimes(1);
+    const call = flagDuplicatePair.mock.calls[0]?.[0] as { doseIds: [string, string] };
+    // Les doseIds doivent être triés (canonicalité pour l'idempotence).
+    expect(call.doseIds).toEqual(['d-A', 'd-B']);
+    expect(notifyDuplicate).toHaveBeenCalledTimes(1);
+  });
+
+  it('ne flag pas les paires sur des pompes différentes', async () => {
+    fakeDoc = {
+      householdId: 'hh-1',
+      events: [
+        signedDoseEvent('evt-1', { doseId: 'd-A', pumpId: 'pump-1' }, 1_000_000),
+        signedDoseEvent('evt-2', { doseId: 'd-B', pumpId: 'pump-2' }, 1_000_000 + 30_000),
+      ],
+    };
+    renderHook(() => useDuplicateDetectionWatcher(buildDeps()));
+    await flush();
+    expect(flagDuplicatePair).not.toHaveBeenCalled();
+  });
+
+  it('ne flag pas les paires de types différents (maintenance vs rescue)', async () => {
+    fakeDoc = {
+      householdId: 'hh-1',
+      events: [
+        signedDoseEvent('evt-1', { doseId: 'd-A', doseType: 'maintenance' }, 1_000_000),
+        signedDoseEvent('evt-2', { doseId: 'd-B', doseType: 'rescue' }, 1_000_000 + 30_000),
+      ],
+    };
+    renderHook(() => useDuplicateDetectionWatcher(buildDeps()));
+    await flush();
+    expect(flagDuplicatePair).not.toHaveBeenCalled();
+  });
+
+  it('ne re-flag pas une paire déjà présente dans le doc (flag antérieur)', async () => {
+    fakeDoc = {
+      householdId: 'hh-1',
+      events: [
+        signedDoseEvent('evt-1', { doseId: 'd-A' }, 1_000_000),
+        signedDoseEvent('evt-2', { doseId: 'd-B' }, 1_000_000 + 30_000),
+        signedFlagEvent('flag-existing', ['d-A', 'd-B'], 1_100_000),
+      ],
+    };
+    renderHook(() => useDuplicateDetectionWatcher(buildDeps()));
+    await flush();
+    expect(flagDuplicatePair).not.toHaveBeenCalled();
+    expect(notifyDuplicate).not.toHaveBeenCalled();
+  });
+
+  it('flag uniquement 1 fois même si le hook est appelé plusieurs fois avec le même doc (cache local)', async () => {
+    fakeDoc = {
+      householdId: 'hh-1',
+      events: [
+        signedDoseEvent('evt-1', { doseId: 'd-A' }, 1_000_000),
+        signedDoseEvent('evt-2', { doseId: 'd-B' }, 1_000_000 + 30_000),
+      ],
+    };
+    const { rerender } = renderHook(() => useDuplicateDetectionWatcher(buildDeps()));
+    await flush();
+    expect(flagDuplicatePair).toHaveBeenCalledTimes(1);
+
+    // Force un re-render avec le même doc — le cache local doit inhiber.
+    rerender();
+    await flush();
+    expect(flagDuplicatePair).toHaveBeenCalledTimes(1);
+    expect(notifyDuplicate).toHaveBeenCalledTimes(1);
+  });
+
+  it('flag une 2e paire distincte quand une nouvelle dose entre en conflit', async () => {
+    fakeDoc = {
+      householdId: 'hh-1',
+      events: [
+        signedDoseEvent('evt-1', { doseId: 'd-A' }, 1_000_000),
+        signedDoseEvent('evt-2', { doseId: 'd-B' }, 1_000_000 + 30_000),
+      ],
+    };
+    const { rerender } = renderHook(() => useDuplicateDetectionWatcher(buildDeps()));
+    await flush();
+    expect(flagDuplicatePair).toHaveBeenCalledTimes(1);
+
+    // Nouvelle paire apparaît (simulant l'arrivée d'un 3e et 4e event).
+    fakeDoc = {
+      householdId: 'hh-1',
+      events: [
+        ...fakeDoc.events,
+        signedDoseEvent('evt-3', { doseId: 'd-C' }, 2_000_000),
+        signedDoseEvent('evt-4', { doseId: 'd-D' }, 2_000_000 + 60_000),
+      ],
+    };
+    rerender();
+    await flush();
+    expect(flagDuplicatePair).toHaveBeenCalledTimes(2);
+    const secondCall = flagDuplicatePair.mock.calls[1]?.[0] as { doseIds: [string, string] };
+    expect(secondCall.doseIds).toEqual(['d-C', 'd-D']);
+  });
+
+  it('passe title/body i18n déjà traduits à notifyDuplicate', async () => {
+    fakeDoc = {
+      householdId: 'hh-1',
+      events: [
+        signedDoseEvent('evt-1', { doseId: 'd-A' }, 1_000_000),
+        signedDoseEvent('evt-2', { doseId: 'd-B' }, 1_000_000 + 30_000),
+      ],
+    };
+    renderHook(() => useDuplicateDetectionWatcher(buildDeps()));
+    await flush();
+
+    const notifCall = notifyDuplicate.mock.calls[0]?.[0] as {
+      id: string;
+      title: string;
+      body: string;
+    };
+    expect(notifCall.title).toBe('Kinhale');
+    expect(notifCall.body).toBe('Double saisie détectée');
+    // id unique/stable par paire pour dédoublonnage OS si la même paire
+    // était flaggée plusieurs fois (paranoïaque).
+    expect(notifCall.id).toMatch(/^dup:/);
+  });
+});

--- a/packages/sync/src/client/index.ts
+++ b/packages/sync/src/client/index.ts
@@ -45,6 +45,13 @@ export type {
 } from './useReminderScheduler.js';
 export { useMissedDoseWatcher } from './useMissedDoseWatcher.js';
 export type { NotifyMissedDoseArgs, UseMissedDoseWatcherDeps } from './useMissedDoseWatcher.js';
+
+export { useDuplicateDetectionWatcher } from './useDuplicateDetectionWatcher.js';
+export type {
+  DuplicateDosePair,
+  NotifyDuplicateArgs,
+  UseDuplicateDetectionWatcherDeps,
+} from './useDuplicateDetectionWatcher.js';
 export { classifyDecryptError, createDecryptFailedReporter } from './telemetry.js';
 export type {
   DecryptErrorClass,

--- a/packages/sync/src/client/useDuplicateDetectionWatcher.ts
+++ b/packages/sync/src/client/useDuplicateDetectionWatcher.ts
@@ -1,0 +1,203 @@
+import * as React from 'react';
+import { findDuplicateCandidates, type DoseSignature } from '@kinhale/domain';
+import type { KinhaleDoc } from '../doc/schema.js';
+import type { DoseReviewFlaggedPayload } from '../events/types.js';
+import { projectDoses } from '../projections/doses.js';
+
+/**
+ * Paire canonique de doses en conflit, triée par `doseId` pour idempotence.
+ */
+export interface DuplicateDosePair {
+  readonly doseIds: [string, string];
+  readonly detectedAtMs: number;
+}
+
+export interface NotifyDuplicateArgs {
+  readonly id: string;
+  readonly title: string;
+  readonly body: string;
+}
+
+export interface UseDuplicateDetectionWatcherDeps {
+  /** Hook plateforme : document Automerge courant. */
+  readonly useDoc: () => KinhaleDoc | null;
+  /**
+   * Persiste un événement `DoseReviewFlagged` dans le doc Automerge.
+   * Implémentation plateforme (append + signature). Le hook passe les
+   * `doseIds` triés par ordre lexicographique pour canonicalité.
+   */
+  readonly flagDuplicatePair: (pair: DuplicateDosePair) => Promise<void>;
+  /**
+   * Émet la notification locale "double saisie". Chaînes déjà traduites
+   * fournies par les wrappers apps. Optionnel : absence = no-op silencieux.
+   *
+   * **Interdit** : aucune donnée santé ne doit transiter par ces chaînes
+   * (pas de nom de pompe, pas de dose, pas de prénom). Ligne rouge
+   * dispositif médical (CLAUDE.md §À ne jamais faire).
+   */
+  readonly notifyDuplicate?: (args: NotifyDuplicateArgs) => Promise<void>;
+  /** Horloge injectée — testable. */
+  readonly now: () => Date;
+  /** Titre déjà traduit de la notification (ex : "Kinhale"). */
+  readonly duplicateTitle: string;
+  /** Corps déjà traduit (ex : "Double saisie détectée"). */
+  readonly duplicateBody: string;
+}
+
+/**
+ * Construit une clé canonique pour une paire de doses (indépendante de
+ * l'ordre des IDs).
+ */
+function pairKey(a: string, b: string): string {
+  return a < b ? `${a}|${b}` : `${b}|${a}`;
+}
+
+function canonicalPair(a: string, b: string): [string, string] {
+  return a < b ? [a, b] : [b, a];
+}
+
+/**
+ * Hook framework-agnostique qui applique RM6 à chaque changement du doc :
+ * détecte les paires de prises du même type sur la même pompe dans une
+ * fenêtre de moins de 2 min, puis :
+ * 1. Émet un événement `DoseReviewFlagged` via `flagDuplicatePair`.
+ * 2. Émet une notification locale "double saisie" (chaînes i18n fournies).
+ *
+ * Garde-fous :
+ * - Lit les `DoseReviewFlagged` déjà présents dans le doc pour ne pas
+ *   re-flaguer une paire déjà connue (idempotence cross-device).
+ * - Cache local `flaggedPairsRef` pour éviter les doublons quand le hook
+ *   rerender avec le même doc avant que le flag ait été appliqué (latence
+ *   Automerge).
+ * - Aucun tick périodique : la détection se fait uniquement au changement
+ *   du doc (moins d'empreinte CPU qu'un polling).
+ *
+ * Principe zero-knowledge : le hook lit uniquement des données déjà
+ * présentes en mémoire (doc déchiffré localement). Aucune donnée santé
+ * n'est loguée ; la notification porte uniquement les chaînes i18n
+ * fournies par le wrapper (garantie par l'interface).
+ *
+ * Refs: KIN-73, E7-S03, RM6 (§4 SPECS), CLAUDE.md.
+ */
+export function useDuplicateDetectionWatcher(deps: UseDuplicateDetectionWatcherDeps): void {
+  const doc = deps.useDoc();
+
+  // Cache local des paires déjà traitées localement pour éviter un double
+  // flag quand le doc rerender avant la réconciliation Automerge.
+  const flaggedPairsRef = React.useRef<Set<string>>(new Set());
+
+  // Latest ref pattern pour stabiliser l'identité des deps dans l'effet.
+  const flagDuplicatePairRef = React.useRef(deps.flagDuplicatePair);
+  const notifyDuplicateRef = React.useRef(deps.notifyDuplicate);
+  const nowRef = React.useRef(deps.now);
+  const titleRef = React.useRef(deps.duplicateTitle);
+  const bodyRef = React.useRef(deps.duplicateBody);
+  flagDuplicatePairRef.current = deps.flagDuplicatePair;
+  notifyDuplicateRef.current = deps.notifyDuplicate;
+  nowRef.current = deps.now;
+  titleRef.current = deps.duplicateTitle;
+  bodyRef.current = deps.duplicateBody;
+
+  React.useEffect(() => {
+    if (doc === null) return undefined;
+
+    // 1. Agréger les paires déjà flaggées dans le doc (DoseReviewFlagged).
+    const alreadyFlaggedPairs = new Set<string>();
+    for (const event of doc.events) {
+      if (event.type !== 'DoseReviewFlagged') continue;
+      let payload: DoseReviewFlaggedPayload;
+      try {
+        payload = JSON.parse(event.payloadJson) as DoseReviewFlaggedPayload;
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(payload.doseIds) || payload.doseIds.length < 2) continue;
+      const [a, b] = payload.doseIds;
+      if (typeof a !== 'string' || typeof b !== 'string') continue;
+      alreadyFlaggedPairs.add(pairKey(a, b));
+    }
+
+    // 2. Projeter les doses et construire les DoseSignature pour RM6.
+    //
+    //    Horodatage : on utilise `occurredAtMs` (instant de création de
+    //    l'événement signé côté client) plutôt que `administeredAtMs`
+    //    (instant déclaré de la prise, potentiellement rétroactif via
+    //    backfill RM17). Un backfill d'une ancienne prise ne doit pas
+    //    flagger les prises actuelles proches de son `administeredAtMs`.
+    //    `occurredAtMs` est le meilleur proxy de `recordedAtUtc` (serveur)
+    //    tant que RM14 n'est pas branché côté client. Refs: kz-review-KIN-073 §M1.
+    const doses = projectDoses(doc);
+    const signatures: DoseSignature[] = doses.map((d) => ({
+      doseId: d.doseId,
+      pumpId: d.pumpId,
+      type: d.doseType,
+      recordedAtUtc: new Date(d.occurredAtMs),
+    }));
+
+    // 3. Pour chaque paire (i, j > i), chercher un conflit RM6. Itérer
+    //    j = i+1 au lieu de filtrer évite la double visite de chaque paire
+    //    et divise le travail par 2. Complexité O(n²) mais acceptable pour
+    //    n ≤ quelques milliers de doses (TODO: indexation par bucket
+    //    minute/pompe/type pour n plus grand — ticket de suivi).
+    //    Refs: kz-review-KIN-073 §M2.
+    const nowMs = nowRef.current().getTime();
+    const pairsToFlag: DuplicateDosePair[] = [];
+
+    for (let i = 0; i < signatures.length; i++) {
+      const candidate = signatures[i];
+      if (candidate === undefined) continue;
+      for (let j = i + 1; j < signatures.length; j++) {
+        const other = signatures[j];
+        if (other === undefined) continue;
+        const conflicts = findDuplicateCandidates(candidate, [other]);
+        if (conflicts.length === 0) continue;
+        const key = pairKey(candidate.doseId, other.doseId);
+        if (alreadyFlaggedPairs.has(key)) continue;
+        if (flaggedPairsRef.current.has(key)) continue;
+        flaggedPairsRef.current.add(key);
+        pairsToFlag.push({
+          doseIds: canonicalPair(candidate.doseId, other.doseId),
+          detectedAtMs: nowMs,
+        });
+      }
+    }
+
+    if (pairsToFlag.length === 0) return undefined;
+
+    void (async () => {
+      for (const pair of pairsToFlag) {
+        try {
+          await flagDuplicatePairRef.current(pair);
+        } catch {
+          // L'écriture a échoué (ex. device verrouillé). On retire la
+          // paire du cache pour permettre un retry au prochain cycle.
+          flaggedPairsRef.current.delete(pairKey(pair.doseIds[0], pair.doseIds[1]));
+          continue;
+        }
+
+        // Notification OS : id stable par paire pour dédoublonnage natif.
+        const notifId = `dup:${pair.doseIds[0]}:${pair.doseIds[1]}`;
+        try {
+          await notifyDuplicateRef.current?.({
+            id: notifId,
+            title: titleRef.current,
+            body: bodyRef.current,
+          });
+        } catch {
+          // La notification est best-effort : l'utilisateur verra le
+          // statut `pending_review` dans l'UI même sans notif OS.
+        }
+      }
+    })();
+
+    // Pas de cleanup du cache ici : `flaggedPairsRef` persiste entre les
+    // re-runs de l'effet déclenchés par un changement du doc (chaque
+    // mutation crée un nouveau doc référence). Purger ici déclencherait
+    // un re-flag au tick suivant tant qu'Automerge n'a pas encore propagé
+    // le flag nouvellement appendé. Le cache est vidé automatiquement au
+    // démontage du composant (garbage collection). Un ticket de suivi
+    // pourra traiter le cas spécifique d'une bascule de foyer (rarissime
+    // en session continue). Refs: kz-securite-KIN-073 §M3.
+    return undefined;
+  }, [doc]);
+}

--- a/packages/sync/src/events/types.ts
+++ b/packages/sync/src/events/types.ts
@@ -1,6 +1,7 @@
 /** Types d'événements domaine persistés dans le document Automerge. */
 export type DomainEventType =
   | 'DoseAdministered'
+  | 'DoseReviewFlagged'
   | 'PumpReplaced'
   | 'PlanUpdated'
   | 'CaregiverInvited'
@@ -21,6 +22,27 @@ export interface DoseAdministeredPayload {
   symptoms: string[];
   circumstances: string[];
   freeFormTag: string | null;
+}
+
+/**
+ * Payload pour DoseReviewFlagged — RM6 (§4).
+ *
+ * Émis par le `useDuplicateDetectionWatcher` quand il détecte une paire de
+ * prises du même type sur la même pompe séparées de moins de 2 min.
+ * Référence les deux doses ; la projection `projectDoses` marque chacune
+ * comme `pending_review` dès qu'un flag existe.
+ *
+ * Idempotence : plusieurs flags pour la même paire (ordre inversé ou non)
+ * sont tolérés — la projection dédoublonne par `doseId`. Le watcher évite
+ * néanmoins les duplications via un cache local (`flaggedPairsRef`).
+ */
+export interface DoseReviewFlaggedPayload {
+  /** Identifiant unique du flag (UUID v4). */
+  flagId: string;
+  /** Les deux prises en conflit, **triées par doseId** pour canonicalité. */
+  doseIds: [string, string];
+  /** Instant de détection (UTC ms). */
+  detectedAtMs: number;
 }
 
 /** Payload pour PumpReplaced */
@@ -80,6 +102,7 @@ export interface ChildRegisteredPayload {
 /** Union discriminée des payloads */
 export type DomainEventPayload =
   | { type: 'DoseAdministered'; payload: DoseAdministeredPayload }
+  | { type: 'DoseReviewFlagged'; payload: DoseReviewFlaggedPayload }
   | { type: 'PumpReplaced'; payload: PumpReplacedPayload }
   | { type: 'PlanUpdated'; payload: PlanUpdatedPayload }
   | { type: 'CaregiverInvited'; payload: CaregiverInvitedPayload }

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -15,6 +15,7 @@ export type {
   DomainEventPayload,
   UnsignedEvent,
   DoseAdministeredPayload,
+  DoseReviewFlaggedPayload,
   PumpReplacedPayload,
   PlanUpdatedPayload,
   CaregiverInvitedPayload,

--- a/packages/sync/src/projections/doses.ts
+++ b/packages/sync/src/projections/doses.ts
@@ -1,5 +1,18 @@
 import type { KinhaleDoc } from '../doc/schema.js';
-import type { DoseAdministeredPayload } from '../events/types.js';
+import type { DoseAdministeredPayload, DoseReviewFlaggedPayload } from '../events/types.js';
+
+/**
+ * Statut projeté d'une prise.
+ *
+ * - `recorded` : saisie normale, aucun conflit.
+ * - `pending_review` : RM6 a détecté un doublon potentiel (paire < 2 min sur
+ *   la même pompe, même type). L'aidant doit confirmer ou annuler.
+ *
+ * Le statut `voided` sera ajouté avec E4-S07 (annulation explicite) — pour
+ * l'instant, seules les deux valeurs ci-dessus sont produites par la
+ * projection.
+ */
+export type ProjectedDoseStatus = 'recorded' | 'pending_review';
 
 export interface ProjectedDose extends DoseAdministeredPayload {
   /** ID de l'événement SignedEventRecord. */
@@ -8,13 +21,36 @@ export interface ProjectedDose extends DoseAdministeredPayload {
   occurredAtMs: number;
   /** Device ayant créé l'événement. */
   deviceId: string;
+  /** Statut de la dose (RM6 pour `pending_review`). */
+  status: ProjectedDoseStatus;
 }
 
 /**
  * Dérive la liste ordonnée des prises depuis le document Automerge.
  * Tri : administeredAtMs décroissant (plus récent en premier).
+ *
+ * Les événements `DoseReviewFlagged` sont lus pour enrichir le `status` de
+ * chaque dose référencée (RM6). Un flag quel que soit son ordre de
+ * réception bascule la dose en `pending_review` — c'est idempotent.
  */
 export function projectDoses(doc: KinhaleDoc): ProjectedDose[] {
+  const flaggedDoseIds = new Set<string>();
+  for (const event of doc.events) {
+    if (event.type !== 'DoseReviewFlagged') continue;
+    let flagPayload: DoseReviewFlaggedPayload;
+    try {
+      flagPayload = JSON.parse(event.payloadJson) as DoseReviewFlaggedPayload;
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(flagPayload.doseIds)) continue;
+    for (const id of flagPayload.doseIds) {
+      if (typeof id === 'string' && id.length > 0) {
+        flaggedDoseIds.add(id);
+      }
+    }
+  }
+
   const result: ProjectedDose[] = [];
   for (const event of doc.events) {
     if (event.type !== 'DoseAdministered') continue;
@@ -38,6 +74,7 @@ export function projectDoses(doc: KinhaleDoc): ProjectedDose[] {
       eventId: event.id,
       occurredAtMs: event.occurredAtMs,
       deviceId: event.deviceId,
+      status: flaggedDoseIds.has(payload.doseId) ? 'pending_review' : 'recorded',
     });
   }
   return result.sort((a, b) => b.administeredAtMs - a.administeredAtMs);


### PR DESCRIPTION
Closes #73

Couvre la story **E7-S03 — Résolution conflit double saisie post-sync**. La règle RM6 (détection des prises du même type sur la même pompe dans une fenêtre de 2 min) était implémentée côté domaine mais n'était branchée nulle part. Cette PR pose la détection côté client + l'événement Automerge + la notification locale.

## Nouveautés

- **Événement domaine `DoseReviewFlagged`** signé/chiffré via le pipeline existant. Payload : `{ flagId, doseIds: [a, b], detectedAtMs }`. Aucune donnée santé, juste 2 UUIDs opaques + timestamp.
- **Projection enrichie** : `ProjectedDose.status = 'recorded' | 'pending_review'`, calculé depuis les flags du doc. Idempotent — plusieurs flags pour la même paire sont absorbés.
- **Hook mutualisé `useDuplicateDetectionWatcher`** : détection RM6 au changement du doc, flag + notification. Framework-agnostique. Garde-fous double-barrière (flags existants du doc + cache local).
- **Branchement apps** : `appendDoseFlag` dans les doc-stores web + mobile, wrapper monté dans `RemindersBootstrap` avec i18n FR+EN neutres.

## Choix de design retenus

- **Horodatage** : on utilise `occurredAtMs` (instant de création de l'événement signé) et non `administeredAtMs` (potentiellement rétroactif via backfill RM17). Un backfill d'une vieille prise ne doit pas flaguer des prises actuelles proches de son `administeredAtMs`. Meilleur proxy de `recordedAtUtc` serveur tant que RM14 n'est pas branché.
- **Cache local `flaggedPairsRef`** : non purgé aux re-runs de l'effet (sinon re-flag tant qu'Automerge n'a pas propagé). GC naturel au démontage. Reset ciblé cross-household en ticket de suivi.
- **Détection côté client** : le relai est zero-knowledge et ne peut pas déchiffrer. La détection est déclenchée par tout changement du doc (WS, catchup, batch HTTP) — cohérent avec l'architecture.

## Tests (14 nouveaux, 180 au total)

- **10 tests du hook** : doc null, 1 dose isolée, paire > 2 min, détection < 2 min, pompes différentes, types différents, flag existant, cache local (rerender), 2e paire distincte, i18n dans la notif.
- **4 tests de projection** : statut `recorded` par défaut, paire `pending_review`, dose non-référencée, flag JSON invalide.

Suite globale : 180 sync + 102 web + 69 mobile + 71 api. Lint + typecheck + format verts.

## Revues préalables (workflow obligatoire zone sync)

- **kz-review** : GO avec réserves. 0 bloquant / **2 majeurs corrigés dans la PR** (switch `occurredAtMs`, optimisation O(n²/2) via `for j=i+1`). 5 mineurs documentés. Rapport : `.agents/current-run/kz-review-KIN-073.md`.
- **kz-securite** : GO sans bloquant ni majeur. 3 mineurs en tickets de suivi. Rapport : `.agents/current-run/kz-securite-KIN-073.md`.

## Limitations connues (tickets de suivi à ouvrir)

- **Indexation par bucket** pour passer de O(n²/2) à O(n) quand le doc grossit (> quelques milliers de doses).
- **Vérification permission Expo** dans `notifyDuplicateNowMobile` — à aligner avec le pattern web (`isWebNotificationPermissionGranted`). Même gap sur `notifyMissedDoseNow` de KIN-038.
- **Reset cache** sur changement de `householdId` (rarissime en session continue).
- **Résolution UI** : cette PR pose le flag, la PR suivante **E7-S06** (KIN-76) exposera un écran `/sync-status` listant les doses `pending_review` + stub vers résolution (option A décidée).

## Test plan

- [ ] CI `Lint · Typecheck · Test` vert
- [ ] CI `Docker · node:20-alpine (musl)` vert
- [ ] CI `playwright` vert (non-régression)
- [ ] QA automatisé recommandé (cf. PR précédentes)

Refs: KIN-73, E7-S03, RM6

🤖 Generated with [Claude Code](https://claude.com/claude-code)