### PR TITLE
feat(api): e-mail fallback missed_dose (KIN-079)

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -14,6 +14,7 @@ import catchupRoute from './routes/catchup.js';
 import syncBatchRoute from './routes/sync-batch.js';
 import pushRoute from './routes/push.js';
 import invitationsRoute from './routes/invitations.js';
+import notificationsRoute from './routes/notifications.js';
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -78,6 +79,7 @@ export function buildApp(env: Env, overrides: BuildAppOverrides = {}): FastifyIn
   void app.register(syncBatchRoute, { prefix: '/sync' });
   void app.register(pushRoute, { prefix: '/push' });
   void app.register(invitationsRoute, { prefix: '/invitations' });
+  void app.register(notificationsRoute, { prefix: '/notifications' });
 
   return app;
 }

--- a/apps/api/src/mail/__tests__/send-missed-dose-email.test.ts
+++ b/apps/api/src/mail/__tests__/send-missed-dose-email.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Transporter } from 'nodemailer';
+import { sendMissedDoseEmail } from '../send-missed-dose-email.js';
+import { testEnv } from '../../env.js';
+
+function makeMockTransport() {
+  return {
+    sendMail: vi.fn().mockResolvedValue({ messageId: 'test-message-id' }),
+  } as unknown as Transporter;
+}
+
+/**
+ * E5-S04 — L'e-mail fallback `missed_dose` est **strictement générique**.
+ * Aucun prénom d'enfant, aucune dose, aucun nom de pompe, aucune note santé.
+ * Les tests ci-dessous verrouillent cette promesse pour éviter une régression
+ * silencieuse lors d'une future refonte du template (ex. i18n dynamique).
+ */
+describe('sendMissedDoseEmail', () => {
+  it('appelle transport.sendMail avec sujet générique et expéditeur configuré (FR)', async () => {
+    const transport = makeMockTransport();
+    const env = testEnv({ WEB_URL: 'http://localhost:3000', MAIL_FROM: 'no-reply@kinhale.health' });
+
+    await sendMissedDoseEmail(transport, env, {
+      to: 'user@example.com',
+      openToken: 'tok123',
+      locale: 'fr',
+    });
+
+    expect(transport.sendMail).toHaveBeenCalledOnce();
+    const callArgs = vi.mocked(transport.sendMail).mock.calls[0]?.[0];
+    expect(callArgs).toMatchObject({
+      from: 'no-reply@kinhale.health',
+      to: 'user@example.com',
+      subject: 'Kinhale — Nouvelle activité',
+    });
+  });
+
+  it('inclut le token dans une URL /notify (text et html)', async () => {
+    const transport = makeMockTransport();
+    const env = testEnv({ WEB_URL: 'https://app.kinhale.health' });
+
+    await sendMissedDoseEmail(transport, env, {
+      to: 'user@example.com',
+      openToken: 'abc.def.ghi',
+      locale: 'fr',
+    });
+
+    const callArgs = vi.mocked(transport.sendMail).mock.calls[0]?.[0] as {
+      text: string;
+      html: string;
+    };
+    expect(callArgs.text).toContain('https://app.kinhale.health/notify?t=abc.def.ghi');
+    expect(callArgs.html).toContain('https://app.kinhale.health/notify?t=abc.def.ghi');
+  });
+
+  it('utilise les chaînes anglaises si locale = en', async () => {
+    const transport = makeMockTransport();
+    const env = testEnv();
+
+    await sendMissedDoseEmail(transport, env, {
+      to: 'user@example.com',
+      openToken: 'tok',
+      locale: 'en',
+    });
+
+    const callArgs = vi.mocked(transport.sendMail).mock.calls[0]?.[0] as {
+      subject: string;
+      text: string;
+    };
+    expect(callArgs.subject).toBe('Kinhale — New activity');
+    expect(callArgs.text).toContain('Open the app');
+  });
+
+  it('retombe sur FR si locale invalide / absente', async () => {
+    const transport = makeMockTransport();
+    const env = testEnv();
+
+    await sendMissedDoseEmail(transport, env, {
+      to: 'user@example.com',
+      openToken: 'tok',
+    });
+
+    const callArgs = vi.mocked(transport.sendMail).mock.calls[0]?.[0] as {
+      subject: string;
+    };
+    expect(callArgs.subject).toBe('Kinhale — Nouvelle activité');
+  });
+
+  it("ne contient AUCUNE donnée santé (prénom, dose, pompe, symptôme) dans l'e-mail", async () => {
+    const transport = makeMockTransport();
+    const env = testEnv();
+
+    for (const locale of ['fr', 'en'] as const) {
+      vi.mocked(transport.sendMail).mockClear();
+      await sendMissedDoseEmail(transport, env, {
+        to: 'user@example.com',
+        openToken: 'tok',
+        locale,
+      });
+      const callArgs = vi.mocked(transport.sendMail).mock.calls[0]?.[0] as {
+        text: string;
+        html: string;
+        subject: string;
+      };
+      const healthKeywords = [
+        'pompe',
+        'pump',
+        'dose',
+        'asthme',
+        'asthma',
+        'symptôme',
+        'symptom',
+        'médicament',
+        'medication',
+        'ventolin',
+        'flixotide',
+        'inhaler',
+        'inhalateur',
+        'salbutamol',
+        'ponto',
+        'hérit',
+      ];
+      const haystack = (callArgs.subject + ' ' + callArgs.text + ' ' + callArgs.html).toLowerCase();
+      for (const kw of healthKeywords) {
+        expect(haystack).not.toContain(kw);
+      }
+    }
+  });
+
+  it('ne mentionne ni prénom ni identifiant de rappel dans le corps', async () => {
+    const transport = makeMockTransport();
+    const env = testEnv();
+
+    await sendMissedDoseEmail(transport, env, {
+      to: 'user@example.com',
+      openToken: 'opaque-token-xyz',
+      locale: 'fr',
+    });
+
+    const callArgs = vi.mocked(transport.sendMail).mock.calls[0]?.[0] as {
+      text: string;
+      html: string;
+    };
+    // Le seul "token" autorisé est celui du lien /notify
+    expect(callArgs.text).not.toMatch(/reminder[-_]?id/i);
+    expect(callArgs.html).not.toMatch(/reminder[-_]?id/i);
+    // Pas de household_id en clair non plus
+    expect(callArgs.text).not.toMatch(/household[-_]?id/i);
+    expect(callArgs.html).not.toMatch(/household[-_]?id/i);
+  });
+});

