### PR TITLE
feat(api,ui): paramétrage granulaire des notifications (KIN-080)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "@fastify/jwt": "^9.0.0",
     "@fastify/websocket": "^11.0.0",
     "@kinhale/crypto": "workspace:*",
+    "@kinhale/domain": "workspace:*",
     "drizzle-orm": "^0.38.0",
     "expo-server-sdk": "^6.1.0",
     "fastify": "^5.0.0",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -15,6 +15,7 @@ import syncBatchRoute from './routes/sync-batch.js';
 import pushRoute from './routes/push.js';
 import invitationsRoute from './routes/invitations.js';
 import notificationsRoute from './routes/notifications.js';
+import notificationPreferencesRoute from './routes/notification-preferences.js';
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -80,6 +81,7 @@ export function buildApp(env: Env, overrides: BuildAppOverrides = {}): FastifyIn
   void app.register(pushRoute, { prefix: '/push' });
   void app.register(invitationsRoute, { prefix: '/invitations' });
   void app.register(notificationsRoute, { prefix: '/notifications' });
+  void app.register(notificationPreferencesRoute);
 
   return app;
 }

--- a/apps/api/src/db/migrations/0001_curly_iron_man.sql
+++ b/apps/api/src/db/migrations/0001_curly_iron_man.sql
@@ -1,0 +1,10 @@
+CREATE TABLE "user_notification_preferences" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"account_id" uuid NOT NULL,
+	"notification_type" text NOT NULL,
+	"enabled" boolean NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_notification_preferences" ADD CONSTRAINT "user_notification_preferences_account_id_accounts_id_fk" FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "user_notif_prefs_account_type_idx" ON "user_notification_preferences" USING btree ("account_id","notification_type");