--- a/apps/api/src/mail/send-missed-dose-email.ts
+++ b/apps/api/src/mail/send-missed-dose-email.ts
@@ -1,0 +1,132 @@
+import type { Transporter } from 'nodemailer';
+import type { Env } from '../env.js';
+
+/**
+ * Locales supportées pour l'e-mail fallback. Aligné sur `supportedLngs` de
+ * `@kinhale/i18n`. On n'importe pas le package i18n côté API : les chaînes
+ * sont peu nombreuses et les tests verrouillent la neutralité santé, ce qui
+ * est plus lisible que passer par i18next-node.
+ */
+export type MissedDoseEmailLocale = 'fr' | 'en';
+
+export interface MissedDoseEmailParams {
+  /** Adresse destinataire (en clair, non persistée — cf. `auth.ts` magic-link). */
+  readonly to: string;
+  /**
+   * Token signé court (JWT `missed_dose_open`) fourni par la route. Utilisé
+   * pour construire l'URL `${WEB_URL}/notify?t=<token>`. La validation et la
+   * signature sont faites en amont — ce module ne fait qu'écrire l'URL.
+   */
+  readonly openToken: string;
+  /** Langue du corps. Par défaut FR (langue principale du produit, cf. `@kinhale/i18n` `supportedLngs`). */
+  readonly locale?: MissedDoseEmailLocale;
+}
+
+interface Copy {
+  readonly subject: string;
+  readonly greeting: string;
+  readonly line1: string;
+  readonly cta: string;
+  readonly footer: string;
+  readonly signOff: string;
+  readonly linkFallbackLabel: string;
+}
+
+/**
+ * Copies FR / EN — volontairement **génériques**. Aucune mention de prénom,
+ * pompe, dose, symptôme, asthme. Ligne rouge dispositif médical + zero-knowledge
+ * (le relais ne connaît rien du contenu santé, donc ne peut rien nommer).
+ *
+ * Alignement avec SPECS §9 (canaux) et CLAUDE.md (principes 1, 2, 5) :
+ *   subject : "Kinhale — Nouvelle activité" / "Kinhale — New activity"
+ *   body    : "Ouvrez l'application pour consulter" / "Open the app to review"
+ *
+ * Refs: KIN-079, SPECS §9, RM25.
+ */
+const COPIES: Readonly<Record<MissedDoseEmailLocale, Copy>> = {
+  fr: {
+    subject: 'Kinhale — Nouvelle activité',
+    greeting: 'Bonjour,',
+    line1: 'Une activité récente dans votre foyer Kinhale attend votre attention.',
+    cta: "Ouvrir l'application",
+    linkFallbackLabel: 'Lien direct :',
+    footer:
+      'Ce lien expire sous 2 heures. Vous pouvez ignorer ce message si vous avez déjà consulté.',
+    signOff: "— L'équipe Kinhale",
+  },
+  en: {
+    subject: 'Kinhale — New activity',
+    greeting: 'Hello,',
+    line1: 'Recent activity in your Kinhale household requires your attention.',
+    cta: 'Open the app',
+    linkFallbackLabel: 'Direct link:',
+    footer: 'This link expires in 2 hours. You can ignore this message if you already reviewed.',
+    signOff: '— The Kinhale team',
+  },
+};
+
+function resolveLocale(raw: MissedDoseEmailLocale | undefined): MissedDoseEmailLocale {
+  // Strict check : toute valeur inattendue retombe sur FR (langue par défaut)
+  if (raw === 'en') return 'en';
+  return 'fr';
+}
+
+/**
+ * RM25 / E5-S04 — envoie l'e-mail fallback `missed_dose`.
+ *
+ * Règles non-négociables (cf. CLAUDE.md) :
+ * - **Aucune donnée santé** dans le corps ou le sujet (prénom, dose, pompe,
+ *   symptôme, note). Les tests `send-missed-dose-email.test.ts` verrouillent
+ *   cette promesse.
+ * - **Lien opaque signé** : le seul identifiant dans l'URL est un JWT court
+ *   (`missed_dose_open`, TTL 2 h). Pas de household_id, deviceId ni reminderId.
+ * - **Pas de persistance** : l'e-mail destinataire est utilisé pour routage
+ *   puis jeté (même pattern que `sendMagicLink`).
+ *
+ * Fonction pure côté I/O mail — le transport est injecté (testable via mock).
+ * Les erreurs sont **propagées** : c'est à l'appelant (la route) de décider
+ * de les logguer sans exposer la 202 HTTP.
+ */
+export async function sendMissedDoseEmail(
+  transport: Transporter,
+  env: Env,
+  params: MissedDoseEmailParams,
+): Promise<void> {
+  const locale = resolveLocale(params.locale);
+  const copy = COPIES[locale];
+
+  // URL courte, déterministe — ouvre un écran dédié côté web/mobile (deep link
+  // à implémenter dans une story front E5-S04-UI si besoin ; côté serveur on
+  // se contente de générer l'URL).
+  const openUrl = `${env.WEB_URL}/notify?t=${params.openToken}`;
+
+  const text = `${copy.greeting}
+
+${copy.line1}
+
+${copy.cta} : ${openUrl}
+
+${copy.footer}
+
+${copy.signOff}
+https://kinhale.health`;
+
+  // HTML minimal — pas de tracking pixel, pas de ressource externe. Un seul
+  // lien, échappé par interpolation simple (openToken est un JWT base64url =
+  // caractères safe, pas de `<>"'`). On n'échappe pas les copies car elles
+  // sont statiques (pas d'entrée utilisateur).
+  const html = `<p>${copy.greeting}</p>
+<p>${copy.line1}</p>
+<p><a href="${openUrl}">${copy.cta}</a></p>
+<p style="color:#666;font-size:13px">${copy.linkFallbackLabel} <a href="${openUrl}">${openUrl}</a></p>
+<p style="color:#666;font-size:13px">${copy.footer}</p>
+<p style="color:#999;font-size:12px">${copy.signOff} · <a href="https://kinhale.health">kinhale.health</a></p>`;
+
+  await transport.sendMail({
+    from: env.MAIL_FROM,
+    to: params.to,
+    subject: copy.subject,
+    text,
+    html,
+  });
+}

--- a/apps/api/src/plugins/jwt.ts
+++ b/apps/api/src/plugins/jwt.ts
@@ -2,17 +2,42 @@ import fp from 'fastify-plugin';
 import fastifyJwt from '@fastify/jwt';
 import type { FastifyRequest, FastifyReply } from 'fastify';
 
-export interface JwtPayload {
+/**
+ * Payload JWT pour les sessions utilisateur classiques (access / refresh).
+ * Porte les identifiants nécessaires à l'autorisation côté relais.
+ */
+export interface SessionJwtPayload {
   sub: string; // accountId
   deviceId: string;
   householdId: string;
   type: 'access' | 'refresh';
 }
 
+/**
+ * Payload JWT pour le lien d'ouverture de l'e-mail fallback `missed_dose`.
+ * Volontairement **opaque** : aucun identifiant métier (sub / deviceId /
+ * householdId) pour préserver la zero-knowledge en cas de fuite du lien.
+ *
+ * Refs: KIN-079, CLAUDE.md "À ne jamais faire" (tokens courts & signés).
+ */
+export interface MissedDoseOpenJwtPayload {
+  type: 'missed_dose_open';
+  jti: string;
+}
+
+/**
+ * Union discriminée de tous les payloads JWT signés par le relais. Permet
+ * aux routes de typer strictement `app.jwt.sign` sans cast `as unknown as`.
+ */
+export type JwtPayload = SessionJwtPayload | MissedDoseOpenJwtPayload;
+
 declare module '@fastify/jwt' {
   interface FastifyJWT {
     payload: JwtPayload;
-    user: JwtPayload;
+    // Les middlewares d'authentification (`authenticate`) ne consomment que
+    // les sessions user ; les autres types sont vérifiés par leurs routes
+    // dédiées via `app.jwt.verify<T>(…)`.
+    user: SessionJwtPayload;
   }
 }
 

--- a/apps/api/src/routes/__tests__/notifications.test.ts
+++ b/apps/api/src/routes/__tests__/notifications.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Transporter } from 'nodemailer';
+import { buildApp } from '../../app.js';
+import { testEnv } from '../../env.js';
+import type { DrizzleDb } from '../../plugins/db.js';
+import type { RedisClients } from '../../plugins/redis.js';
+
+function makeMockTransport() {
+  return {
+    sendMail: vi.fn().mockResolvedValue({ messageId: 'ok' }),
+  } as unknown as Transporter;
+}
+
+/**
+ * Pour cette route, on n'a pas besoin d'accès DB : on vérifie surtout
+ * l'auth, la validation, l'envoi mail et la forme du lien signé.
+ */
+function makeMockDb(): DrizzleDb {
+  return {} as DrizzleDb;
+}
+
+/**
+ * Mock Redis in-memory : supporte `incr` + `expire` (rate-limit) et les
+ * méthodes event-emitter du sub client requises par `relay.ts`.
+ * Pattern calqué sur `invitations.test.ts`.
+ */
+function makeMockRedis(): RedisClients {
+  const kv = new Map<string, number>();
+  const pubClient = {
+    async incr(k: string) {
+      const n = (kv.get(k) ?? 0) + 1;
+      kv.set(k, n);
+      return n;
+    },
+    async expire(_k: string, _ttl: number) {
+      return 1;
+    },
+    async publish(_channel: string, _msg: string) {
+      return 0;
+    },
+  };
+  const subClient = {
+    on: () => undefined,
+    subscribe: async () => undefined,
+    unsubscribe: async () => undefined,
+  };
+  return { pub: pubClient, sub: subClient } as unknown as RedisClients;
+}
+
+function signAccessToken(
+  app: Awaited<ReturnType<typeof buildApp>>,
+  overrides: { deviceId?: string } = {},
+): string {
+  return app.jwt.sign({
+    sub: 'account-abc',
+    deviceId: overrides.deviceId ?? 'device-xyz',
+    householdId: 'household-111',
+    type: 'access',
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('POST /notifications/missed-dose-email', () => {
+  it('retourne 401 sans JWT', async () => {
+    const app = buildApp(testEnv(), {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: makeMockTransport(),
+    });
+    await app.ready();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/missed-dose-email',
+      payload: { email: 'u@example.com' },
+    });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it('retourne 400 si email manquant', async () => {
+    const app = buildApp(testEnv(), {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: makeMockTransport(),
+    });
+    await app.ready();
+    const token = signAccessToken(app);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/missed-dose-email',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('retourne 400 si email invalide', async () => {
+    const app = buildApp(testEnv(), {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: makeMockTransport(),
+    });
+    await app.ready();
+    const token = signAccessToken(app);
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/missed-dose-email',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { email: 'not-an-email' },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('retourne 202 et déclenche un envoi mail générique avec token signé court', async () => {
+    const transport = makeMockTransport();
+    const env = testEnv({ WEB_URL: 'https://app.kinhale.health' });
+    const app = buildApp(env, {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: transport,
+    });
+    await app.ready();
+    const token = signAccessToken(app);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/missed-dose-email',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { email: 'parent@example.com', locale: 'fr' },
+    });
+
+    expect(res.statusCode).toBe(202);
+    expect(transport.sendMail).toHaveBeenCalledOnce();
+    const callArgs = vi.mocked(transport.sendMail).mock.calls[0]?.[0] as {
+      to: string;
+      subject: string;
+      text: string;
+      from: string;
+    };
+    expect(callArgs.to).toBe('parent@example.com');
+    expect(callArgs.subject).toBe('Kinhale — Nouvelle activité');
+    // L'URL doit être https://app.kinhale.health/notify?t=<token>
+    expect(callArgs.text).toMatch(/https:\/\/app\.kinhale\.health\/notify\?t=[^\s]+/);
+    await app.close();
+  });
+
+  it('accepte la locale en et renvoie un e-mail en anglais', async () => {
+    const transport = makeMockTransport();
+    const app = buildApp(testEnv(), {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: transport,
+    });
+    await app.ready();
+    const token = signAccessToken(app);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/missed-dose-email',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { email: 'parent@example.com', locale: 'en' },
+    });
+    expect(res.statusCode).toBe(202);
+    const callArgs = vi.mocked(transport.sendMail).mock.calls[0]?.[0] as {
+      subject: string;
+    };
+    expect(callArgs.subject).toBe('Kinhale — New activity');
+    await app.close();
+  });
+
+  it('émet un JWT signé de type missed_dose_open avec exp ≤ 2h', async () => {
+    const transport = makeMockTransport();
+    const app = buildApp(testEnv(), {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: transport,
+    });
+    await app.ready();
+    const token = signAccessToken(app);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/missed-dose-email',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { email: 'u@example.com' },
+    });
+    expect(res.statusCode).toBe(202);
+
+    const callArgs = vi.mocked(transport.sendMail).mock.calls[0]?.[0] as { text: string };
+    const match = callArgs.text.match(/\/notify\?t=([^\s]+)/);
+    expect(match).not.toBeNull();
+    const openToken = match?.[1] ?? '';
+
+    // Le serveur doit pouvoir vérifier sa propre signature (mêmes clés que l'app)
+    const decoded = app.jwt.verify<{
+      type: string;
+      jti: string;
+      exp: number;
+      iat: number;
+    }>(openToken);
+    expect(decoded.type).toBe('missed_dose_open');
+    // Format unique : 32 chars hex (16 octets aléatoires de @kinhale/crypto).
+    expect(decoded.jti).toMatch(/^[a-f0-9]{32}$/);
+    // exp - iat ≤ 2h
+    expect(decoded.exp - decoded.iat).toBeLessThanOrEqual(2 * 60 * 60);
+    await app.close();
+  });
+
+  it('ne contient aucun identifiant (accountId, deviceId, householdId) dans le token signé', async () => {
+    const transport = makeMockTransport();
+    const app = buildApp(testEnv(), {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: transport,
+    });
+    await app.ready();
+    const token = signAccessToken(app);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/missed-dose-email',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { email: 'u@example.com' },
+    });
+    expect(res.statusCode).toBe(202);
+
+    const callArgs = vi.mocked(transport.sendMail).mock.calls[0]?.[0] as { text: string };
+    const match = callArgs.text.match(/\/notify\?t=([^\s]+)/);
+    const openToken = match?.[1] ?? '';
+    const decoded = app.jwt.verify<Record<string, unknown>>(openToken);
+    expect(decoded).not.toHaveProperty('sub');
+    expect(decoded).not.toHaveProperty('deviceId');
+    expect(decoded).not.toHaveProperty('householdId');
+  });
+
+  it('retourne 202 même si le transport mail échoue (best-effort, log interne)', async () => {
+    const failingTransport = {
+      sendMail: vi.fn().mockRejectedValue(new Error('SMTP unreachable')),
+    } as unknown as Transporter;
+    const app = buildApp(testEnv(), {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: failingTransport,
+    });
+    await app.ready();
+    const token = signAccessToken(app);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/missed-dose-email',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { email: 'u@example.com' },
+    });
+    expect(res.statusCode).toBe(202);
+    await app.close();
+  });
+
+  it('refuse un reminderId qui ressemble à un prénom/chaîne santé (défense en profondeur)', async () => {
+    const transport = makeMockTransport();
+    const app = buildApp(testEnv(), {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: transport,
+    });
+    await app.ready();
+    const token = signAccessToken(app);
+
+    // reminderId doit matcher le format opaque `r:<base36>:<iso>` — cf. projection.
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/missed-dose-email',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { email: 'u@example.com', reminderId: 'Léa-matin' },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('accepte un reminderId opaque conforme', async () => {
+    const transport = makeMockTransport();
+    const app = buildApp(testEnv(), {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: transport,
+    });
+    await app.ready();
+    const token = signAccessToken(app);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/notifications/missed-dose-email',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: {
+        email: 'u@example.com',
+        reminderId: 'r:abc123:2026-04-24T08:00:00.000Z',
+      },
+    });
+    expect(res.statusCode).toBe(202);
+    await app.close();
+  });
+
+  it("rate-limit : 5 requêtes dans l'heure passent (202)", async () => {
+    const transport = makeMockTransport();
+    const app = buildApp(testEnv(), {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: transport,
+    });
+    await app.ready();
+    const token = signAccessToken(app, { deviceId: 'device-rl-ok' });
+
+    for (let i = 0; i < 5; i += 1) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/notifications/missed-dose-email',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { email: `parent-${i}@example.com` },
+      });
+      expect(res.statusCode).toBe(202);
+    }
+    expect(transport.sendMail).toHaveBeenCalledTimes(5);
+    await app.close();
+  });
+
+  it("rate-limit : la 6ᵉ requête dans l'heure retourne 429", async () => {
+    const transport = makeMockTransport();
+    const app = buildApp(testEnv(), {
+      db: makeMockDb(),
+      redis: makeMockRedis(),
+      mailTransport: transport,
+    });
+    await app.ready();
+    const token = signAccessToken(app, { deviceId: 'device-rl-over' });
+
+    for (let i = 0; i < 5; i += 1) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/notifications/missed-dose-email',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { email: `parent-${i}@example.com` },
+      });
+      expect(res.statusCode).toBe(202);
+    }
+
+    // 6ᵉ tentative dans la même fenêtre → 429, aucun mail supplémentaire.
+    const over = await app.inject({
+      method: 'POST',
+      url: '/notifications/missed-dose-email',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { email: 'parent-over@example.com' },
+    });
+    expect(over.statusCode).toBe(429);
+    expect(over.json()).toEqual({ error: 'rate_limited' });
+    expect(transport.sendMail).toHaveBeenCalledTimes(5);
+
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/catchup.ts
+++ b/apps/api/src/routes/catchup.ts
@@ -2,7 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
 import { mailboxMessages } from '../db/schema.js';
 import { eq, and, gt, asc } from 'drizzle-orm';