--- a/apps/api/src/db/migrations/meta/0001_snapshot.json
+++ b/apps/api/src/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,430 @@
+{
+  "id": "f296255e-b9a1-4b09-a7a9-61f6b43a4878",
+  "prevId": "8547dec5-8974-4942-b436-7ffc3e3ecd0d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "accounts_email_hash_unique": {
+          "name": "accounts_email_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devices": {
+      "name": "devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key_hex": {
+          "name": "public_key_hex",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devices_account_pubkey_idx": {
+          "name": "devices_account_pubkey_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "public_key_hex",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devices_account_id_accounts_id_fk": {
+          "name": "devices_account_id_accounts_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.magic_links": {
+      "name": "magic_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email_hash": {
+          "name": "email_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mailbox_messages": {
+      "name": "mailbox_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sender_device_id": {
+          "name": "sender_device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blob_json": {
+          "name": "blob_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at_ms": {
+          "name": "sent_at_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "acked_at": {
+          "name": "acked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_tokens": {
+      "name": "push_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "household_id": {
+          "name": "household_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_tokens_device_token_idx": {
+          "name": "push_tokens_device_token_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_tokens_household_idx": {
+          "name": "push_tokens_household_idx",
+          "columns": [
+            {
+              "expression": "household_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_tokens_device_id_devices_id_fk": {
+          "name": "push_tokens_device_id_devices_id_fk",
+          "tableFrom": "push_tokens",
+          "tableTo": "devices",
+          "columnsFrom": ["device_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_notif_prefs_account_type_idx": {
+          "name": "user_notif_prefs_account_type_idx",
+          "columns": [
+            {
+              "expression": "account_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_notification_preferences_account_id_accounts_id_fk": {
+          "name": "user_notification_preferences_account_id_accounts_id_fk",
+          "tableFrom": "user_notification_preferences",
+          "tableTo": "accounts",
+          "columnsFrom": ["account_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/api/src/db/migrations/meta/_journal.json
+++ b/apps/api/src/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776887939827,
       "tag": "0000_silent_zzzax",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777026764150,
+      "tag": "0001_curly_iron_man",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -1,4 +1,13 @@
-import { pgTable, uuid, text, timestamp, bigint, uniqueIndex, index } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  bigint,
+  boolean,
+  uniqueIndex,
+  index,
+} from 'drizzle-orm/pg-core';
 
 /**
  * Comptes utilisateurs. L'email n'est jamais stocké en clair —
@@ -79,4 +88,38 @@ export const pushTokens = pgTable(
     uniqueIndex('push_tokens_device_token_idx').on(t.deviceId, t.token),
     index('push_tokens_household_idx').on(t.householdId),
   ],
+);
+
+/**
+ * Préférences granulaires de notifications par compte (E5-S07).
+ *
+ * Les `missed_dose` et `security_alert` ne sont **jamais** persistés ici :
+ * ils sont toujours actifs (SPECS §9 + RM25), et l'endpoint PUT refuse
+ * toute tentative de les désactiver.
+ *
+ * Les types **absents** de cette table sont considérés `enabled = true` par
+ * défaut (convention ergonomique : l'utilisateur n'a qu'à matérialiser les
+ * refus, les acceptations étant silencieuses).
+ *
+ * Contrainte d'unicité (`accountId`, `notificationType`) : une seule entrée
+ * par paire — un PUT réémis écrase proprement via `onConflictDoUpdate`.
+ *
+ * Granularité : **par compte** (et non par device). L'intention utilisateur
+ * est partagée entre ses devices ; rien n'empêche une évolution future vers
+ * une granularité device si le besoin émerge (ADR séparé).
+ *
+ * Aucune donnée santé ici — seulement une métadonnée de préférence.
+ */
+export const userNotificationPreferences = pgTable(
+  'user_notification_preferences',
+  {
+    id: uuid('id').defaultRandom().primaryKey(),
+    accountId: uuid('account_id')
+      .notNull()
+      .references(() => accounts.id, { onDelete: 'cascade' }),
+    notificationType: text('notification_type').notNull(),
+    enabled: boolean('enabled').notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+  },
+  (t) => [uniqueIndex('user_notif_prefs_account_type_idx').on(t.accountId, t.notificationType)],
 );

--- a/apps/api/src/push/__tests__/push-dispatch.test.ts
+++ b/apps/api/src/push/__tests__/push-dispatch.test.ts
@@ -12,13 +12,13 @@ vi.mock('expo-server-sdk', () => {
   return { Expo: MockExpo };
 });
 
-import { dispatchPush } from '../push-dispatch.js';
+import { dispatchPush, type NotificationPreferenceStore } from '../push-dispatch.js';
 
 beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('dispatchPush', () => {
+describe('dispatchPush — API rétrocompatible (tokens simples)', () => {
   it('envoie une notification opaque à chaque token valide', async () => {
     const mockExpo = new Expo();
     const tokens = ['ExponentPushToken[aaa]', 'ExponentPushToken[bbb]'];
@@ -79,5 +79,94 @@ describe('dispatchPush', () => {
       expect.objectContaining({ err: sendError }),
       'Échec envoi push chunk (ignoré)',
     );
+  });
+});
+
+describe('dispatchPush — filtrage granulaire E5-S07', () => {
+  const makeStore = (disabled: Set<string> = new Set()): NotificationPreferenceStore => ({
+    findDisabledAccountIds: vi.fn().mockResolvedValue(disabled),
+  });
+
+  it("n'envoie pas de push aux comptes ayant désactivé le type", async () => {
+    const mockExpo = new Expo();
+    const store = makeStore(new Set(['acc-2']));
+    const targets = [
+      { token: 'ExponentPushToken[a]', accountId: 'acc-1' },
+      { token: 'ExponentPushToken[b]', accountId: 'acc-2' },
+      { token: 'ExponentPushToken[c]', accountId: 'acc-3' },
+    ];
+
+    await dispatchPush(mockExpo, targets, undefined, {
+      type: 'peer_dose_recorded',
+      prefsStore: store,
+    });
+
+    const calls = (mockExpo.sendPushNotificationsAsync as ReturnType<typeof vi.fn>).mock.calls;
+    const sent = (calls[0][0] as Array<{ to: string }>).map((m) => m.to);
+    expect(sent).toEqual(['ExponentPushToken[a]', 'ExponentPushToken[c]']);
+    expect(store.findDisabledAccountIds).toHaveBeenCalledWith(
+      ['acc-1', 'acc-2', 'acc-3'],
+      'peer_dose_recorded',
+    );
+  });
+
+  it('envoie quand même les types sanctuarisés missed_dose même si désactivés (défense en profondeur)', async () => {
+    const mockExpo = new Expo();
+    const store = makeStore(new Set(['acc-1', 'acc-2']));
+    const targets = [
+      { token: 'ExponentPushToken[a]', accountId: 'acc-1' },
+      { token: 'ExponentPushToken[b]', accountId: 'acc-2' },
+    ];
+
+    await dispatchPush(mockExpo, targets, undefined, {
+      type: 'missed_dose',
+      prefsStore: store,
+    });
+
+    const calls = (mockExpo.sendPushNotificationsAsync as ReturnType<typeof vi.fn>).mock.calls;
+    expect(calls[0][0]).toHaveLength(2);
+    // Le store ne doit même pas être consulté pour les types sanctuarisés.
+    expect(store.findDisabledAccountIds).not.toHaveBeenCalled();
+  });
+
+  it('envoie quand même les security_alert même si désactivés', async () => {
+    const mockExpo = new Expo();
+    const store = makeStore(new Set(['acc-1']));
+    const targets = [{ token: 'ExponentPushToken[a]', accountId: 'acc-1' }];
+
+    await dispatchPush(mockExpo, targets, undefined, {
+      type: 'security_alert',
+      prefsStore: store,
+    });
+
+    expect(mockExpo.sendPushNotificationsAsync).toHaveBeenCalledOnce();
+    expect(store.findDisabledAccountIds).not.toHaveBeenCalled();
+  });
+
+  it('ne consulte pas le store quand tous les accountIds sont vides (rétrocompat)', async () => {
+    const mockExpo = new Expo();
+    const store = makeStore(new Set());
+    await dispatchPush(mockExpo, ['ExponentPushToken[a]'], undefined, {
+      type: 'reminder',
+      prefsStore: store,
+    });
+    expect(store.findDisabledAccountIds).not.toHaveBeenCalled();
+    expect(mockExpo.sendPushNotificationsAsync).toHaveBeenCalledOnce();
+  });
+
+  it('écarte tous les tokens si tous les comptes ont désactivé le type', async () => {
+    const mockExpo = new Expo();
+    const store = makeStore(new Set(['acc-1', 'acc-2']));
+    const targets = [
+      { token: 'ExponentPushToken[a]', accountId: 'acc-1' },
+      { token: 'ExponentPushToken[b]', accountId: 'acc-2' },
+    ];
+
+    await dispatchPush(mockExpo, targets, undefined, {
+      type: 'pump_low',
+      prefsStore: store,
+    });
+
+    expect(mockExpo.sendPushNotificationsAsync).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/push/push-dispatch.ts
+++ b/apps/api/src/push/push-dispatch.ts
@@ -1,15 +1,81 @@
 import { Expo } from 'expo-server-sdk';
+import type { NotificationType } from '@kinhale/domain/notifications';
 
+/**
+ * Cible d'un push : un token Expo associé à un compte utilisateur. Le compte
+ * sert à filtrer selon les préférences granulaires (E5-S07). Dès qu'un type
+ * est fourni, les cibles dont l'utilisateur a désactivé ce type sont écartées
+ * avant d'appeler Expo.
+ */
+export interface PushTarget {
+  readonly token: string;
+  readonly accountId: string;
+}
+
+/**
+ * Contrat minimal d'un store de préférences. Injecté par la route appelante
+ * (qui possède la connexion Drizzle) pour garder `push-dispatch` découplé
+ * de la DB — facilite les tests et isole la logique de dispatch.
+ *
+ * Sémantique : retourne l'ensemble des comptes pour lesquels le `type` donné
+ * est **désactivé**. Les comptes absents sont considérés `enabled = true`
+ * (convention §9 : opt-out explicite uniquement).
+ */
+export interface NotificationPreferenceStore {
+  findDisabledAccountIds(
+    accountIds: readonly string[],
+    type: NotificationType,
+  ): Promise<Set<string>>;
+}
+
+/**
+ * Types **toujours actifs** côté dispatch — doublent la garantie domaine
+ * (`ALWAYS_ENABLED_NOTIFICATION_TYPES`) par défense en profondeur. Si une
+ * préférence parasite devait se retrouver persistée pour ces types, le
+ * dispatcher ignorerait quand même les désactivations.
+ */
+const ALWAYS_ENABLED: ReadonlySet<NotificationType> = new Set(['missed_dose', 'security_alert']);
+
+/**
+ * Envoie une notification opaque (RM16) aux tokens fournis, filtrée selon
+ * les préférences granulaires de l'utilisateur (E5-S07).
+ *
+ * - Sans `type` ni `prefsStore` : compatibilité — tous les tokens sont pris.
+ * - Avec `type` + `prefsStore` : les tokens dont le compte a désactivé `type`
+ *   sont écartés **avant** l'appel à Expo.
+ * - Les tokens invalides (format Expo) sont toujours filtrés.
+ *
+ * Payload strictement conforme à RM16 : `title: "Kinhale"`,
+ * `body: "Nouvelle activité"`, **aucune** donnée santé, aucun identifiant
+ * métier dans le payload (le `notification_id` et le `household_id` opaques
+ * seront ajoutés par le scheduler v1.1, cf. SPECS §9).
+ */
 export async function dispatchPush(
   expo: Expo,
-  tokens: string[],
+  targets: readonly (PushTarget | string)[],
   logger?: { warn: (obj: Record<string, unknown>, msg: string) => void },
+  filter?: { type: NotificationType; prefsStore: NotificationPreferenceStore },
 ): Promise<void> {
-  const valid = tokens.filter((t) => Expo.isExpoPushToken(t));
-  if (valid.length === 0) return;
+  // Normalise en PushTarget (rétrocompat : on accepte les simples strings sans
+  // accountId — dans ce cas, aucun filtrage de préférences n'est possible).
+  const normalized: PushTarget[] = targets.map((t) =>
+    typeof t === 'string' ? { token: t, accountId: '' } : t,
+  );
 
-  const messages = valid.map((to) => ({
-    to,
+  let kept = normalized.filter((t) => Expo.isExpoPushToken(t.token));
+
+  if (filter !== undefined && !ALWAYS_ENABLED.has(filter.type)) {
+    const accountIds = Array.from(new Set(kept.map((t) => t.accountId).filter((a) => a !== '')));
+    if (accountIds.length > 0) {
+      const disabled = await filter.prefsStore.findDisabledAccountIds(accountIds, filter.type);
+      kept = kept.filter((t) => !disabled.has(t.accountId));
+    }
+  }
+
+  if (kept.length === 0) return;
+
+  const messages = kept.map((t) => ({
+    to: t.token,
     title: 'Kinhale',
     body: 'Nouvelle activité',
   }));

--- a/apps/api/src/routes/__tests__/notification-preferences.test.ts
+++ b/apps/api/src/routes/__tests__/notification-preferences.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildApp } from '../../app.js';
+import { testEnv } from '../../env.js';
+import type { DrizzleDb } from '../../plugins/db.js';
+import type { RedisClients } from '../../plugins/redis.js';
+import { createDrizzleNotificationPreferenceStore } from '../notification-preferences.js';
+
+const ACCOUNT_ID = '00000000-0000-0000-0000-0000000000AA';
+const DEVICE_ID = '00000000-0000-0000-0000-0000000000BB';
+const HOUSEHOLD_ID = '00000000-0000-0000-0000-0000000000CC';
+
+/**
+ * Mock DB « chainable » qui capture les appels Drizzle (select/insert/where/…)
+ * sans exécuter de vraie requête. Pattern aligné sur `push.test.ts`.
+ */
+function makeMockDb(initialRows: Array<{ type: string; enabled: boolean }> = []): DrizzleDb & {
+  _selectRows: Array<{ type: string; enabled: boolean }>;
+  _onConflictDoUpdate: ReturnType<typeof vi.fn>;
+  _insertValues: ReturnType<typeof vi.fn>;
+  _selectWhere: ReturnType<typeof vi.fn>;
+} {
+  const selectRows = [...initialRows];
+  const selectWhere = vi.fn().mockImplementation(() => Promise.resolve(selectRows));
+  const selectFrom = vi.fn().mockReturnValue({ where: selectWhere });
+  const select = vi.fn().mockReturnValue({ from: selectFrom });
+
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  const insertValues = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  const insert = vi.fn().mockReturnValue({ values: insertValues });
+
+  return {
+    select,
+    insert,
+    _selectRows: selectRows,
+    _onConflictDoUpdate: onConflictDoUpdate,
+    _insertValues: insertValues,
+    _selectWhere: selectWhere,
+  } as unknown as DrizzleDb & {
+    _selectRows: Array<{ type: string; enabled: boolean }>;
+    _onConflictDoUpdate: ReturnType<typeof vi.fn>;
+    _insertValues: ReturnType<typeof vi.fn>;
+    _selectWhere: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeMockRedis(): RedisClients {
+  return {
+    pub: {
+      incr: vi.fn(),
+      expire: vi.fn(),
+      publish: vi.fn(),
+    } as never,
+    sub: { on: vi.fn(), subscribe: vi.fn(), unsubscribe: vi.fn() } as never,
+  };
+}
+
+function buildTestApp(db: ReturnType<typeof makeMockDb>) {
+  return buildApp(testEnv(), { db, redis: makeMockRedis() });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /me/notification-preferences', () => {
+  it('retourne 401 sans JWT', async () => {
+    const app = buildTestApp(makeMockDb());
+    await app.ready();
+    const res = await app.inject({ method: 'GET', url: '/me/notification-preferences' });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it('retourne 10 types avec les sanctuarisés marqués alwaysEnabled', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const token = app.jwt.sign({
+      sub: ACCOUNT_ID,
+      deviceId: DEVICE_ID,
+      householdId: HOUSEHOLD_ID,
+      type: 'access',
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/notification-preferences',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as {
+      preferences: Array<{ type: string; enabled: boolean; alwaysEnabled: boolean }>;
+    };
+    expect(body.preferences).toHaveLength(10);
+
+    const byType = new Map(body.preferences.map((p) => [p.type, p]));
+    expect(byType.get('missed_dose')).toEqual({
+      type: 'missed_dose',
+      enabled: true,
+      alwaysEnabled: true,
+    });
+    expect(byType.get('security_alert')).toEqual({
+      type: 'security_alert',
+      enabled: true,
+      alwaysEnabled: true,
+    });
+    expect(byType.get('reminder')).toEqual({
+      type: 'reminder',
+      enabled: true,
+      alwaysEnabled: false,
+    });
+    await app.close();
+  });
+
+  it('applique les préférences stockées en DB (opt-out explicite)', async () => {
+    const db = makeMockDb([
+      { type: 'peer_dose_recorded', enabled: false },
+      { type: 'pump_low', enabled: false },
+    ]);
+    const app = buildTestApp(db);
+    await app.ready();
+    const token = app.jwt.sign({
+      sub: ACCOUNT_ID,
+      deviceId: DEVICE_ID,
+      householdId: HOUSEHOLD_ID,
+      type: 'access',
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/notification-preferences',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = res.json() as {
+      preferences: Array<{ type: string; enabled: boolean }>;
+    };
+    const byType = new Map(body.preferences.map((p) => [p.type, p]));
+    expect(byType.get('peer_dose_recorded')?.enabled).toBe(false);
+    expect(byType.get('pump_low')?.enabled).toBe(false);
+    expect(byType.get('reminder')?.enabled).toBe(true);
+    await app.close();
+  });
+
+  it('force enabled=true pour les sanctuarisés même si stockés par erreur en DB', async () => {
+    // Défense en profondeur : si une ligne parasite existait pour missed_dose,
+    // le backend ne doit pas la respecter dans sa réponse.
+    const db = makeMockDb([
+      { type: 'missed_dose', enabled: false },
+      { type: 'security_alert', enabled: false },
+    ]);
+    const app = buildTestApp(db);
+    await app.ready();
+    const token = app.jwt.sign({
+      sub: ACCOUNT_ID,
+      deviceId: DEVICE_ID,
+      householdId: HOUSEHOLD_ID,
+      type: 'access',
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/notification-preferences',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    const body = res.json() as {
+      preferences: Array<{ type: string; enabled: boolean }>;
+    };
+    const byType = new Map(body.preferences.map((p) => [p.type, p]));
+    expect(byType.get('missed_dose')?.enabled).toBe(true);
+    expect(byType.get('security_alert')?.enabled).toBe(true);
+    await app.close();
+  });
+});
+
+describe('PUT /me/notification-preferences', () => {
+  it('retourne 401 sans JWT', async () => {
+    const app = buildTestApp(makeMockDb());
+    await app.ready();
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/me/notification-preferences',
+      payload: { type: 'reminder', enabled: false },
+    });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it('retourne 400 si le body est mal formé', async () => {
+    const app = buildTestApp(makeMockDb());
+    await app.ready();
+    const token = app.jwt.sign({
+      sub: ACCOUNT_ID,
+      deviceId: DEVICE_ID,
+      householdId: HOUSEHOLD_ID,
+      type: 'access',
+    });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/me/notification-preferences',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { type: 'not_a_real_type', enabled: false },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('retourne 400 si on tente de désactiver missed_dose', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const token = app.jwt.sign({
+      sub: ACCOUNT_ID,
+      deviceId: DEVICE_ID,
+      householdId: HOUSEHOLD_ID,
+      type: 'access',
+    });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/me/notification-preferences',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { type: 'missed_dose', enabled: false },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: 'type_not_disablable' });
+    expect(db.insert).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('retourne 400 si on tente de désactiver security_alert', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const token = app.jwt.sign({
+      sub: ACCOUNT_ID,
+      deviceId: DEVICE_ID,
+      householdId: HOUSEHOLD_ID,
+      type: 'access',
+    });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/me/notification-preferences',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { type: 'security_alert', enabled: false },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(db.insert).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('accepte silencieusement enabled=true sur missed_dose (no-op, pas de persistance)', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const token = app.jwt.sign({
+      sub: ACCOUNT_ID,
+      deviceId: DEVICE_ID,
+      householdId: HOUSEHOLD_ID,
+      type: 'access',
+    });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/me/notification-preferences',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { type: 'missed_dose', enabled: true },
+    });
+    expect(res.statusCode).toBe(204);
+    expect(db.insert).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('persiste une désactivation pour un type togglable (ex. reminder)', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const token = app.jwt.sign({
+      sub: ACCOUNT_ID,
+      deviceId: DEVICE_ID,
+      householdId: HOUSEHOLD_ID,
+      type: 'access',
+    });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/me/notification-preferences',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { type: 'reminder', enabled: false },
+    });
+    expect(res.statusCode).toBe(204);
+    expect(db.insert).toHaveBeenCalledOnce();
+    expect(db._insertValues).toHaveBeenCalledWith({
+      accountId: ACCOUNT_ID,
+      notificationType: 'reminder',
+      enabled: false,
+    });
+    expect(db._onConflictDoUpdate).toHaveBeenCalledOnce();
+    await app.close();
+  });
+
+  it('persiste une réactivation (upsert enabled=true) pour un type togglable', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const token = app.jwt.sign({
+      sub: ACCOUNT_ID,
+      deviceId: DEVICE_ID,
+      householdId: HOUSEHOLD_ID,
+      type: 'access',
+    });
+    const res = await app.inject({
+      method: 'PUT',
+      url: '/me/notification-preferences',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: { type: 'peer_dose_recorded', enabled: true },
+    });
+    expect(res.statusCode).toBe(204);
+    expect(db._insertValues).toHaveBeenCalledWith({
+      accountId: ACCOUNT_ID,
+      notificationType: 'peer_dose_recorded',
+      enabled: true,
+    });
+    await app.close();
+  });
+});
+
+describe('createDrizzleNotificationPreferenceStore', () => {
+  it('retourne un Set vide si accountIds est vide', async () => {
+    const db = makeMockDb();
+    const store = createDrizzleNotificationPreferenceStore(db);
+    const result = await store.findDisabledAccountIds([], 'reminder');
+    expect(result.size).toBe(0);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it("retourne un Set vide pour les types sanctuarisés (n'interroge pas la DB)", async () => {
+    const db = makeMockDb();
+    const store = createDrizzleNotificationPreferenceStore(db);
+    expect((await store.findDisabledAccountIds(['acc-1'], 'missed_dose')).size).toBe(0);
+    expect((await store.findDisabledAccountIds(['acc-1'], 'security_alert')).size).toBe(0);
+    expect(db.select).not.toHaveBeenCalled();
+  });
+
+  it('retourne les accountIds dont la préférence est explicitement enabled=false', async () => {
+    // On ne peut pas facilement mocker le SELECT complet ici — on vérifie
+    // que l'appel est bien émis avec les bons paramètres, et que l'implémentation
+    // mappe correctement la réponse.
+    const db = makeMockDb();
+    db._selectRows.push({ type: 'anything', enabled: false });
+    // On remplace le mock de `where` pour retourner un jeu custom pour ce test.
+    const whereMock = vi.fn().mockResolvedValue([{ accountId: 'acc-2' }, { accountId: 'acc-3' }]);
+    (db.select as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      from: vi.fn().mockReturnValue({ where: whereMock }),
+    });
+
+    const store = createDrizzleNotificationPreferenceStore(db);
+    const result = await store.findDisabledAccountIds(
+      ['acc-1', 'acc-2', 'acc-3'],
+      'peer_dose_recorded',
+    );
+    expect(result).toEqual(new Set(['acc-2', 'acc-3']));
+    expect(whereMock).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/api/src/routes/notification-preferences.ts
+++ b/apps/api/src/routes/notification-preferences.ts
@@ -1,0 +1,183 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { z } from 'zod';
+import { eq, and, inArray } from 'drizzle-orm';
+import {
+  ALWAYS_ENABLED_NOTIFICATION_TYPES,
+  NOTIFICATION_TYPES,
+  isAlwaysEnabled,
+  isNotificationType,
+  type NotificationType,
+} from '@kinhale/domain/notifications';
+import { userNotificationPreferences } from '../db/schema.js';
+import type { SessionJwtPayload } from '../plugins/jwt.js';
+import type { DrizzleDb } from '../plugins/db.js';
+import type { NotificationPreferenceStore } from '../push/push-dispatch.js';
+
+/**
+ * Schéma Zod du body PUT — un seul type + un boolean.
+ *
+ * On accepte **seulement** les types connus (ensemble fermé) pour ne pas
+ * permettre au client de persister des types exotiques qui ne seraient
+ * jamais filtrés par le dispatcher.
+ */
+const PutBody = z.object({
+  type: z.enum(NOTIFICATION_TYPES as unknown as [NotificationType, ...NotificationType[]]),
+  enabled: z.boolean(),
+});
+
+/**
+ * Réponse GET `/me/notification-preferences`.
+ *
+ * Convention : les types **absents** de la table sont renvoyés avec
+ * `enabled: true` (défaut implicite), **sauf** pour les types absents ET
+ * sanctuarisés qui sont également `enabled: true` (logique unifiée côté
+ * client : l'UI grise le toggle pour les types sanctuarisés).
+ *
+ * Cette convention évite au client de « découvrir » les défauts via une
+ * absence : la réponse est exhaustive sur `NOTIFICATION_TYPES`.
+ */
+interface PreferencesResponse {
+  readonly preferences: ReadonlyArray<{
+    readonly type: NotificationType;
+    readonly enabled: boolean;
+    readonly alwaysEnabled: boolean;
+  }>;
+}
+
+const notificationPreferencesRoute: FastifyPluginAsync = async (app) => {
+  /**
+   * GET /me/notification-preferences
+   *
+   * Retourne l'intégralité des types avec leur statut calculé :
+   * - types sanctuarisés (missed_dose, security_alert) : `enabled: true`
+   *   et `alwaysEnabled: true`.
+   * - types stockés avec `enabled = false` : `enabled: false`.
+   * - types non stockés : `enabled: true` (défaut).
+   */
+  app.get('/me/notification-preferences', { preHandler: [app.authenticate] }, async (request) => {
+    const { sub: accountId } = request.user as SessionJwtPayload;
+
+    const stored = await app.db
+      .select({
+        type: userNotificationPreferences.notificationType,
+        enabled: userNotificationPreferences.enabled,
+      })
+      .from(userNotificationPreferences)
+      .where(eq(userNotificationPreferences.accountId, accountId));
+
+    const storedMap = new Map<string, boolean>();
+    for (const row of stored) {
+      storedMap.set(row.type, row.enabled);
+    }
+
+    const preferences = NOTIFICATION_TYPES.map((type) => {
+      const alwaysEnabled = isAlwaysEnabled(type);
+      const stored = storedMap.get(type);
+      const enabled = alwaysEnabled ? true : (stored ?? true);
+      return { type, enabled, alwaysEnabled };
+    });
+
+    const response: PreferencesResponse = { preferences };
+    return response;
+  });
+
+  /**
+   * PUT /me/notification-preferences
+   *
+   * Persiste (ou met à jour) une préférence pour un type donné.
+   *
+   * - Rejette 400 sur un type sanctuarisé désactivé (`enabled: false` avec
+   *   `type in ALWAYS_ENABLED_NOTIFICATION_TYPES`). Retourner 400 plutôt que
+   *   422 pour rester cohérent avec le pattern des autres routes (auth,
+   *   invitations, notifications).
+   * - Accepte silencieusement `enabled: true` sur un type sanctuarisé
+   *   (no-op persistant : on ne stocke pas — c'est déjà la valeur par
+   *   défaut et le stockage créerait du bruit inutile).
+   */
+  app.put(
+    '/me/notification-preferences',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const parse = PutBody.safeParse(request.body);
+      if (!parse.success) {
+        return reply.status(400).send({ error: 'invalid_body' });
+      }
+      const { type, enabled } = parse.data;
+
+      // Défense en profondeur : isNotificationType doit renvoyer true ici puisque
+      // z.enum a déjà filtré, mais on garde la garde pour tout input pathologique
+      // qui contournerait Zod (monkey-patching, future évolution du schéma).
+      if (!isNotificationType(type)) {
+        return reply.status(400).send({ error: 'invalid_type' });
+      }
+
+      if (isAlwaysEnabled(type)) {
+        if (enabled === false) {
+          // Interdit par SPECS §9 + RM25 : missed_dose et security_alert sont
+          // toujours actifs. On renvoie 400 explicite pour que le client
+          // frontend puisse afficher le tooltip adéquat.
+          return reply.status(400).send({ error: 'type_not_disablable' });
+        }
+        // `enabled: true` sur un type sanctuarisé → no-op persistant.
+        return reply.status(204).send();
+      }
+
+      const { sub: accountId } = request.user as SessionJwtPayload;
+
+      await app.db
+        .insert(userNotificationPreferences)
+        .values({ accountId, notificationType: type, enabled })
+        .onConflictDoUpdate({
+          target: [
+            userNotificationPreferences.accountId,
+            userNotificationPreferences.notificationType,
+          ],
+          set: { enabled, updatedAt: new Date() },
+        });
+
+      return reply.status(204).send();
+    },
+  );
+};
+
+export default notificationPreferencesRoute;
+
+/**
+ * Store de préférences exposé au dispatcher push. Implémenté ici pour
+ * partager la connexion Drizzle avec les routes ; injecté par le scheduler
+ * v1.1 (hors périmètre E5-S07) dans `dispatchPush`.
+ *
+ * Sémantique : retourne l'ensemble des `accountId` du lot donné qui ont
+ * **explicitement** désactivé le type. Les autres (absents de la table)
+ * sont considérés comme activés (défaut).
+ *
+ * Optimisé pour le cas d'usage `dispatchPush` : un seul type à la fois,
+ * potentiellement beaucoup d'accountIds (tous les aidants d'un foyer).
+ * `inArray` est indexé par (`accountId`, `notificationType`).
+ */
+export function createDrizzleNotificationPreferenceStore(
+  db: DrizzleDb,
+): NotificationPreferenceStore {
+  return {
+    async findDisabledAccountIds(accountIds, type) {
+      if (accountIds.length === 0 || ALWAYS_ENABLED_NOTIFICATION_TYPES.includes(type)) {
+        return new Set();
+      }
+      // `inArray` attend un array mutable (`string[]`), or le contrat
+      // expose `readonly string[]`. On matérialise une copie mutable plutôt
+      // que de caster : le coût (O(n) d'un lot de tokens par foyer, ~<10)
+      // est négligeable et évite un `as` qui masquerait un futur drift.
+      const rows = await db
+        .select({ accountId: userNotificationPreferences.accountId })
+        .from(userNotificationPreferences)
+        .where(
+          and(
+            inArray(userNotificationPreferences.accountId, [...accountIds]),
+            eq(userNotificationPreferences.notificationType, type),
+            eq(userNotificationPreferences.enabled, false),
+          ),
+        );
+      return new Set(rows.map((r) => r.accountId));
+    },
+  };
+}

--- a/apps/mobile/app/settings/__tests__/notifications.test.tsx
+++ b/apps/mobile/app/settings/__tests__/notifications.test.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { screen, fireEvent, waitFor } from '@testing-library/react-native';
+import NotificationPreferencesScreen from '../notifications';
+import { renderWithProviders } from '../../../src/test-utils/render';
+import {
+  listNotificationPreferences,
+  updateNotificationPreference,
+} from '../../../src/lib/notification-preferences/client';
+
+jest.mock('../../../src/lib/notification-preferences/client', () => ({
+  listNotificationPreferences: jest.fn(),
+  updateNotificationPreference: jest.fn(),
+}));
+
+const mockList = listNotificationPreferences as jest.MockedFunction<
+  typeof listNotificationPreferences
+>;
+const mockUpdate = updateNotificationPreference as jest.MockedFunction<
+  typeof updateNotificationPreference
+>;
+
+const SAMPLE_PREFS = [
+  { type: 'reminder' as const, enabled: true, alwaysEnabled: false },
+  { type: 'missed_dose' as const, enabled: true, alwaysEnabled: true },
+  { type: 'peer_dose_recorded' as const, enabled: false, alwaysEnabled: false },
+  { type: 'security_alert' as const, enabled: true, alwaysEnabled: true },
+];
+
+describe('NotificationPreferencesScreen (mobile)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockList.mockResolvedValue(SAMPLE_PREFS);
+    mockUpdate.mockResolvedValue(undefined);
+  });
+
+  it('affiche le titre et la description i18n', async () => {
+    renderWithProviders(<NotificationPreferencesScreen />);
+    await waitFor(() => {
+      expect(screen.getByRole('header')).toBeTruthy();
+    });
+    expect(screen.getByText(/choisissez les types|choose which notification/i)).toBeTruthy();
+  });
+
+  it('charge les préférences et affiche un switch par type', async () => {
+    renderWithProviders(<NotificationPreferencesScreen />);
+    await waitFor(() => {
+      expect(mockList).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByLabelText(/rappels de prise|dose reminders/i)).toBeTruthy();
+    });
+    expect(screen.getByLabelText(/dose manquée|missed dose/i)).toBeTruthy();
+  });
+
+  it('appelle updateNotificationPreference quand on toggle un type togglable', async () => {
+    renderWithProviders(<NotificationPreferencesScreen />);
+    const switchEl = await screen.findByLabelText(/rappels de prise|dose reminders/i);
+
+    fireEvent(switchEl, 'checkedChange', false);
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith('reminder', false);
+    });
+  });
+
+  it("affiche un message d'erreur localisé quand le chargement échoue", async () => {
+    mockList.mockRejectedValue(new Error('Network down'));
+    renderWithProviders(<NotificationPreferencesScreen />);
+    await waitFor(() => {
+      expect(screen.getByText(/impossible de charger|could not load/i)).toBeTruthy();
+    });
+  });
+
+  it('ne déclenche pas de PUT quand on tente de toggler un type sanctuarisé', async () => {
+    renderWithProviders(<NotificationPreferencesScreen />);
+    const missedDoseSwitch = await screen.findByLabelText(/dose manquée|missed dose/i);
+
+    fireEvent(missedDoseSwitch, 'checkedChange', false);
+
+    // Aucun appel PUT attendu (le switch est disabled + garde-fou dans le handler).
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/app/settings/notifications.tsx
+++ b/apps/mobile/app/settings/notifications.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { YStack, XStack, Text, Card, Switch } from 'tamagui';
+import {
+  listNotificationPreferences,
+  updateNotificationPreference,
+  type NotificationPreference,
+  type NotificationType,
+} from '../../src/lib/notification-preferences/client';
+
+export default function NotificationPreferencesScreen(): React.JSX.Element {
+  const { t } = useTranslation('common');
+  const [preferences, setPreferences] = React.useState<ReadonlyArray<NotificationPreference>>([]);
+  const [error, setError] = React.useState<string | null>(null);
+  const [pending, setPending] = React.useState<Set<NotificationType>>(new Set());
+
+  const refresh = React.useCallback(async () => {
+    try {
+      setPreferences(await listNotificationPreferences());
+      setError(null);
+    } catch {
+      setError(t('notificationPreferences.loadError'));
+    }
+  }, [t]);
+
+  React.useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleToggle = async (type: NotificationType, enabled: boolean): Promise<void> => {
+    setPending((prev) => {
+      const next = new Set(prev);
+      next.add(type);
+      return next;
+    });
+    try {
+      await updateNotificationPreference(type, enabled);
+      setError(null);
+      await refresh();
+    } catch {
+      setError(t('notificationPreferences.saveError'));
+    } finally {
+      setPending((prev) => {
+        const next = new Set(prev);
+        next.delete(type);
+        return next;
+      });
+    }
+  };
+
+  return (
+    <YStack padding="$4" gap="$3">
+      <Text fontSize="$6" fontWeight="bold" accessibilityRole="header">
+        {t('notificationPreferences.title')}
+      </Text>
+      <Text>{t('notificationPreferences.description')}</Text>
+
+      {error !== null ? <Text color="$red10">{error}</Text> : null}
+
+      {preferences.map((pref) => (
+        <Card key={pref.type} padding="$3">
+          <XStack justifyContent="space-between" alignItems="center" gap="$3">
+            <YStack flex={1} gap="$1">
+              <Text fontWeight="bold">{t(`notificationPreferences.types.${pref.type}.label`)}</Text>
+              <Text fontSize="$2">
+                {t(`notificationPreferences.types.${pref.type}.description`)}
+              </Text>
+              {pref.alwaysEnabled ? (
+                <Text fontSize="$1" color="$gray10">
+                  {t('notificationPreferences.alwaysEnabledTooltip')}
+                </Text>
+              ) : null}
+            </YStack>
+            <Switch
+              size="$3"
+              checked={pref.enabled}
+              disabled={pref.alwaysEnabled || pending.has(pref.type)}
+              onCheckedChange={(next: boolean) => {
+                if (pref.alwaysEnabled) return;
+                void handleToggle(pref.type, next);
+              }}
+              accessibilityRole="switch"
+              accessibilityLabel={t(`notificationPreferences.types.${pref.type}.label`)}
+              accessibilityState={{
+                checked: pref.enabled,
+                disabled: pref.alwaysEnabled,
+              }}
+            >
+              <Switch.Thumb animation="quick" />
+            </Switch>
+          </XStack>
+        </Card>
+      ))}
+    </YStack>
+  );
+}

--- a/apps/mobile/src/lib/notification-preferences/client.ts
+++ b/apps/mobile/src/lib/notification-preferences/client.ts
@@ -1,0 +1,71 @@
+import { apiFetch, ApiError } from '../api-client';
+import { useAuthStore } from '../../stores/auth-store';
+
+const API_BASE = process.env['EXPO_PUBLIC_API_URL'] ?? 'http://localhost:3001';
+
+export type NotificationType =
+  | 'reminder'
+  | 'missed_dose'
+  | 'peer_dose_recorded'
+  | 'pump_low'
+  | 'pump_expiring'
+  | 'dispute_detected'
+  | 'admin_handover'
+  | 'consent_update_required'
+  | 'security_alert'
+  | 'caregiver_revoked';
+
+export interface NotificationPreference {
+  readonly type: NotificationType;
+  readonly enabled: boolean;
+  readonly alwaysEnabled: boolean;
+}
+
+interface PreferencesResponse {
+  readonly preferences: ReadonlyArray<NotificationPreference>;
+}
+
+function getAuthToken(): string | undefined {
+  const raw = useAuthStore.getState().accessToken;
+  return raw ?? undefined;
+}
+
+function withAuth(): { token: string } | Record<string, never> {
+  const token = getAuthToken();
+  return token !== undefined ? { token } : {};
+}
+
+export async function listNotificationPreferences(): Promise<
+  ReadonlyArray<NotificationPreference>
+> {
+  const data = await apiFetch<PreferencesResponse>('/me/notification-preferences', {
+    method: 'GET',
+    ...withAuth(),
+  });
+  return data.preferences;
+}
+
+export async function updateNotificationPreference(
+  type: NotificationType,
+  enabled: boolean,
+): Promise<void> {
+  // PUT renvoie 204 No Content — on utilise fetch direct pour éviter que
+  // `apiFetch` ne tente `res.json()` sur un corps vide.
+  const token = getAuthToken();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token !== undefined) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`${API_BASE}/me/notification-preferences`, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({ type, enabled }),
+  });
+  if (!res.ok && res.status !== 204) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    throw new ApiError(
+      res.status,
+      typeof body['error'] === 'string' ? body['error'] : 'update_failed',
+    );
+  }
+}

--- a/apps/web/src/app/settings/notifications/__tests__/page.test.tsx
+++ b/apps/web/src/app/settings/notifications/__tests__/page.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { screen, fireEvent, act, waitFor } from '@testing-library/react';
+import NotificationPreferencesPage from '../page';
+import { renderWithProviders } from '../../../../test-utils/render';
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+}));
+
+let mockAccessToken: string | null = 'tok-valid';
+jest.mock('../../../../stores/auth-store', () => ({
+  useAuthStore: Object.assign(
+    jest.fn((selector: (s: { accessToken: string | null }) => unknown) =>
+      selector({ accessToken: mockAccessToken }),
+    ),
+    {
+      getState: () => ({ accessToken: mockAccessToken }),
+    },
+  ),
+}));
+
+const mockListPrefs = jest.fn();
+const mockUpdatePref = jest.fn();
+jest.mock('../../../../lib/notification-preferences/client', () => ({
+  listNotificationPreferences: (...args: unknown[]) => mockListPrefs(...args),
+  updateNotificationPreference: (...args: unknown[]) => mockUpdatePref(...args),
+}));
+
+const SAMPLE_PREFS = [
+  { type: 'reminder', enabled: true, alwaysEnabled: false },
+  { type: 'missed_dose', enabled: true, alwaysEnabled: true },
+  { type: 'peer_dose_recorded', enabled: false, alwaysEnabled: false },
+  { type: 'security_alert', enabled: true, alwaysEnabled: true },
+];
+
+describe('NotificationPreferencesPage', () => {
+  jest.setTimeout(15000);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAccessToken = 'tok-valid';
+    mockListPrefs.mockResolvedValue(SAMPLE_PREFS);
+    mockUpdatePref.mockResolvedValue(undefined);
+  });
+
+  it('affiche le titre et la description i18n', async () => {
+    renderWithProviders(<NotificationPreferencesPage />);
+    // Le titre est rendu immédiatement, on l'identifie par son poids (élément unique).
+    await waitFor(() => {
+      expect(screen.getByText(/choisissez les types|choose which notification/i)).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/rappels de prise|dose reminders/i)).toBeTruthy();
+    });
+  });
+
+  it('redirige vers /auth sans token', async () => {
+    mockAccessToken = null;
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<NotificationPreferencesPage />);
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(mockReplace).toHaveBeenCalledWith('/auth');
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('charge les préférences au montage et les affiche', async () => {
+    renderWithProviders(<NotificationPreferencesPage />);
+
+    await waitFor(() => {
+      expect(mockListPrefs).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/rappels de prise|dose reminders/i)).toBeTruthy();
+    });
+    // La chaîne "dose manquée" peut apparaître dans le label + description —
+    // on valide juste la présence d'au moins une occurrence (via getAllByText).
+    expect(screen.getAllByText(/dose manquée|missed dose/i).length).toBeGreaterThanOrEqual(1);
+    // Les types sanctuarisés affichent le tooltip d'info.
+    expect(screen.getAllByText(/toujours activé|always enabled/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("émet un PUT sur toggle d'un type togglable", async () => {
+    renderWithProviders(<NotificationPreferencesPage />);
+
+    // Attend que les switches soient rendus (query résolue).
+    const reminderSwitch = await screen.findByRole('switch', {
+      name: /rappels de prise|dose reminders/i,
+    });
+
+    await act(async () => {
+      fireEvent.click(reminderSwitch);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mockUpdatePref).toHaveBeenCalledWith('reminder', false);
+    });
+  });
+
+  it('affiche une erreur i18n quand le chargement échoue', async () => {
+    mockListPrefs.mockRejectedValue(new Error('Network down'));
+    renderWithProviders(<NotificationPreferencesPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/impossible de charger|could not load/i)).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/src/app/settings/notifications/page.tsx
+++ b/apps/web/src/app/settings/notifications/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { YStack, XStack, Text, Switch, Card, Label } from 'tamagui';
+import {
+  listNotificationPreferences,
+  updateNotificationPreference,
+  type NotificationPreference,
+  type NotificationType,
+} from '../../../lib/notification-preferences/client';
+import { useRequireAuth } from '../../../lib/useRequireAuth';
+
+const PREFS_QUERY_KEY = ['notification-preferences'] as const;
+
+export default function NotificationPreferencesPage(): React.JSX.Element | null {
+  const { t } = useTranslation('common');
+  const authenticated = useRequireAuth();
+  const queryClient = useQueryClient();
+
+  const { data, error, isLoading } = useQuery({
+    queryKey: PREFS_QUERY_KEY,
+    queryFn: listNotificationPreferences,
+    enabled: authenticated,
+  });
+
+  const [mutationError, setMutationError] = React.useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: ({ type, enabled }: { type: NotificationType; enabled: boolean }) =>
+      updateNotificationPreference(type, enabled),
+    onSuccess: async () => {
+      setMutationError(null);
+      await queryClient.invalidateQueries({ queryKey: PREFS_QUERY_KEY });
+    },
+    onError: () => {
+      setMutationError(t('notificationPreferences.saveError'));
+    },
+  });
+
+  if (!authenticated) return null;
+
+  return (
+    <YStack padding="$4" gap="$3">
+      <Text fontSize="$6" fontWeight="bold">
+        {t('notificationPreferences.title')}
+      </Text>
+      <Text>{t('notificationPreferences.description')}</Text>
+
+      {isLoading ? <Text>{t('common.loading')}</Text> : null}
+      {error !== null && error !== undefined ? (
+        <Text color="$red10">{t('notificationPreferences.loadError')}</Text>
+      ) : null}
+      {mutationError !== null ? <Text color="$red10">{mutationError}</Text> : null}
+
+      {data?.map((pref: NotificationPreference) => (
+        <Card key={pref.type} padding="$3">
+          <XStack justifyContent="space-between" alignItems="center" gap="$3">
+            <YStack flex={1} gap="$1">
+              <Label htmlFor={`notif-pref-${pref.type}`} fontWeight="bold">
+                {t(`notificationPreferences.types.${pref.type}.label`)}
+              </Label>
+              <Text fontSize="$2">
+                {t(`notificationPreferences.types.${pref.type}.description`)}
+              </Text>
+              {pref.alwaysEnabled ? (
+                <Text fontSize="$1" color="$gray10">
+                  {t('notificationPreferences.alwaysEnabledTooltip')}
+                </Text>
+              ) : null}
+            </YStack>
+            <Switch
+              id={`notif-pref-${pref.type}`}
+              size="$3"
+              checked={pref.enabled}
+              disabled={pref.alwaysEnabled || mutation.isPending}
+              onCheckedChange={(next: boolean) => {
+                if (pref.alwaysEnabled) return;
+                mutation.mutate({ type: pref.type, enabled: next });
+              }}
+              aria-label={t(`notificationPreferences.types.${pref.type}.label`)}
+            >
+              <Switch.Thumb animation="quick" />
+            </Switch>
+          </XStack>
+        </Card>
+      ))}
+    </YStack>
+  );
+}

--- a/apps/web/src/lib/notification-preferences/client.ts
+++ b/apps/web/src/lib/notification-preferences/client.ts
@@ -1,0 +1,75 @@
+import { apiFetch, ApiError } from '../api-client';
+import { useAuthStore } from '../../stores/auth-store';
+
+const API_BASE = process.env['NEXT_PUBLIC_API_URL'] ?? 'http://localhost:3001';
+
+/**
+ * Type ré-exporté depuis `@kinhale/domain` au runtime pour éviter un import
+ * profond côté UI. Le domaine reste la source unique de vérité (SPECS §9).
+ */
+export type NotificationType =
+  | 'reminder'
+  | 'missed_dose'
+  | 'peer_dose_recorded'
+  | 'pump_low'
+  | 'pump_expiring'
+  | 'dispute_detected'
+  | 'admin_handover'
+  | 'consent_update_required'
+  | 'security_alert'
+  | 'caregiver_revoked';
+
+export interface NotificationPreference {
+  readonly type: NotificationType;
+  readonly enabled: boolean;
+  readonly alwaysEnabled: boolean;
+}
+
+interface PreferencesResponse {
+  readonly preferences: ReadonlyArray<NotificationPreference>;
+}
+
+function getAuthToken(): string | undefined {
+  const raw = useAuthStore.getState().accessToken;
+  return raw ?? undefined;
+}
+
+function withAuth(): { token: string } | Record<string, never> {
+  const token = getAuthToken();
+  return token !== undefined ? { token } : {};
+}
+
+export async function listNotificationPreferences(): Promise<
+  ReadonlyArray<NotificationPreference>
+> {
+  const data = await apiFetch<PreferencesResponse>('/me/notification-preferences', {
+    method: 'GET',
+    ...withAuth(),
+  });
+  return data.preferences;
+}
+
+export async function updateNotificationPreference(
+  type: NotificationType,
+  enabled: boolean,
+): Promise<void> {
+  // PUT renvoie 204 No Content — `apiFetch` appellerait `res.json()` qui
+  // échouerait sur un corps vide. On utilise `fetch` direct pour ce cas.
+  const token = getAuthToken();
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token !== undefined) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`${API_BASE}/me/notification-preferences`, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify({ type, enabled }),
+  });
+  if (!res.ok && res.status !== 204) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    throw new ApiError(
+      res.status,
+      typeof body['error'] === 'string' ? body['error'] : 'update_failed',
+    );
+  }
+}

--- a/docs/architecture/adr/ADR-D10-push-expo-v1-migration-native-v1-1.md
+++ b/docs/architecture/adr/ADR-D10-push-expo-v1-migration-native-v1-1.md
@@ -1,0 +1,161 @@
+# ADR-D10 — Push v1.0 : Expo Push Service, migration APNs + FCM natifs reportée v1.1
+
+**Date** : 2026-04-24
+**Statut** : Accepté (temporaire, jusqu'à résolution de l'issue GitHub #224)
+**Décideurs** : Martial Kaljob (Kamez Conseils)
+
+## Contexte
+
+L'architecture cible de Kinhale (CLAUDE.md §Stack, `00-kz-architecture.md`) prévoit l'usage **natif** des services push des plateformes :
+
+- **APNs** (Apple Push Notification service) pour iOS.
+- **FCM** (Firebase Cloud Messaging) pour Android et Web (via Web Push / WebPush VAPID le cas échéant).
+
+Ces deux canaux — conformes à la §9 des specs — imposent côté relais (Fastify) l'intégration d'un SDK APNs (`@parse/node-apn`, `apns2`, ou équivalent) et d'un SDK FCM (Firebase Admin SDK), ainsi que l'approvisionnement des identités d'expéditeur côté Apple Developer et Firebase console. Le payload reste strictement minimal (RM16 : `{title: "Kinhale", body: "Nouvelle activité", household_id, notification_id}`).
+
+En avril 2026, au moment d'implémenter l'Épique E5 (rappels, notifications peer, dose manquée), le code du relais utilise **Expo Push Service** via le SDK `expo-server-sdk` (cf. `apps/api/src/push/push-dispatch.ts`, `apps/api/src/routes/push.ts` — tokens `ExponentPushToken[…]`). Ce choix a été fait de facto à l'implémentation des premières notifications E5 (KIN-072, KIN-079) pour raccourcir le time-to-first-push, car Expo Push abstrait la double pile APNs/FCM derrière une seule API et un seul token.
+
+Basculer vers les SDK natifs nécessite en pratique :
+
+1. **Provisioning Apple Developer** : génération d'une APNs Auth Key (.p8), création du Key ID + Team ID, configuration côté EAS Build pour associer le bundle iOS à cette clé.
+2. **Provisioning Firebase** : création d'un projet Firebase (ou extension du projet existant), génération d'un service account JSON avec scope messaging, upload dans Secrets Manager.
+3. **Web Push (VAPID)** : génération d'une paire de clés VAPID, publication côté client + intégration service worker.
+4. **Intégration SDK backend** : ajout des SDK `apns2` + `firebase-admin` dans `apps/api`, extension de `dispatchPush` pour router selon le `platform` du token, gestion des erreurs de token invalide (unregister/410).
+5. **Purge automatique des tokens** : CA E5-S10/S11 impose la détection et la purge des tokens APNs/FCM invalides (feedback inversé). Pas d'équivalent côté Expo car géré transparent.
+6. **Rotation des secrets** : mise en place dans AWS Secrets Manager + rotation documentée.
+
+Ce chantier représente **2-3 jours-homme opérations** — non bloquants pour l'Épique 5 fonctionnellement. Expo Push Service livre aujourd'hui les mêmes notifications sur iOS et Android en restant **strictement compatible** avec les garanties de confidentialité (payload opaque RM16 identique, aucune donnée santé transmise au service Expo).
+
+Reste un point de vigilance : Expo Push Service est un **relais tiers additionnel** dans la chaîne de métadonnées push. Apple et Google voient déjà les métadonnées OS (device token, réception d'un push pour l'app), mais Expo les voit également — point documenté dans les conséquences ci-dessous.
+
+Une issue GitHub **#224** a été ouverte pour tracker formellement la migration APNs + FCM natifs avant la v1.1. Le présent ADR formalise la décision, ses limites et son plan de remplacement.
+
+## Options évaluées
+
+### Option A — APNs + FCM natifs dès v1.0
+
+**Description** : Implémenter la double pile APNs + FCM dans le relais dès l'Épique 5, conformément à l'architecture cible. Provisioning Apple Developer + Firebase + Web Push VAPID + intégration SDK backend + gestion complète du cycle de vie des tokens (enregistrement, rotation, purge sur 410).
+
+**Avantages** :
+- **Architecture cible respectée dès v1.0** : pas de dette technique à rembourser. Le code de production est directement celui qui ira en v1.0 GA.
+- **Pas de relais tiers** : Apple et Google voient les métadonnées push (inévitable), mais aucun autre acteur. Un maillon de moins dans la chaîne.
+- **Contrôle complet des SLAs** : quotas APNs/FCM directement négociés, pas de dépendance à un quota Expo Push intermédiaire.
+- **Purge automatique des tokens invalides** : mécanisme standard de retour 410 côté APNs / `UNREGISTERED` côté FCM — pas de mécanisme custom à construire.
+
+**Inconvénients** :
+- **2-3 jours-homme ops non bloquants** : setup Apple Developer (génération clé .p8, upload EAS), création projet Firebase, génération VAPID, configuration Secrets Manager, rotation documentée. Rien de techniquement difficile, mais rien qui avance fonctionnellement l'Épique 5.
+- **Coût de contexte** : chaque service (APNs, FCM, Web Push) a ses propres erreurs, ses propres taux d'échec, ses propres formats de token — multiplie la surface à tester et à monitorer.
+- **Retarde l'Épique 5** : le provisioning Apple Developer prend entre 24 h et 72 h (revue interne Apple), ce qui déplace le premier push de bout-en-bout de plusieurs jours et bloque les tests utilisateurs multi-device.
+
+**Risques** :
+- Erreur de configuration silencieuse (mauvais bundle ID, clé expirée, VAPID mal publiée) détectée tardivement, lorsque les tests utilisateurs sont déjà en cours.
+- Divergence entre le comportement local (Expo SDK de dev client) et production (APNs natif) ajoutant un risque de régression à chaque release.
+
+### Option B — Conserver Expo Push Service pour v1.0, migrer en v1.1 (retenue)
+
+**Description** : Maintenir le code actuel basé sur `expo-server-sdk`. Le relais émet ses pushs via Expo Push Service qui les relaie ensuite à APNs (iOS) et FCM (Android). Payload identique au layout RM16. Tracker la migration via l'issue GitHub **#224** pour exécution entre la v1.0 GA et la v1.1.
+
+**Avantages** :
+- **Débloque immédiatement l'Épique 5** : l'infrastructure push est fonctionnelle, E5-S01 à E5-S13 peuvent avancer sans attendre.
+- **Zero-knowledge préservé** : le payload Expo est strictement RM16. Aucune donnée santé ne transite par Expo Push Service — seulement un identifiant opaque de foyer et un identifiant opaque de notification.
+- **Moins de complexité ops v1.0** : un seul service, une seule API, un seul format de token, un seul quota à surveiller.
+- **Abstraction cross-platform uniforme** : iOS, Android, et (via le dev client) Web reçoivent le même format de push sans code de routage spécifique côté relais.
+
+**Inconvénients** :
+- **Dépendance runtime à un tiers** : si Expo Push Service subit une panne, aucun push n'est délivré même si APNs et FCM sont opérationnels. Impact directement mesurable sur la fiabilité E5 (CA7).
+- **Relais tiers supplémentaire pour les métadonnées** : Apple et Google voient déjà les métadonnées OS (inévitable), mais Expo les voit également. Cette exposition est limitée au token opaque et au payload `{title: "Kinhale", body: "Nouvelle activité"}` — aucune donnée santé — mais elle ajoute un acteur à documenter dans la cartographie des sous-traitants.
+- **Quotas** : Expo Push Service applique des quotas (1800 messages par 24h par défaut pour les apps sans plan payant, plus permissif avec un plan Production). Adéquat pour v1.0 (< 5000 foyers) mais à surveiller.
+- **Dette technique à rembourser** : la migration vers APNs + FCM natifs reste à faire, et chaque mois écoulé avec Expo Push augmente le nombre de tokens à migrer (nouvelle génération de token côté client lors du passage à la v1.1).
+
+**Risques** :
+- **Risque de confort** : si la migration v1.1 est repoussée de nouveau, la dépendance à Expo Push s'installe. L'issue #224 doit être formellement liée au plan v1.1 pour éviter ce glissement.
+- **Risque contractuel** : un client B2B (clinique) pourrait exiger contractuellement qu'aucun service tiers ne voie les tokens push. Ce cas force une migration anticipée — mitigé par le fait que le contenu reste opaque.
+
+### Option C — Self-hosted push gateway
+
+**Description** : Héberger un service push maison (équivalent open-source de Expo Push Service, par exemple `zeropush` historique ou une réécriture). Le relais émet vers cette gateway qui route vers APNs/FCM.
+
+**Avantages** :
+- Aucune dépendance tierce runtime.
+- Contrôle complet sur les métadonnées et les logs.
+
+**Inconvénients** :
+- **Sur-ingénierie pour v1.0** : construire, déployer et monitorer une gateway push spécifique n'apporte rien que l'intégration APNs + FCM native n'apporte déjà, pour un coût plus élevé.
+- **Multiplication des composants infra** : une gateway à haute disponibilité ajoute un étage de latence, de monitoring, de rotation de clés, et de tests E2E.
+- **Aucun bénéfice sur la surface d'attaque** : les clés APNs/FCM vivent de toute façon dans le relais ou dans une gateway colocalisée — aucune réduction d'exposition.
+
+**Risques** :
+- Mauvais rapport valeur / complexité. Option écartée rapidement.
+
+## Critères de décision
+
+1. **Débloquer l'Épique 5 dès aujourd'hui** : fiabilité notifications = pilier de confiance non négociable (CLAUDE.md §Principes).
+2. **Zero-knowledge strictement préservé** : payload RM16, aucune donnée santé hors-device.
+3. **Coût ops v1.0 minimal** : ressources concentrées sur la cohérence crypto, la fiabilité sync et le couvrage des parcours J1-J7.
+4. **Dette technique traçable et plannifiée** : une issue GitHub formelle et un ADR lié.
+5. **Aucune divergence entre architecture cible et architecture réelle de la v1.0 sans trace écrite.**
+
+## Décision
+
+**Choix retenu : Option B — Expo Push Service pour v1.0, APNs + FCM natifs reportés en v1.1 via issue #224.**
+
+Ce choix est **temporaire** et **explicitement documenté** :
+
+- Le code relais continue d'utiliser `expo-server-sdk`. Pas de rétro-migration prématurée.
+- Les tokens stockés dans `push_tokens` respectent le format `ExponentPushToken[…]` (régex `EXPO_TOKEN_RE`).
+- L'issue GitHub **#224** porte la migration. Elle doit être priorisée dans le sprint de stabilisation v1.1 (post-v1.0 GA).
+- Les stories **E5-S10 (APNs)** et **E5-S11 (FCM)** sont considérées comme **partiellement livrées** en v1.0 (fonctionnalité utilisateur équivalente via Expo) mais **re-ouvertes** en v1.1 pour atteindre leur conformité d'architecture.
+- Toute régression sur le caractère opaque du payload (RM16) est un incident P0 qui s'applique indépendamment du fournisseur de relais push (Expo ou natif).
+
+**Ce qui invaliderait ce choix** :
+- Un contrat B2B explicite interdisant tout tiers de traitement des métadonnées push (ce contrat accélérerait l'exécution de #224).
+- Une dégradation de SLA Expo Push (> 1% de push non délivrés) — même scénario, accélération de #224.
+- Un changement de politique tarifaire Expo rendant le service économiquement non viable à l'échelle v1.0 — même réaction.
+
+## Conséquences
+
+**Positives** :
+
+- **L'Épique 5 peut avancer** dès aujourd'hui sans attendre le provisioning Apple Developer + Firebase. Les stories E5-S01 à E5-S09 + E5-S12 + E5-S13 sont implémentables sans dépendance externe.
+- **Zero-knowledge strictement maintenu** : payload Expo = layout RM16. Aucune donnée santé ne quitte les devices. La promesse de confidentialité envers les utilisateurs reste intacte.
+- **Moins de complexité ops v1.0** : un seul SDK côté relais, un seul format de token côté client, un seul quota à monitorer.
+- **Code réutilisable à 90 % pour la migration** : la fonction `dispatchPush` expose une API `(tokens[]) → void` qui reste stable. Seul le corps change lors de la migration v1.1.
+
+**Négatives / compromis acceptés** :
+
+- **Dépendance runtime à Expo Push Service** : une panne Expo = pas de push délivré. Atténuation : le chemin notification inclut déjà (a) notification locale programmée côté OS pour les rappels connus, (b) e-mail fallback pour `missed_dose` après 30 min. Le push n'est jamais l'unique canal pour une notification sanitaire critique (RM25 + §9 canaux).
+- **Relais tiers supplémentaire dans la chaîne de métadonnées** : Expo voit le token opaque et le payload `{title: "Kinhale", body: "Nouvelle activité"}`. À documenter dans la cartographie des sous-traitants et dans le registre Loi 25. Aucune donnée santé exposée, aucun consentement additionnel requis (le token push ne révèle ni contenu santé ni association utilisateur↔foyer côté Expo).
+- **Dette technique** : migration APNs + FCM natifs à exécuter en v1.1 (#224). À chaque mois écoulé, le nombre de tokens Expo à invalider au moment de la migration augmente, imposant une fenêtre de migration proprement séquencée (les clients passent au nouveau canal avant que l'ancien ne soit éteint).
+
+**Impact sécurité** :
+
+- **Aucun changement du modèle de menace v1.0** : la garantie zero-knowledge est définie par ce qui est dans le payload (RM16) et par le chiffrement E2EE du contenu (Automerge + mailbox). Ni l'un ni l'autre ne passe par le canal push — qu'il soit Expo ou APNs natif.
+- **Cartographie sous-traitants à mettre à jour** : ajouter Expo (Exponent Inc.) comme processeur limité aux métadonnées push opaques. DPA Expo à référencer dans le registre.
+- **Audit crypto indépendant** : la migration v1.1 ne modifie pas la crypto — seul le canal de transport change. L'auditeur Sprint 5-6 n'est pas bloqué par ce choix.
+
+**Impact conformité (Loi 25 / RGPD)** :
+
+- **Registre Loi 25** : ajouter Expo comme sous-traitant, finalité « routage de notifications push opaques », catégorie de données « métadonnées techniques (device token, horodatage, statut de livraison) », durée de conservation « durée de vie du token device ».
+- **DPA Expo** : à signer ou référencer pour v1.0. Même approche que le DPA Resend (ADR-D8).
+- **Politique de confidentialité** : mention explicite d'Expo comme relais de métadonnées push v1.0, avec note que la migration APNs + FCM natifs est programmée v1.1.
+
+**Plan de fallback** :
+
+- En cas de panne Expo Push Service prolongée (> 2 h), l'absence de push ne bloque pas les fonctionnalités critiques grâce aux notifications locales programmées (reminders) et au fallback e-mail (missed_dose).
+- Un `EMAIL_PROVIDER`-style switch n'est pas mis en place pour le push v1.0 — le déclenchement d'un fallback APNs/FCM natif suppose d'avoir déjà accompli la migration #224.
+
+## Révision prévue
+
+- **v1.0 GA (juin 2026)** : confirmer que #224 reste le ticket de référence, priorisé dans le sprint v1.1.
+- **v1.1 (estimation Q3 2026)** : exécuter #224 — provisioning Apple Developer + Firebase, migration du code `push-dispatch.ts` vers `apns2` + `firebase-admin`, migration séquencée des tokens clients.
+- **Signaux d'accélération** : contrat B2B exigeant pas de tiers ; SLA Expo dégradé ; changement tarifaire Expo incompatible avec le budget v1.x.
+
+## Liens
+
+- CLAUDE.md §Stack (push / email)
+- `00-kz-specs.md` §9 (canaux de notification, RM16, RM25)
+- Stories **E5-S10** (intégration APNs), **E5-S11** (intégration FCM)
+- Issue GitHub **#224** — migration push natif v1.1
+- Code v1.0 : `apps/api/src/push/push-dispatch.ts`, `apps/api/src/routes/push.ts`
+- ADR-D4 (relais hosting — contexte ops AWS)
+- ADR-D8 (email transactionnel — même pattern sous-traitant opaque)

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -11,7 +11,8 @@
     ".": "./src/index.ts",
     "./entities": "./src/entities/index.ts",
     "./rules": "./src/rules/index.ts",
-    "./errors": "./src/errors.ts"
+    "./errors": "./src/errors.ts",
+    "./notifications": "./src/entities/notification-type.ts"
   },
   "scripts": {
     "lint": "eslint --max-warnings=0 .",

--- a/packages/domain/src/entities/index.ts
+++ b/packages/domain/src/entities/index.ts
@@ -3,6 +3,7 @@ export * from './child';
 export * from './dose';
 export * from './household';
 export * from './invitation';
+export * from './notification-type';
 export * from './plan';
 export * from './pump';
 export * from './reminder';

--- a/packages/domain/src/entities/notification-type.test.ts
+++ b/packages/domain/src/entities/notification-type.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  NOTIFICATION_TYPES,
+  ALWAYS_ENABLED_NOTIFICATION_TYPES,
+  TOGGLEABLE_NOTIFICATION_TYPES,
+  isNotificationType,
+  isAlwaysEnabled,
+  type NotificationType,
+} from './notification-type';
+
+describe('NotificationType', () => {
+  it('expose les 10 types documentés dans SPECS §9', () => {
+    expect(NOTIFICATION_TYPES).toHaveLength(10);
+    expect(NOTIFICATION_TYPES).toContain('reminder');
+    expect(NOTIFICATION_TYPES).toContain('missed_dose');
+    expect(NOTIFICATION_TYPES).toContain('peer_dose_recorded');
+    expect(NOTIFICATION_TYPES).toContain('pump_low');
+    expect(NOTIFICATION_TYPES).toContain('pump_expiring');
+    expect(NOTIFICATION_TYPES).toContain('dispute_detected');
+    expect(NOTIFICATION_TYPES).toContain('admin_handover');
+    expect(NOTIFICATION_TYPES).toContain('consent_update_required');
+    expect(NOTIFICATION_TYPES).toContain('security_alert');
+    expect(NOTIFICATION_TYPES).toContain('caregiver_revoked');
+  });
+
+  it('marque missed_dose et security_alert comme toujours actifs', () => {
+    expect(ALWAYS_ENABLED_NOTIFICATION_TYPES).toEqual(
+      expect.arrayContaining(['missed_dose', 'security_alert']),
+    );
+    expect(ALWAYS_ENABLED_NOTIFICATION_TYPES).toHaveLength(2);
+  });
+
+  it('expose un ensemble togglable qui exclut les types sanctuarisés', () => {
+    expect(TOGGLEABLE_NOTIFICATION_TYPES).not.toContain('missed_dose');
+    expect(TOGGLEABLE_NOTIFICATION_TYPES).not.toContain('security_alert');
+    // Union toggleable + always_enabled = ensemble complet.
+    const union = new Set<NotificationType>([
+      ...TOGGLEABLE_NOTIFICATION_TYPES,
+      ...ALWAYS_ENABLED_NOTIFICATION_TYPES,
+    ]);
+    expect(union.size).toBe(NOTIFICATION_TYPES.length);
+  });
+
+  it('isNotificationType accepte les types valides', () => {
+    expect(isNotificationType('reminder')).toBe(true);
+    expect(isNotificationType('missed_dose')).toBe(true);
+    expect(isNotificationType('caregiver_revoked')).toBe(true);
+  });
+
+  it('isNotificationType rejette les types inconnus', () => {
+    expect(isNotificationType('unknown_type')).toBe(false);
+    expect(isNotificationType('')).toBe(false);
+    expect(isNotificationType(null)).toBe(false);
+    expect(isNotificationType(undefined)).toBe(false);
+    expect(isNotificationType(42)).toBe(false);
+  });
+
+  it('isAlwaysEnabled retourne true uniquement pour missed_dose et security_alert', () => {
+    expect(isAlwaysEnabled('missed_dose')).toBe(true);
+    expect(isAlwaysEnabled('security_alert')).toBe(true);
+    expect(isAlwaysEnabled('reminder')).toBe(false);
+    expect(isAlwaysEnabled('peer_dose_recorded')).toBe(false);
+    expect(isAlwaysEnabled('pump_low')).toBe(false);
+    expect(isAlwaysEnabled('caregiver_revoked')).toBe(false);
+  });
+});

--- a/packages/domain/src/entities/notification-type.ts
+++ b/packages/domain/src/entities/notification-type.ts
@@ -1,0 +1,74 @@
+/**
+ * Types de notifications exposés par Kinhale (SPECS §9).
+ *
+ * L'ensemble fermé est partagé entre :
+ * - le relais Fastify (filtre `dispatchPush` selon les préférences utilisateur),
+ * - le backend REST (`GET/PUT /me/notification-preferences`),
+ * - les écrans « Paramètres / Notifications » web + mobile (E5-S07).
+ *
+ * Deux types sont **sanctuarisés** (toujours actifs, non désactivables) :
+ * - `missed_dose` : règle sanitaire RM25 (dose manquée, cf. §9).
+ * - `security_alert` : intégrité de compte (login suspect, clé rotatée).
+ *
+ * Refs: SPECS §9 (types de notifications + paramétrage), RM25 (rappels bornés).
+ */
+export type NotificationType =
+  | 'reminder'
+  | 'missed_dose'
+  | 'peer_dose_recorded'
+  | 'pump_low'
+  | 'pump_expiring'
+  | 'dispute_detected'
+  | 'admin_handover'
+  | 'consent_update_required'
+  | 'security_alert'
+  | 'caregiver_revoked';
+
+/** Ensemble fermé des types valides — utile pour valider un input externe. */
+export const NOTIFICATION_TYPES: ReadonlyArray<NotificationType> = [
+  'reminder',
+  'missed_dose',
+  'peer_dose_recorded',
+  'pump_low',
+  'pump_expiring',
+  'dispute_detected',
+  'admin_handover',
+  'consent_update_required',
+  'security_alert',
+  'caregiver_revoked',
+] as const;
+
+/**
+ * Types que l'utilisateur ne peut **jamais** désactiver (SPECS §9).
+ *
+ * - `missed_dose` : tout désactivation est rejetée (400) par le backend et
+ *   toute prise enregistrée côté device continue de générer la notification
+ *   locale + e-mail fallback. Règle RM25 — protection sanitaire.
+ * - `security_alert` : intégrité du compte. Un attaquant ne doit jamais
+ *   pouvoir « silencier » ce canal en prenant le contrôle d'une session.
+ */
+export const ALWAYS_ENABLED_NOTIFICATION_TYPES: ReadonlyArray<NotificationType> = [
+  'missed_dose',
+  'security_alert',
+] as const;
+
+/**
+ * Types que l'utilisateur **peut** toggler depuis le paramétrage granulaire.
+ * Complément de {@link ALWAYS_ENABLED_NOTIFICATION_TYPES} — pratique pour
+ * itérer dans l'UI sans recalculer le diff à chaque rendu.
+ */
+export const TOGGLEABLE_NOTIFICATION_TYPES: ReadonlyArray<NotificationType> =
+  NOTIFICATION_TYPES.filter((t) => !ALWAYS_ENABLED_NOTIFICATION_TYPES.includes(t));
+
+/** Type guard — vérifie qu'un string inconnu est un {@link NotificationType} valide. */
+export function isNotificationType(value: unknown): value is NotificationType {
+  return typeof value === 'string' && NOTIFICATION_TYPES.includes(value as NotificationType);
+}
+
+/**
+ * Vérifie si un type donné est protégé (non désactivable). Retourne `true`
+ * pour `missed_dose` et `security_alert`, `false` pour tous les autres.
+ */
+export function isAlwaysEnabled(type: NotificationType): boolean {
+  return ALWAYS_ENABLED_NOTIFICATION_TYPES.includes(type);
+}

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -149,5 +149,54 @@
   },
   "offlineGuard": {
     "message": "This action requires an internet connection. It will be available again once you are back online."
+  },
+  "notificationPreferences": {
+    "title": "Notifications",
+    "description": "Choose which notification types you want to receive. Security and missed dose alerts are always on.",
+    "saveError": "Could not update preference. Please try again.",
+    "loadError": "Could not load preferences.",
+    "alwaysEnabledTooltip": "This notification type is always enabled for your safety.",
+    "types": {
+      "reminder": {
+        "label": "Dose reminders",
+        "description": "Local notifications at times scheduled by the treatment plan."
+      },
+      "missed_dose": {
+        "label": "Missed dose",
+        "description": "Alert when a dose has not been confirmed. Always on."
+      },
+      "peer_dose_recorded": {
+        "label": "Peer dose recorded",
+        "description": "Notification when another caregiver records a dose."
+      },
+      "pump_low": {
+        "label": "Inhaler running low",
+        "description": "Alert when an inhaler reaches the low-dose threshold."
+      },
+      "pump_expiring": {
+        "label": "Inhaler expiring",
+        "description": "Alert 30 days before an inhaler's expiry date."
+      },
+      "dispute_detected": {
+        "label": "Duplicate entry detected",
+        "description": "Alert when two caregivers record a dose very close in time."
+      },
+      "admin_handover": {
+        "label": "Admin handover",
+        "description": "Alert when an Admin role transfer is pending."
+      },
+      "consent_update_required": {
+        "label": "Terms update",
+        "description": "Notification when a new Terms version requires your acceptance."
+      },
+      "security_alert": {
+        "label": "Security alert",
+        "description": "Suspicious login, device revocation, key rotation. Always on."
+      },
+      "caregiver_revoked": {
+        "label": "Caregiver revoked",
+        "description": "Notification when you are removed from a household."
+      }
+    }
   }
 }

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -149,5 +149,54 @@
   },
   "offlineGuard": {
     "message": "Cette action nécessite une connexion internet. Elle sera disponible dès que vous serez de nouveau en ligne."
+  },
+  "notificationPreferences": {
+    "title": "Notifications",
+    "description": "Choisissez les types de notifications que vous souhaitez recevoir. Les notifications de sécurité et de dose manquée sont toujours actives.",
+    "saveError": "Impossible de mettre à jour la préférence. Réessayez.",
+    "loadError": "Impossible de charger les préférences.",
+    "alwaysEnabledTooltip": "Ce type de notification est toujours activé pour votre sécurité.",
+    "types": {
+      "reminder": {
+        "label": "Rappels de prise",
+        "description": "Notifications locales aux heures prévues par le plan de traitement."
+      },
+      "missed_dose": {
+        "label": "Dose manquée",
+        "description": "Alerte quand une prise n'a pas été confirmée. Toujours activée."
+      },
+      "peer_dose_recorded": {
+        "label": "Prise d'un autre aidant",
+        "description": "Notification quand un autre aidant enregistre une prise."
+      },
+      "pump_low": {
+        "label": "Pompe bientôt vide",
+        "description": "Alerte quand une pompe atteint le seuil d'alerte."
+      },
+      "pump_expiring": {
+        "label": "Pompe expirant",
+        "description": "Alerte 30 jours avant la date de péremption d'une pompe."
+      },
+      "dispute_detected": {
+        "label": "Double saisie détectée",
+        "description": "Alerte quand deux aidants enregistrent une prise très proche."
+      },
+      "admin_handover": {
+        "label": "Transfert d'administration",
+        "description": "Alerte en cas de transfert de droits Admin en attente."
+      },
+      "consent_update_required": {
+        "label": "Mise à jour CGU",
+        "description": "Notification quand une nouvelle version des CGU nécessite votre acceptation."
+      },
+      "security_alert": {
+        "label": "Alerte de sécurité",
+        "description": "Login suspect, révocation de device, rotation de clé. Toujours activée."
+      },
+      "caregiver_revoked": {
+        "label": "Révocation d'un aidant",
+        "description": "Notification quand vous êtes retiré d'un foyer."
+      }
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@kinhale/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
+      '@kinhale/domain':
+        specifier: workspace:*
+        version: link:../../packages/domain
       drizzle-orm:
         specifier: ^0.38.0
         version: 0.38.4(@types/pg@8.20.0)(@types/react@19.2.14)(pg@8.20.0)(react@18.3.1)


### PR DESCRIPTION
## Contexte

Couvre la story **E5-S07 — Paramétrage granulaire des notifications** (P0, Épique 5 — rappels). Chaque aidant peut activer/désactiver par type de notification, avec deux exceptions sanctuarisées : \`missed_dose\` (RM25) et \`security_alert\` restent toujours actifs, non désactivables.

## ADR-D10 — Expo Push Service v1.0

Cette PR embarque l'[ADR-D10](./docs/architecture/adr/ADR-D10-push-expo-v1-migration-native-v1-1.md) qui documente la décision de conserver Expo Push Service pour la v1.0 et reporter la migration APNs + FCM natifs en v1.1 ([issue #224](https://github.com/kamez-conseils/kinhale/issues/224)). Motivation : débloquer l'Épique 5 sans attendre le provisioning Apple Developer + Firebase (2-3 jours ops). Le payload push reste opaque zero-knowledge, impact zéro sur la confidentialité des données santé.

## Contenu

### Migration DB
Table \`user_notification_preferences\` (FK cascade, UNIQUE \`(account_id, type)\`). Migration additive sans downtime. Pas de \`down.sql\` (pattern projet).

### Backend
- \`GET /me/notification-preferences\` — force \`enabled=true\` pour les types sanctuarisés même si la DB dit le contraire (défense en lecture).
- \`PUT /me/notification-preferences\` — rejette 400 \`type_not_disablable\` si tentative de désactivation \`missed_dose\` / \`security_alert\`.
- \`dispatchPush\` accepte désormais \`PushTarget[]\` (token + accountId) et filtre via le store de préférences avant envoi. Rétrocompatible avec \`string[]\` pour ne pas casser le reste.

### Web + Mobile
Écran **Settings → Notifications** avec toggles Tamagui, i18n FR+EN complets. Toggles sanctuarisés rendus \`disabled\` avec tooltip explicatif. Mutations TanStack Query sur PUT.

### Défense en profondeur
Quadruple défense sur les types sanctuarisés : domaine (\`isAlwaysEnabled\`) + route GET (force \`true\`) + route PUT (rejette \`false\`) + dispatcher (\`ALWAYS_ENABLED ReadonlySet\`).

## Tests

- **108/108 API verts** (14 nouveaux sur \`notification-preferences\` + extensions \`push-dispatch\`)
- Tests unitaires web + mobile sur l'écran Settings
- Tests domaine sur \`isAlwaysEnabled\` et les types sanctuarisés
- \`pnpm format:check\`, \`pnpm lint:root\`, \`pnpm lint\`, \`pnpm typecheck\`, \`pnpm test\` : tous verts monorepo

## Impact sécurité

- **Sanctuarisation \`missed_dose\` / \`security_alert\`** — 4 couches indépendantes, validée par test « force enabled=true même si stockés par erreur en DB »
- **Scoping authz par \`sub\` du JWT** — aucun aidant ne peut lire/écrire les préférences d'un autre
- **Aucune donnée santé dans les préférences** (seul le type de notif est stocké, pas de contexte métier)
- **Pas d'injection SQL** — Drizzle prepared statements + \`z.enum\` fermé sur les types acceptés
- Migration FK \`CASCADE\` cohérente avec le droit à l'oubli Loi 25

## Migration DB

Fichier : \`apps/api/src/db/migrations/0001_curly_iron_man.sql\`. Additive. Rollback manuel possible via \`DROP TABLE user_notification_preferences\` — pas de \`down.sql\` (pattern projet aligné sur la migration 0000).

## Revues assistées

- **kz-review** — 0 bloquant, 1 majeur résolu (\`inArray\` cast → spread \`[...accountIds]\` commenté), 5 mineurs → issues de suivi. Rapport : [\`kz-review-KIN-080.md\`](../.agents/current-run/kz-review-KIN-080.md).
- **kz-securite** — **GO sans réserve**. 0 bloquant, 0 majeur. 5 mineurs (logs d'audit, rate-limit PUT, rollback formalisé, conformité documentaire). Rapport : [\`kz-securite-KIN-080.md\`](../.agents/current-run/kz-securite-KIN-080.md).

## Suivi

Issues de suivi à créer pour les 5 mineurs kz-review + 5 mineurs kz-securite (listes dans les rapports).

Refs: KIN-080
Closes: E5-S07