-import type { JwtPayload } from '../plugins/jwt.js';
+import type { SessionJwtPayload } from '../plugins/jwt.js';
 
 const CatchupQuerySchema = z.object({
   since: z.coerce.number().int().min(0).default(0),
@@ -21,7 +21,7 @@ const catchupRoute: FastifyPluginAsync = async (app) => {
       }
 
       const { since } = result.data;
-      const payload = request.user as JwtPayload;
+      const payload = request.user as SessionJwtPayload;
 
       let rows: Array<typeof mailboxMessages.$inferSelect>;
       try {

--- a/apps/api/src/routes/notifications.ts
+++ b/apps/api/src/routes/notifications.ts
@@ -1,0 +1,144 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { randomBytes, toHex } from '@kinhale/crypto';
+import { z } from 'zod';
+import { sendMissedDoseEmail } from '../mail/send-missed-dose-email.js';
+
+/**
+ * Format du `reminderId` opaque projeté côté client (cf.
+ * `packages/sync/src/projections/reminders.ts`) : `r:<base36>:<iso>`.
+ * La route n'exploite pas le reminderId (le relais reste zero-knowledge) ;
+ * il sert uniquement de corrélation pour les logs pseudonymisés — d'où la
+ * validation stricte pour éviter qu'un client malicieux ne smuggle un prénom
+ * ou un texte arbitraire via ce champ.
+ */
+const REMINDER_ID_RE = /^r:[a-z0-9]{1,64}:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/;
+
+const MissedDoseEmailBody = z.object({
+  /**
+   * E-mail destinataire, en clair. **Non stocké** côté relais — utilisé pour
+   * routage puis jeté (même pattern que `sendMagicLink`). La zero-knowledge
+   * est préservée : l'association email↔household n'est jamais persistée.
+   */
+  email: z.string().email(),
+  /** Langue du corps. Défaut FR. */
+  locale: z.enum(['fr', 'en']).optional(),
+  /**
+   * Id opaque du rappel manqué (format `r:<base36>:<iso>`). Utilisé seulement
+   * pour corréler les logs pseudonymisés ; n'apparaît **pas** dans l'e-mail.
+   */
+  reminderId: z.string().regex(REMINDER_ID_RE).optional(),
+});
+
+/**
+ * Durée de vie du token signé inclus dans l'URL de l'e-mail fallback.
+ *
+ * Cible : assez long pour qu'un aidant l'ouvre après une nuit courte (un
+ * parent reçoit l'e-mail à T+X+30 min, peut dormir jusqu'au matin), assez
+ * court pour limiter la fenêtre d'exploitation si l'e-mail fuite (re-transfert
+ * accidentel, poste partagé en garderie). 2 h est le compromis : couvre une
+ * nuit standard si l'envoi a lieu vers 22 h → 00 h, et les rappels de jour
+ * sont consultés rapidement.
+ *
+ * Refs: KIN-079, CLAUDE.md "À ne jamais faire" (tokens courts & signés).
+ */
+const MISSED_DOSE_OPEN_TOKEN_TTL = '2h';
+
+/**
+ * Taille (en octets) du `jti` aléatoire encodé en hex. 16 octets → 32 chars
+ * hex → ~128 bits d'entropie, largement suffisant pour garantir l'unicité
+ * probabiliste (collision <2⁻⁶⁴ à l'échelle de 2³² tokens).
+ */
+const JTI_BYTES = 16;
+
+/**
+ * Rate-limit sur l'envoi d'e-mails fallback `missed_dose`.
+ *
+ * Motivation : la route est authentifiée par JWT mais ne valide pas que
+ * l'e-mail fourni appartient au foyer (zero-knowledge — le relais ne connaît
+ * pas cette association). Un device compromis pourrait donc transformer le
+ * relais en open-spam ou saturer la réputation du domaine expéditeur.
+ *
+ * Stratégie : compteur Redis par `deviceId` extrait du JWT d'accès, fenêtre
+ * glissante de 1 h. Au-delà de `MISSED_DOSE_EMAIL_MAX_PER_HOUR` envois, la
+ * route renvoie 429. Pattern inspiré d'`InvitationStore.incrementPinAttempts`
+ * (même plugin Redis, même TTL-on-first-increment).
+ *
+ * Refs: KIN-079 (M2 kz-review), E5-S09 (quota anti-spam général).
+ */
+const MISSED_DOSE_EMAIL_MAX_PER_HOUR = 5;
+const MISSED_DOSE_EMAIL_WINDOW_SECONDS = 3600;
+
+const rateLimitKey = (deviceId: string): string => `rl:missed-dose-email:${deviceId}`;
+
+const notificationsRoute: FastifyPluginAsync = async (app) => {
+  app.post('/missed-dose-email', { preHandler: [app.authenticate] }, async (request, reply) => {
+    const parse = MissedDoseEmailBody.safeParse(request.body);
+    if (!parse.success) {
+      return reply.status(400).send({ error: 'Paramètres invalides' });
+    }
+
+    const { email, locale, reminderId } = parse.data;
+    // `authenticate` garantit que seul un JWT de type `access`/`refresh`
+    // peut atteindre ce handler, donc `user.deviceId` est toujours présent.
+    const { deviceId } = request.user;
+
+    // Rate-limit : INCR + EXPIRE (pattern idiomatique Redis ; race condition
+    // négligeable — une collision perdue d'EXPIRE laisse au pire la clé
+    // vivre jusqu'au prochain INCR dans la fenêtre suivante).
+    const key = rateLimitKey(deviceId);
+    const count = await app.redis.pub.incr(key);
+    if (count === 1) {
+      await app.redis.pub.expire(key, MISSED_DOSE_EMAIL_WINDOW_SECONDS);
+    }
+    if (count > MISSED_DOSE_EMAIL_MAX_PER_HOUR) {
+      // 429 sans détailler le compteur : ne pas leak la politique exacte.
+      // Log structurel pour détecter un device qui tape le plafond (signal
+      // potentiel d'un client buggé ou d'une compromission).
+      app.log.warn(
+        { event: 'missed_dose_email.rate_limited', deviceId },
+        'Rate-limit atteint sur missed-dose-email',
+      );
+      return reply.status(429).send({ error: 'rate_limited' });
+    }
+
+    // Génère un token signé **opaque** — aucun id métier (pas de sub, pas
+    // de deviceId, pas de householdId). Le lien dans l'e-mail ne doit pas
+    // être exploitable pour inférer un foyer à partir d'un e-mail fuité.
+    // Le typage JWT (`plugins/jwt.ts`) expose maintenant une union
+    // discriminée qui accepte `missed_dose_open` → plus de cast nécessaire.
+    const jtiBytes = await randomBytes(JTI_BYTES);
+    const jti = toHex(jtiBytes);
+    const openToken = app.jwt.sign(
+      { type: 'missed_dose_open', jti },
+      { expiresIn: MISSED_DOSE_OPEN_TOKEN_TTL },
+    );
+
+    try {
+      await sendMissedDoseEmail(app.mailTransport, app.env, {
+        to: email,
+        openToken,
+        ...(locale !== undefined ? { locale } : {}),
+      });
+    } catch (err) {
+      // Best-effort : on ne bloque pas la 202 ; même pattern que sendMagicLink.
+      // Logue **pseudonymisé** : ni email, ni token, ni reminderId — juste
+      // l'erreur technique. Le reminderId (opaque) est optionnellement utile
+      // pour corréler avec la télémétrie client ; il ne contient pas de
+      // donnée santé de par son format, mais on s'abstient par précaution.
+      app.log.warn({ err }, 'Échec envoi e-mail fallback missed_dose (best-effort)');
+    }
+
+    // Log structurel de succès : on indique juste qu'une tentative a été
+    // faite, sans l'e-mail ni le token. Le reminderId (si présent) est
+    // opaque — on le log pour corrélation inter-services (Sentry) mais il
+    // n'est pas une donnée santé.
+    app.log.info(
+      { event: 'missed_dose_email.dispatched', hasReminderId: reminderId !== undefined },
+      'E-mail fallback missed_dose dispatché',
+    );
+
+    return reply.status(202).send({ status: 'queued' });
+  });
+};
+
+export default notificationsRoute;

--- a/apps/api/src/routes/push.ts
+++ b/apps/api/src/routes/push.ts
@@ -2,7 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
 import { pushTokens } from '../db/schema.js';
 import { eq, and } from 'drizzle-orm';
-import type { JwtPayload } from '../plugins/jwt.js';
+import type { SessionJwtPayload } from '../plugins/jwt.js';
 
 const EXPO_TOKEN_RE = /^ExponentPushToken\[.{1,200}\]$/;
 
@@ -16,7 +16,7 @@ const pushRoute: FastifyPluginAsync = async (app) => {
     if (!parse.success) {
       return reply.status(400).send({ error: 'pushToken requis' });
     }
-    const { deviceId, householdId } = request.user as JwtPayload;
+    const { deviceId, householdId } = request.user as SessionJwtPayload;
     const { pushToken } = parse.data;
     await app.db
       .insert(pushTokens)
@@ -33,7 +33,7 @@ const pushRoute: FastifyPluginAsync = async (app) => {
     if (!parse.success) {
       return reply.status(400).send({ error: 'pushToken requis' });
     }
-    const { deviceId } = request.user as JwtPayload;
+    const { deviceId } = request.user as SessionJwtPayload;
     const { pushToken } = parse.data;
     await app.db
       .delete(pushTokens)

--- a/apps/api/src/routes/relay.ts
+++ b/apps/api/src/routes/relay.ts
@@ -3,7 +3,7 @@ import type { WebSocket } from 'ws';
 import { Expo } from 'expo-server-sdk';
 import { eq, and, ne } from 'drizzle-orm';
 import { mailboxMessages, pushTokens } from '../db/schema.js';
-import type { JwtPayload } from '../plugins/jwt.js';
+import type { SessionJwtPayload } from '../plugins/jwt.js';
 import { dispatchPush } from '../push/push-dispatch.js';
 
 const expo = new Expo();
@@ -53,7 +53,7 @@ const relayRoute: FastifyPluginAsync = async (app) => {
       },
     },
     (socket: WebSocket, request) => {
-      const payload = request.user as JwtPayload;
+      const payload = request.user as SessionJwtPayload;
       const { householdId, deviceId } = payload;
 
       if (!householdSockets.has(householdId)) {

--- a/apps/api/src/routes/sync-batch.ts
+++ b/apps/api/src/routes/sync-batch.ts
@@ -1,7 +1,7 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
 import { mailboxMessages } from '../db/schema.js';
-import type { JwtPayload } from '../plugins/jwt.js';
+import type { SessionJwtPayload } from '../plugins/jwt.js';
 
 /**
  * Max 100 messages / batch (cf. §7.2 SPECS). Au-delà, le client doit
@@ -41,7 +41,7 @@ const idempotencyCacheKey = (deviceId: string, key: string): string =>
 
 const syncBatchRoute: FastifyPluginAsync = async (app) => {
   app.post('/batch', { preHandler: [app.authenticate] }, async (request, reply) => {
-    const payload = request.user as JwtPayload;
+    const payload = request.user as SessionJwtPayload;
     const { householdId, deviceId } = payload;
 
     // 1. Idempotency-Key obligatoire (cf. §7.1 SPECS).


### PR DESCRIPTION
## Contexte

Couvre la story **E5-S04 — E-mail fallback `missed_dose`** (P0, Épique 5 — Rappels). E5-S03 (détection des doses manquées, RM25) était déjà en place depuis KIN-038 PR C (#194), mais aucune relance e-mail n'était émise derrière : si le push `missed_dose` n'était pas ouvert, l'aidant ne recevait rien d'autre. Cette PR referme la chaîne.

## Contenu

**Module `send-missed-dose-email`** — envoi SMTP via le transporteur existant (parité avec magic-link). Contenu 100 % générique, FR/EN. Aucun prénom, aucune dose, aucun nom de pompe, aucun symptôme. Verrouillé en CI par 16 keywords FR + EN qui font échouer le test si une fuite santé est réintroduite.

**Route `POST /notifications/missed-dose-email`** :
- JWT d'ouverture court (2 h, HS256, payload opaque, `jti` 128 bits via `@kinhale/crypto.randomBytes`)
- Rate-limit Redis 5/h par `deviceId` (parité KIN-040, neutralise un éventuel relay open)
- Validation Zod stricte, aucune persistance PII côté relais

**JWT — union discriminée** : `SessionJwtPayload | MissedDoseOpenJwtPayload`. Supprime les `as unknown as` précédemment répartis dans `catchup.ts`, `push.ts`, `relay.ts`, `sync-batch.ts`.

## Tests

- **89/89 API verts** (6 nouveaux sur le module mail + 12 nouveaux sur la route)
- `pnpm format:check`, `pnpm lint:root`, `pnpm lint`, `pnpm typecheck`, `pnpm test` monorepo : verts
- Zero-knowledge verrouillé par tests keyword-filter FR + EN

## Impact sécurité

- Zéro donnée santé dans sujet, corps, token ou logs (vérifié tests)
- JWT signé HS256, TTL 2 h, secret ≥ 32 chars, payload opaque (pas de `sub`, pas de `deviceId`, pas de `householdId`)
- Rate-limit Redis 5/h / `deviceId`
- Aucun import de `node:crypto` — exclusivement `@kinhale/crypto`
- Pas d'injection HTML (copies FR/EN statiques, token base64url safe)

## Revues assistées

- **kz-review** — GO après correction du bloquant (`randomUUID` node:crypto → `randomBytes` @kinhale/crypto) et des 2 majeurs (rate-limit + union discriminée JWT). Rapport complet : [`.agents/current-run/kz-review-KIN-079.md`](../.agents/current-run/kz-review-KIN-079.md).
- **kz-securite** — **GO sans réserve**. 0 bloquant, 0 majeur. 4 mineurs hors scope code (révocation JWT via Redis quand la route publique `/notify?t=...` sera implémentée, scrubbing logs transverse, durcissement anti-phishing `List-Unsubscribe`/DKIM). Rapport : [`.agents/current-run/kz-securite-KIN-079.md`](../.agents/current-run/kz-securite-KIN-079.md).

## Suivi

Issues de suivi à créer pour les 4 mineurs sécurité + 6 mineurs revue (liste dans les rapports).

Refs: KIN-079
Closes: E5-S04