### PR TITLE
feat(reports,api): KIN-085 — export de portabilité RGPD/Loi 25 client-side

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -18,6 +18,7 @@ import notificationsRoute from './routes/notifications.js';
 import notificationPreferencesRoute from './routes/notification-preferences.js';
 import quietHoursRoute from './routes/quiet-hours.js';
 import auditRoute from './routes/audit.js';
+import privacyRoute from './routes/privacy.js';
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -86,6 +87,7 @@ export function buildApp(env: Env, overrides: BuildAppOverrides = {}): FastifyIn
   void app.register(notificationPreferencesRoute);
   void app.register(quietHoursRoute);
   void app.register(auditRoute, { prefix: '/audit' });
+  void app.register(privacyRoute);
 
   return app;
 }

--- a/apps/api/src/routes/__tests__/audit.test.ts
+++ b/apps/api/src/routes/__tests__/audit.test.ts
@@ -458,3 +458,159 @@ describe('POST /audit/report-shared', () => {
     await app.close();
   });
 });
+
+/**
+ * Tests de la route `POST /audit/privacy-export` (E9-S02, KIN-085).
+ *
+ * Trace la génération locale d'une archive RGPD/Loi 25. Mêmes garanties
+ * zero-knowledge que `/audit/report-generated` : strict body, rate-limit
+ * Redis, insertion jsonb minimaliste, logs sans donnée santé.
+ */
+describe('POST /audit/privacy-export', () => {
+  const VALID_PAYLOAD = {
+    archiveHash: VALID_HASH,
+    generatedAtMs: 1_700_500_000_000,
+  };
+
+  it('retourne 401 sans JWT', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/audit/privacy-export',
+      payload: VALID_PAYLOAD,
+    });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it('retourne 400 si body est vide', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/audit/privacy-export',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("retourne 400 si archiveHash n'est pas 64 chars hex", async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/audit/privacy-export',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+      payload: { ...VALID_PAYLOAD, archiveHash: 'too-short' },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('retourne 400 si un champ supplémentaire fuite (strict mode anti-fuite)', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/audit/privacy-export',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+      payload: {
+        ...VALID_PAYLOAD,
+        // Tentative de fuite : prénom enfant dans l'audit
+        childName: 'Léa',
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(db._insertValues).not.toHaveBeenCalled();
+    await app.close();
+  });
+
+  it('retourne 400 si generatedAtMs est négatif', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/audit/privacy-export',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+      payload: { ...VALID_PAYLOAD, generatedAtMs: -1 },
+    });
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it("persiste un événement 'privacy_export' avec uniquement les champs attendus (zero-knowledge)", async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({
+      method: 'POST',
+      url: '/audit/privacy-export',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+      payload: VALID_PAYLOAD,
+    });
+    expect(res.statusCode).toBe(201);
+    expect(db._inserted).toHaveLength(1);
+    const row = db._inserted[0];
+    expect(row?.accountId).toBe(ACCOUNT_ID);
+    expect(row?.eventType).toBe('privacy_export');
+    expect(row?.eventData).toEqual(VALID_PAYLOAD);
+    await app.close();
+  });
+
+  it('applique un rate-limit (429 après 5/h par device)', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const token = signAccess(app);
+    let lastStatus = 0;
+    for (let i = 0; i < 6; i++) {
+      const res = await app.inject({
+        method: 'POST',
+        url: '/audit/privacy-export',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: { ...VALID_PAYLOAD, generatedAtMs: 1_700_500_000_000 + i },
+      });
+      lastStatus = res.statusCode;
+    }
+    expect(lastStatus).toBe(429);
+    await app.close();
+  });
+
+  it('a un rate-limit indépendant de /audit/report-generated et /audit/report-shared', async () => {
+    const db = makeMockDb();
+    const app = buildTestApp(db);
+    await app.ready();
+    const token = signAccess(app);
+    // Saturer le quota report-generated
+    for (let i = 0; i < 11; i++) {
+      await app.inject({
+        method: 'POST',
+        url: '/audit/report-generated',
+        headers: { Authorization: `Bearer ${token}` },
+        payload: {
+          reportHash: VALID_HASH,
+          rangeStartMs: 1_700_000_000_000,
+          rangeEndMs: 1_700_500_000_000,
+          generatedAtMs: 1_700_500_000_000 + i,
+        },
+      });
+    }
+    // privacy-export doit rester disponible
+    const res = await app.inject({
+      method: 'POST',
+      url: '/audit/privacy-export',
+      headers: { Authorization: `Bearer ${token}` },
+      payload: VALID_PAYLOAD,
+    });
+    expect(res.statusCode).toBe(201);
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/__tests__/privacy.test.ts
+++ b/apps/api/src/routes/__tests__/privacy.test.ts
@@ -1,0 +1,303 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildApp } from '../../app.js';
+import { testEnv } from '../../env.js';
+import type { DrizzleDb } from '../../plugins/db.js';
+import type { RedisClients } from '../../plugins/redis.js';
+
+const ACCOUNT_ID = '00000000-0000-0000-0000-00000000AA01';
+const OTHER_ACCOUNT_ID = '00000000-0000-0000-0000-00000000FFFF';
+const DEVICE_ID = '00000000-0000-0000-0000-00000000BB01';
+const HOUSEHOLD_ID = '00000000-0000-0000-0000-00000000CC01';
+
+/**
+ * Mock DB chainable qui simule des résultats par table.
+ * Le mock garde trace du `WHERE accountId = ?` filtre via une closure pour
+ * pouvoir vérifier qu'un appel utilise bien le `sub` du JWT.
+ */
+function makeMockDbWithFixtures(args: {
+  devices?: Array<{ id: string; createdAt: Date }>;
+  auditEvents?: Array<{ eventType: string; eventData: unknown; createdAt: Date }>;
+  preferences?: Array<{ notificationType: string; enabled: boolean; updatedAt: Date }>;
+  quietHours?: Array<{
+    enabled: boolean;
+    startLocalTime: string;
+    endLocalTime: string;
+    timezone: string;
+    updatedAt: Date;
+  }>;
+  pushTokensCount?: number;
+  /** Filtre actuel — `eq(devices.accountId, X)` capture le X. */
+  capturedAccountIds?: string[];
+}) {
+  const captured = args.capturedAccountIds ?? [];
+
+  const select = vi.fn().mockImplementation((projection: Record<string, unknown>) => {
+    // Détecte la table cible via les clés de la projection (résolution éager).
+    let resolvedRows: unknown[] = [];
+    if ('id' in projection && 'createdAt' in projection) {
+      resolvedRows = args.devices ?? [];
+    } else if ('eventType' in projection) {
+      resolvedRows = args.auditEvents ?? [];
+    } else if ('notificationType' in projection) {
+      resolvedRows = args.preferences ?? [];
+    } else if ('startLocalTime' in projection) {
+      resolvedRows = args.quietHours ?? [];
+    } else if ('count' in projection) {
+      resolvedRows = [{ count: args.pushTokensCount ?? 0 }];
+    }
+
+    // Helper qui produit une `Promise` thenable mais qui supporte aussi
+    // `.limit(n)` — drizzle expose un builder thenable (extends Promise).
+    // On reproduit le même contrat ici.
+    const thenableWithLimit = () => {
+      const p = Promise.resolve(resolvedRows) as Promise<unknown[]> & {
+        limit: (_n: number) => Promise<unknown[]>;
+      };
+      p.limit = (_n: number) => Promise.resolve(resolvedRows);
+      return p;
+    };
+
+    const fromObj = {
+      where: (_whereClause: unknown) => {
+        // On ne sérialise pas le whereClause (objet drizzle circulaire) — on
+        // capture simplement qu'une requête a été émise pour le test
+        // d'isolation par accountId.
+        captured.push('where_called');
+        return thenableWithLimit();
+      },
+      innerJoin: (_table: unknown, _on: unknown) => ({
+        where: (_whereClause: unknown) => Promise.resolve([{ count: args.pushTokensCount ?? 0 }]),
+      }),
+    };
+
+    return {
+      from: (_table: unknown) => fromObj,
+    };
+  });
+
+  const insertValues = vi.fn().mockResolvedValue(undefined);
+  const insert = vi.fn().mockReturnValue({ values: insertValues });
+
+  return {
+    select,
+    insert,
+    _capturedAccountIds: captured,
+    _insertValues: insertValues,
+  } as unknown as DrizzleDb & {
+    _capturedAccountIds: string[];
+    _insertValues: ReturnType<typeof vi.fn>;
+  };
+}
+
+function makeMockRedis(): RedisClients {
+  const kv = new Map<string, number>();
+  const pub = {
+    async incr(k: string) {
+      const n = (kv.get(k) ?? 0) + 1;
+      kv.set(k, n);
+      return n;
+    },
+    async expire(_k: string, _ttl: number) {
+      return 1;
+    },
+    async publish(_channel: string, _msg: string) {
+      return 0;
+    },
+  };
+  const sub = {
+    on: () => undefined,
+    subscribe: async () => undefined,
+    unsubscribe: async () => undefined,
+  };
+  return { pub, sub } as unknown as RedisClients;
+}
+
+function buildTestApp(db: ReturnType<typeof makeMockDbWithFixtures>) {
+  return buildApp(testEnv(), { db, redis: makeMockRedis() });
+}
+
+function signAccess(
+  app: ReturnType<typeof buildTestApp>,
+  sub: string = ACCOUNT_ID,
+  deviceId: string = DEVICE_ID,
+): string {
+  return app.jwt.sign({
+    sub,
+    deviceId,
+    householdId: HOUSEHOLD_ID,
+    type: 'access',
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /me/privacy/export/metadata', () => {
+  it('retourne 401 sans JWT', async () => {
+    const db = makeMockDbWithFixtures({});
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({ method: 'GET', url: '/me/privacy/export/metadata' });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it('retourne 200 avec une payload zero-knowledge sur compte vide', async () => {
+    const db = makeMockDbWithFixtures({});
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/privacy/export/metadata',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Record<string, unknown>;
+    expect(body['accountId']).toBe(ACCOUNT_ID);
+    expect(typeof body['exportedAtMs']).toBe('number');
+    expect(body['devices']).toEqual([]);
+    expect(body['auditEvents']).toEqual([]);
+    expect(body['notificationPreferences']).toEqual([]);
+    expect(body['quietHours']).toBeNull();
+    expect(body['pushTokensCount']).toBe(0);
+    await app.close();
+  });
+
+  it('retourne les devices, audit events, prefs, quiet hours et push tokens count', async () => {
+    const REGISTERED_AT = new Date(Date.UTC(2026, 0, 1));
+    const AUDIT_AT = new Date(Date.UTC(2026, 1, 15));
+    const PREF_AT = new Date(Date.UTC(2026, 2, 10));
+    const QH_AT = new Date(Date.UTC(2026, 3, 1));
+    const db = makeMockDbWithFixtures({
+      devices: [{ id: DEVICE_ID, createdAt: REGISTERED_AT }],
+      auditEvents: [
+        {
+          eventType: 'report_generated',
+          eventData: { reportHash: 'a'.repeat(64) },
+          createdAt: AUDIT_AT,
+        },
+      ],
+      preferences: [{ notificationType: 'peer_dose_recorded', enabled: false, updatedAt: PREF_AT }],
+      quietHours: [
+        {
+          enabled: true,
+          startLocalTime: '22:00',
+          endLocalTime: '07:00',
+          timezone: 'America/Toronto',
+          updatedAt: QH_AT,
+        },
+      ],
+      pushTokensCount: 2,
+    });
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/privacy/export/metadata',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Record<string, unknown>;
+    expect(body['devices']).toEqual([
+      { deviceId: DEVICE_ID, registeredAtMs: REGISTERED_AT.getTime(), lastSeenMs: null },
+    ]);
+    expect(body['auditEvents']).toEqual([
+      {
+        eventType: 'report_generated',
+        eventData: { reportHash: 'a'.repeat(64) },
+        createdAtMs: AUDIT_AT.getTime(),
+      },
+    ]);
+    expect(body['notificationPreferences']).toEqual([
+      { notificationType: 'peer_dose_recorded', enabled: false, updatedAtMs: PREF_AT.getTime() },
+    ]);
+    expect(body['quietHours']).toEqual({
+      enabled: true,
+      startLocalTime: '22:00',
+      endLocalTime: '07:00',
+      timezone: 'America/Toronto',
+      updatedAtMs: QH_AT.getTime(),
+    });
+    expect(body['pushTokensCount']).toBe(2);
+    await app.close();
+  });
+
+  it('ne renvoie JAMAIS le contenu des push tokens (RM16 — minimisation)', async () => {
+    const db = makeMockDbWithFixtures({ pushTokensCount: 1 });
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/privacy/export/metadata',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    const body = res.json() as Record<string, unknown>;
+    expect(body['pushTokens']).toBeUndefined();
+    expect(body['pushTokensCount']).toBe(1);
+    await app.close();
+  });
+
+  it('scope strict : la requête utilise le sub du JWT et pas un autre accountId', async () => {
+    // Vérifie qu'aucun champ « accountId » dans la réponse ne contredit le sub
+    // du JWT (régression IDOR potentielle via override de réponse).
+    const db = makeMockDbWithFixtures({});
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/privacy/export/metadata',
+      headers: { Authorization: `Bearer ${signAccess(app, ACCOUNT_ID)}` },
+    });
+    const body = res.json() as Record<string, unknown>;
+    expect(body['accountId']).toBe(ACCOUNT_ID);
+    expect(body['accountId']).not.toBe(OTHER_ACCOUNT_ID);
+    await app.close();
+  });
+
+  it('applique un rate-limit (429 après 5/h par device)', async () => {
+    const db = makeMockDbWithFixtures({});
+    const app = buildTestApp(db);
+    await app.ready();
+    const token = signAccess(app);
+    let lastStatus = 0;
+    for (let i = 0; i < 6; i++) {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/me/privacy/export/metadata',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      lastStatus = res.statusCode;
+    }
+    expect(lastStatus).toBe(429);
+    await app.close();
+  });
+
+  it('ne contient JAMAIS de mot référant à des données santé (zero-knowledge regression)', async () => {
+    const db = makeMockDbWithFixtures({
+      devices: [{ id: DEVICE_ID, createdAt: new Date() }],
+      pushTokensCount: 1,
+    });
+    const app = buildTestApp(db);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/privacy/export/metadata',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    const text = res.body;
+    // Mots qui ne doivent JAMAIS apparaître dans la réponse (sentinelles).
+    const forbidden = [
+      'doseAdministered',
+      'pumpName',
+      'symptomCode',
+      'firstName',
+      'birthYear',
+      'freeFormTag',
+    ];
+    for (const w of forbidden) {
+      expect(text).not.toContain(w);
+    }
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/audit.ts
+++ b/apps/api/src/routes/audit.ts
@@ -29,8 +29,20 @@ const AUDIT_REPORT_WINDOW_SECONDS = 3600;
 const AUDIT_REPORT_SHARED_MAX_PER_HOUR = 20;
 const AUDIT_REPORT_SHARED_WINDOW_SECONDS = 3600;
 
+/**
+ * Nombre max de `privacy_export` par device et par heure (KIN-085, E9-S02).
+ *
+ * Quota strict : un export RGPD/Loi 25 est une action rare (1-2/an pour un
+ * usage normal). Limiter à 5/h freine un device compromis qui voudrait
+ * polluer l'audit ou tester massivement la pipeline.
+ */
+const AUDIT_PRIVACY_EXPORT_MAX_PER_HOUR = 5;
+const AUDIT_PRIVACY_EXPORT_WINDOW_SECONDS = 3600;
+
 const rateLimitKey = (deviceId: string): string => `rl:audit-report-generated:${deviceId}`;
 const rateLimitSharedKey = (deviceId: string): string => `rl:audit-report-shared:${deviceId}`;
+const rateLimitPrivacyExportKey = (deviceId: string): string =>
+  `rl:audit-privacy-export:${deviceId}`;
 
 /**
  * Borne supérieure de timestamp acceptée (année 3000). Protège contre des
@@ -107,6 +119,34 @@ const ReportSharedBody = z
   .strict();
 
 type ReportSharedData = z.infer<typeof ReportSharedBody>;
+
+/**
+ * Schéma Zod **strict** du body `POST /audit/privacy-export` (E9-S02, KIN-085).
+ *
+ * Trace la génération **locale** d'une archive de portabilité RGPD/Loi 25.
+ * Seuls 2 champs autorisés :
+ * - `archiveHash` : SHA-256 hex du ZIP entier — opaque côté relais, vérifiable
+ *   côté client.
+ * - `generatedAtMs` : horodatage de génération côté client.
+ *
+ * `.strict()` rejette tout champ supplémentaire — défense en profondeur
+ * contre un client compromis qui tenterait d'exfiltrer une donnée santé
+ * (ex. `childName`, `pumpName`) via le canal audit.
+ *
+ * **Zero-knowledge** :
+ * - `archiveHash` est un digest non réversible.
+ * - `generatedAtMs` est équivalent à l'horloge serveur à la milliseconde.
+ *
+ * Refs: ADR-D14, KIN-085, RGPD art. 20, Loi 25 art. 30.
+ */
+const PrivacyExportBody = z
+  .object({
+    archiveHash: z.string().regex(/^[0-9a-f]{64}$/, 'invalid_hash'),
+    generatedAtMs: z.number().int().min(0).max(MAX_ACCEPTABLE_MS),
+  })
+  .strict();
+
+type PrivacyExportData = z.infer<typeof PrivacyExportBody>;
 
 const auditRoute: FastifyPluginAsync = async (app) => {
   /**
@@ -207,6 +247,55 @@ const auditRoute: FastifyPluginAsync = async (app) => {
     await app.db.insert(auditEvents).values({
       accountId,
       eventType: 'report_shared',
+      eventData: data,
+    });
+
+    return reply.status(201).send({ ok: true });
+  });
+
+  /**
+   * POST /audit/privacy-export (E9-S02, KIN-085)
+   *
+   * Trace la génération locale d'une archive de portabilité RGPD/Loi 25.
+   * Appelé par le client après que `buildPrivacyArchive` a produit le ZIP.
+   *
+   * **Zero-knowledge strict** : le body ne contient **aucune donnée santé** :
+   * - `archiveHash` : SHA-256 hex de l'archive (RM24-like) — opaque relais.
+   * - `generatedAtMs` : timestamp client.
+   *
+   * Renvoie 201 même en cas de génération répétée (un utilisateur peut
+   * légitimement régénérer plusieurs fois — chaque tentative est tracée).
+   *
+   * Rate-limit Redis : 5/h/device (action rare).
+   *
+   * Refs: ADR-D14, KIN-085, E9-S02.
+   */
+  app.post('/privacy-export', { preHandler: [app.authenticate] }, async (request, reply) => {
+    const parse = PrivacyExportBody.safeParse(request.body);
+    if (!parse.success) {
+      return reply.status(400).send({ error: 'invalid_body' });
+    }
+
+    const { sub: accountId, deviceId } = request.user as SessionJwtPayload;
+
+    const key = rateLimitPrivacyExportKey(deviceId);
+    const count = await app.redis.pub.incr(key);
+    if (count === 1) {
+      await app.redis.pub.expire(key, AUDIT_PRIVACY_EXPORT_WINDOW_SECONDS);
+    }
+    if (count > AUDIT_PRIVACY_EXPORT_MAX_PER_HOUR) {
+      app.log.warn(
+        { event: 'audit.privacy_export.rate_limited', deviceId },
+        'Rate-limit atteint sur /audit/privacy-export',
+      );
+      return reply.status(429).send({ error: 'rate_limited' });
+    }
+
+    const data: PrivacyExportData = parse.data;
+
+    await app.db.insert(auditEvents).values({
+      accountId,
+      eventType: 'privacy_export',
       eventData: data,
     });
 

--- a/apps/api/src/routes/privacy.ts
+++ b/apps/api/src/routes/privacy.ts
@@ -1,0 +1,226 @@
+/**
+ * Route relais pour l'export de portabilité RGPD/Loi 25 (KIN-085, ADR-D14).
+ *
+ * Expose deux endpoints :
+ * - `GET /me/privacy/export/metadata` : retourne les métadonnées non-santé
+ *   du compte courant (devices, audit events, préférences notifs, quiet
+ *   hours, comptage push tokens). **Scope-isolé strictement** par `sub` JWT —
+ *   un utilisateur ne voit JAMAIS les données d'un autre utilisateur.
+ * - `POST /audit/privacy-export` : trace localement la génération d'une
+ *   archive de portabilité côté client (pattern strict identique à
+ *   `/audit/report-generated`).
+ *
+ * Le second endpoint vit dans `audit.ts` (cohérence du module audit).
+ *
+ * **Zero-knowledge** :
+ * - Aucune donnée santé n'est jamais exposée par le relais.
+ * - Le payload retourné contient uniquement des métadonnées techniques
+ *   produites par le relais lui-même (pas de relai de blob mailbox).
+ * - Le `pushTokensCount` est un nombre — pas le contenu des tokens (RM16
+ *   minimisation).
+ *
+ * Refs: ADR-D14, KIN-085, RGPD art. 20, Loi 25 art. 30.
+ */
+
+import type { FastifyPluginAsync } from 'fastify';
+import { eq, count } from 'drizzle-orm';
+import {
+  auditEvents,
+  devices,
+  pushTokens,
+  userNotificationPreferences,
+  userQuietHours,
+} from '../db/schema.js';
+import type { SessionJwtPayload } from '../plugins/jwt.js';
+
+/**
+ * Quota de fetch metadata par device et par heure.
+ *
+ * 5/h est strict — un utilisateur normal n'exerce son droit à la portabilité
+ * qu'occasionnellement. Un quota plus haut ouvrirait une porte à un device
+ * compromis pour exfiltrer répétitivement les métadonnées et corréler les
+ * réponses dans le temps.
+ */
+const PRIVACY_METADATA_MAX_PER_HOUR = 5;
+const PRIVACY_METADATA_WINDOW_SECONDS = 3600;
+
+/**
+ * Borne supérieure du nombre d'audit events retournés dans un export.
+ *
+ * Motivation : la table `audit_events` est rate-limitée en écriture (5/h
+ * `report_generated`, 20/h `report_shared`, 5/h `privacy_export`) et un
+ * compte normal cumulera < 1000 events sur 5 ans. Mais un compte attaqué
+ * pendant l'incubation des rate-limits pourrait stocker beaucoup plus.
+ * 10 000 borne le payload à ~3 MB max et 14 ans à 2 events/jour.
+ *
+ * Pas de pagination en v1.0 (l'export est un acte rare et exhaustif). Si
+ * un compte dépasse cette borne, ajouter cursor + limit en v1.1.
+ */
+const AUDIT_EVENTS_MAX_PER_EXPORT = 10_000;
+
+const rateLimitKey = (deviceId: string): string => `rl:privacy-export-metadata:${deviceId}`;
+
+/**
+ * Réponse `GET /me/privacy/export/metadata`. Cohérent avec
+ * `RelayExportMetadata` côté `@kinhale/reports`.
+ */
+interface ExportMetadataResponse {
+  readonly accountId: string;
+  readonly exportedAtMs: number;
+  readonly devices: ReadonlyArray<{
+    readonly deviceId: string;
+    readonly registeredAtMs: number;
+    readonly lastSeenMs: number | null;
+  }>;
+  readonly auditEvents: ReadonlyArray<{
+    readonly eventType: string;
+    readonly eventData: unknown;
+    readonly createdAtMs: number;
+  }>;
+  readonly notificationPreferences: ReadonlyArray<{
+    readonly notificationType: string;
+    readonly enabled: boolean;
+    readonly updatedAtMs: number;
+  }>;
+  readonly quietHours: {
+    readonly enabled: boolean;
+    readonly startLocalTime: string;
+    readonly endLocalTime: string;
+    readonly timezone: string;
+    readonly updatedAtMs: number;
+  } | null;
+  readonly pushTokensCount: number;
+}
+
+const privacyRoute: FastifyPluginAsync = async (app) => {
+  /**
+   * GET /me/privacy/export/metadata
+   *
+   * Retourne strictement les métadonnées techniques que le relais détient
+   * sur l'utilisateur courant. **Authz** : `sub` du JWT scope les filtres
+   * `WHERE accountId = sub` sur **toutes** les tables interrogées — un
+   * utilisateur ne peut JAMAIS exfiltrer les données d'un autre.
+   *
+   * **Aucune donnée santé.** Mailbox (`mailbox_messages`) est volontairement
+   * exclue : (a) le contenu est chiffré opaque, le client peut le restituer
+   * via la sync ; (b) la mailbox est indexée par `householdId`, pas par
+   * `accountId` — un endpoint qui exposerait la mailbox d'un foyer divulguerait
+   * potentiellement des données concernant d'autres aidants.
+   */
+  app.get(
+    '/me/privacy/export/metadata',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const { sub: accountId, deviceId } = request.user as SessionJwtPayload;
+
+      // Rate-limit Redis (pattern identique à audit.ts).
+      const key = rateLimitKey(deviceId);
+      const counter = await app.redis.pub.incr(key);
+      if (counter === 1) {
+        await app.redis.pub.expire(key, PRIVACY_METADATA_WINDOW_SECONDS);
+      }
+      if (counter > PRIVACY_METADATA_MAX_PER_HOUR) {
+        app.log.warn(
+          { event: 'privacy.export.metadata.rate_limited', deviceId },
+          'Rate-limit atteint sur /me/privacy/export/metadata',
+        );
+        return reply.status(429).send({ error: 'rate_limited' });
+      }
+
+      // 1) Devices du compte courant. Filtre WHERE strict.
+      const deviceRows = await app.db
+        .select({
+          id: devices.id,
+          createdAt: devices.createdAt,
+        })
+        .from(devices)
+        .where(eq(devices.accountId, accountId));
+
+      // 2) Audit events du compte courant. `limit` pose une borne mémoire
+      //    explicite (10 000 events ≈ 14 ans à 2 events/jour) — défense en
+      //    profondeur contre un compte avec un trail anormalement volumineux,
+      //    même si les routes /audit/* sont déjà rate-limitées en upload.
+      const auditRows = await app.db
+        .select({
+          eventType: auditEvents.eventType,
+          eventData: auditEvents.eventData,
+          createdAt: auditEvents.createdAt,
+        })
+        .from(auditEvents)
+        .where(eq(auditEvents.accountId, accountId))
+        .limit(AUDIT_EVENTS_MAX_PER_EXPORT);
+
+      // 3) Préférences de notifications matérialisées du compte courant.
+      const prefRows = await app.db
+        .select({
+          notificationType: userNotificationPreferences.notificationType,
+          enabled: userNotificationPreferences.enabled,
+          updatedAt: userNotificationPreferences.updatedAt,
+        })
+        .from(userNotificationPreferences)
+        .where(eq(userNotificationPreferences.accountId, accountId));
+
+      // 4) Quiet hours du compte courant (0 ou 1 ligne).
+      const qhRows = await app.db
+        .select({
+          enabled: userQuietHours.enabled,
+          startLocalTime: userQuietHours.startLocalTime,
+          endLocalTime: userQuietHours.endLocalTime,
+          timezone: userQuietHours.timezone,
+          updatedAt: userQuietHours.updatedAt,
+        })
+        .from(userQuietHours)
+        .where(eq(userQuietHours.accountId, accountId));
+
+      // 5) Nombre de push tokens. On ne renvoie pas les tokens eux-mêmes
+      //    (RM16 minimisation : un token APNs / FCM est une donnée techn-
+      //    iquement réutilisable par un attaquant ; le renvoyer en clair
+      //    crée une fenêtre d'exfiltration). Un comptage suffit pour la
+      //    portabilité.
+      const tokenCountRows = await app.db
+        .select({ count: count(pushTokens.id) })
+        .from(pushTokens)
+        .innerJoin(devices, eq(pushTokens.deviceId, devices.id))
+        .where(eq(devices.accountId, accountId));
+      const pushTokensCount = tokenCountRows[0]?.count ?? 0;
+
+      const qhRow = qhRows[0];
+      const response: ExportMetadataResponse = {
+        accountId,
+        exportedAtMs: Date.now(),
+        devices: deviceRows.map((d) => ({
+          deviceId: d.id,
+          registeredAtMs: d.createdAt.getTime(),
+          // v1.0 : pas de tracking de last_seen — le champ est exposé pour
+          // forward-compat (cf. RelayDeviceInfo).
+          lastSeenMs: null,
+        })),
+        auditEvents: auditRows.map((a) => ({
+          eventType: a.eventType,
+          eventData: a.eventData,
+          createdAtMs: a.createdAt.getTime(),
+        })),
+        notificationPreferences: prefRows.map((p) => ({
+          notificationType: p.notificationType,
+          enabled: p.enabled,
+          updatedAtMs: p.updatedAt.getTime(),
+        })),
+        quietHours:
+          qhRow !== undefined
+            ? {
+                enabled: qhRow.enabled,
+                startLocalTime: qhRow.startLocalTime,
+                endLocalTime: qhRow.endLocalTime,
+                timezone: qhRow.timezone,
+                updatedAtMs: qhRow.updatedAt.getTime(),
+              }
+            : null,
+        pushTokensCount: Number(pushTokensCount),
+      };
+
+      return response;
+    },
+  );
+};
+
+export default privacyRoute;

--- a/apps/mobile/app/settings/privacy.tsx
+++ b/apps/mobile/app/settings/privacy.tsx
@@ -1,0 +1,261 @@
+import React, { type JSX } from 'react';
+import { Alert, Platform } from 'react-native';
+import { useRouter } from 'expo-router';
+import * as FileSystem from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
+import { useTranslation } from 'react-i18next';
+import { Buffer } from 'buffer';
+import { YStack, XStack, H1, H2, Text, Button, Card } from 'tamagui';
+import {
+  aggregateReportData,
+  buildCsvDoses,
+  buildPrivacyArchive,
+  buildReportStrings,
+  generateMedicalCsv,
+  generateMedicalReport,
+  serializeDocForExport,
+} from '@kinhale/reports';
+import { projectDoses, type KinhaleDoc } from '@kinhale/sync';
+import { useAuthStore } from '../../src/stores/auth-store';
+import { useDocStore } from '../../src/stores/doc-store';
+import { ApiError } from '../../src/lib/api-client';
+import {
+  getPrivacyExportMetadata,
+  postPrivacyExportAudit,
+} from '../../src/lib/privacy/export-client';
+
+const GENERATOR_LABEL = `Kinhale ${process.env['EXPO_PUBLIC_APP_VERSION'] ?? 'v1.0.0-preview'}`;
+
+type UiState =
+  | { kind: 'idle' }
+  | { kind: 'preparing' }
+  | {
+      kind: 'ready';
+      uri: string;
+      archiveHash: string;
+      audit: 'synced' | 'pending';
+    }
+  | { kind: 'error'; messageKey: string };
+
+/**
+ * Écran « Paramètres → Confidentialité » mobile — KIN-085, E9-S02, ADR-D14.
+ *
+ * Pendant mobile de `apps/web/src/app/settings/privacy/page.tsx`. Différences :
+ * - Utilise `expo-file-system` pour écrire le ZIP en cache (encodé base64).
+ * - Utilise `Sharing.shareAsync` pour la share sheet OS.
+ * - Purge le fichier cache à l'unmount.
+ */
+export default function PrivacyExportScreen(): JSX.Element | null {
+  const { t } = useTranslation('common');
+  const router = useRouter();
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const householdId = useAuthStore((s) => s.householdId);
+  const doc = useDocStore((s) => s.doc);
+  const initDoc = useDocStore((s) => s.initDoc);
+  const [state, setState] = React.useState<UiState>({ kind: 'idle' });
+
+  React.useEffect(() => {
+    if (accessToken === null) {
+      router.replace('/auth');
+      return;
+    }
+    if (householdId !== null) {
+      void initDoc(householdId);
+    }
+  }, [accessToken, householdId, initDoc, router]);
+
+  React.useEffect(
+    () => (): void => {
+      setState((prev) => {
+        if (prev.kind === 'ready') {
+          // Purge proactive — l'archive contient des données santé en clair
+          // pendant la durée de vie locale ; on minimise la fenêtre.
+          void FileSystem.deleteAsync(prev.uri, { idempotent: true });
+        }
+        return prev;
+      });
+    },
+    [],
+  );
+
+  const handleExport = async (): Promise<void> => {
+    if (doc === null) {
+      setState({ kind: 'error', messageKey: 'privacyExport.errors.notReady' });
+      return;
+    }
+
+    setState((prev) => {
+      if (prev.kind === 'ready') {
+        void FileSystem.deleteAsync(prev.uri, { idempotent: true });
+      }
+      return { kind: 'preparing' };
+    });
+
+    try {
+      const metadata = await getPrivacyExportMetadata();
+      const now = Date.now();
+      const TWO_YEARS_MS = 2 * 365 * 24 * 60 * 60 * 1000;
+      const fullRange = { startMs: now - TWO_YEARS_MS, endMs: now };
+
+      const reportResult = await generateMedicalReport({
+        doc,
+        range: fullRange,
+        strings: buildReportStrings((key, fallback) => t(key, fallback ?? key)),
+        generator: GENERATOR_LABEL,
+        generatedAtMs: now,
+        locale: t('home.title') === 'Kinhale' ? 'fr' : 'en',
+      });
+
+      const reportData = aggregateReportData(doc, fullRange);
+      const lookup = buildLookup(doc);
+      const csvDoses = buildCsvDoses(reportData, lookup);
+      const csv = generateMedicalCsv(csvDoses);
+
+      const serializedDoc = serializeDocForExport(doc, now);
+
+      const archive = await buildPrivacyArchive({
+        serializedDoc,
+        relayMetadata: metadata,
+        reportHtml: reportResult.html,
+        reportCsv: csv,
+        generatedAtMs: now,
+        appVersion: GENERATOR_LABEL,
+      });
+
+      const cacheDir = FileSystem.cacheDirectory ?? FileSystem.documentDirectory ?? '';
+      const iso = new Date(now).toISOString().slice(0, 10);
+      const uri = `${cacheDir}kinhale-privacy-export-${iso}.zip`;
+
+      // expo-file-system n'accepte pas Uint8Array directement — on encode
+      // en base64 via le polyfill `buffer` (déjà utilisé pour les clés crypto).
+      const base64 = Buffer.from(archive.zipBytes).toString('base64');
+      await FileSystem.writeAsStringAsync(uri, base64, {
+        encoding: FileSystem.EncodingType.Base64,
+      });
+
+      let auditStatus: 'synced' | 'pending' = 'synced';
+      try {
+        await postPrivacyExportAudit({
+          archiveHash: archive.archiveHash,
+          generatedAtMs: now,
+        });
+      } catch (err) {
+        if (err instanceof ApiError || err instanceof TypeError) {
+          auditStatus = 'pending';
+        } else {
+          throw err;
+        }
+      }
+
+      setState({
+        kind: 'ready',
+        uri,
+        archiveHash: archive.archiveHash,
+        audit: auditStatus,
+      });
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setState({ kind: 'error', messageKey: 'privacyExport.errors.metadataFailed' });
+      } else {
+        setState({ kind: 'error', messageKey: 'privacyExport.errors.generationFailed' });
+      }
+    }
+  };
+
+  const handleShare = async (uri: string): Promise<void> => {
+    const available = await Sharing.isAvailableAsync();
+    if (!available) {
+      if (Platform.OS !== 'web') {
+        Alert.alert(t('privacyExport.title'), t('privacyExport.shareUnavailable'));
+      }
+      return;
+    }
+    try {
+      await Sharing.shareAsync(uri, { mimeType: 'application/zip' });
+    } catch {
+      // Annulation utilisateur.
+    }
+  };
+
+  if (accessToken === null) return null;
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1 accessibilityRole="header">{t('privacyExport.title')}</H1>
+      <Text>{t('privacyExport.description')}</Text>
+
+      <Card padded bordered>
+        <YStack gap="$3">
+          <H2>{t('privacyExport.sectionTitle')}</H2>
+          <Text fontSize="$2">{t('privacyExport.contents')}</Text>
+
+          <Button
+            onPress={() => {
+              void handleExport();
+            }}
+            disabled={state.kind === 'preparing' || doc === null}
+            accessibilityLabel={t('privacyExport.exportCta')}
+            accessibilityRole="button"
+          >
+            {state.kind === 'preparing'
+              ? t('privacyExport.preparing')
+              : t('privacyExport.exportCta')}
+          </Button>
+
+          {state.kind === 'error' ? (
+            <Text color="$red10" accessibilityLiveRegion="polite">
+              {t(state.messageKey)}
+            </Text>
+          ) : null}
+
+          {state.kind === 'ready' ? (
+            <YStack gap="$3">
+              <Text color="$green10">{t('privacyExport.readyMessage')}</Text>
+              <XStack gap="$2" flexWrap="wrap">
+                <Button
+                  onPress={() => {
+                    void handleShare(state.uri);
+                  }}
+                  accessibilityRole="button"
+                >
+                  {t('privacyExport.shareCta')}
+                </Button>
+              </XStack>
+              <Text fontSize="$1" color="$color10" selectable>
+                {t('privacyExport.archiveHashLabel')}
+                {': '}
+                {state.archiveHash}
+              </Text>
+              <Text color={state.audit === 'synced' ? '$color10' : '$orange10'}>
+                {state.audit === 'synced'
+                  ? t('privacyExport.auditNotice')
+                  : t('privacyExport.auditFailed')}
+              </Text>
+            </YStack>
+          ) : null}
+        </YStack>
+      </Card>
+
+      <Text fontSize="$2" color="$color9">
+        {t('privacyExport.disclaimer')}
+      </Text>
+      <Text fontSize="$2" color="$color9">
+        {t('privacyExport.signedLinkComingSoon')}
+      </Text>
+    </YStack>
+  );
+}
+
+function buildLookup(
+  doc: KinhaleDoc,
+): (doseId: string) => { pumpId: string; caregiverId: string; dosesAdministered: number } | null {
+  const map = new Map<string, { pumpId: string; caregiverId: string; dosesAdministered: number }>();
+  for (const d of projectDoses(doc)) {
+    map.set(d.doseId, {
+      pumpId: d.pumpId,
+      caregiverId: d.caregiverId,
+      dosesAdministered: d.dosesAdministered,
+    });
+  }
+  return (doseId: string) => map.get(doseId) ?? null;
+}

--- a/apps/mobile/src/lib/privacy/export-client.ts
+++ b/apps/mobile/src/lib/privacy/export-client.ts
@@ -1,0 +1,58 @@
+/**
+ * Client mobile pour l'export de portabilité RGPD/Loi 25 (KIN-085, ADR-D14).
+ *
+ * Pendant mobile de `apps/web/src/lib/privacy/export-client.ts`. Mêmes
+ * sémantiques zero-knowledge — diffère uniquement sur la lecture de la
+ * variable d'env `EXPO_PUBLIC_API_URL` au lieu de `NEXT_PUBLIC_API_URL`.
+ */
+
+import type { RelayExportMetadata } from '@kinhale/reports';
+import { ApiError } from '../api-client';
+import { useAuthStore } from '../../stores/auth-store';
+
+const API_BASE = process.env['EXPO_PUBLIC_API_URL'] ?? 'http://localhost:3001';
+
+export async function getPrivacyExportMetadata(): Promise<RelayExportMetadata> {
+  const token = useAuthStore.getState().accessToken;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token !== null) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`${API_BASE}/me/privacy/export/metadata`, {
+    method: 'GET',
+    headers,
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    throw new ApiError(
+      res.status,
+      typeof body['error'] === 'string' ? body['error'] : 'metadata_failed',
+    );
+  }
+  return (await res.json()) as RelayExportMetadata;
+}
+
+export interface PrivacyExportAuditPayload {
+  readonly archiveHash: string;
+  readonly generatedAtMs: number;
+}
+
+export async function postPrivacyExportAudit(payload: PrivacyExportAuditPayload): Promise<void> {
+  const token = useAuthStore.getState().accessToken;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token !== null) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`${API_BASE}/audit/privacy-export`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    throw new ApiError(
+      res.status,
+      typeof body['error'] === 'string' ? body['error'] : 'audit_failed',
+    );
+  }
+}

--- a/apps/web/src/app/settings/privacy/page.tsx
+++ b/apps/web/src/app/settings/privacy/page.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { YStack, XStack, H1, H2, Text, Button, Card } from 'tamagui';
+import {
+  aggregateReportData,
+  buildCsvDoses,
+  buildPrivacyArchive,
+  buildReportStrings,
+  generateMedicalCsv,
+  generateMedicalReport,
+  serializeDocForExport,
+  type RelayExportMetadata,
+} from '@kinhale/reports';
+import { projectDoses } from '@kinhale/sync';
+import { useRequireAuth } from '../../../lib/useRequireAuth';
+import { useDocStore } from '../../../stores/doc-store';
+import { useAuthStore } from '../../../stores/auth-store';
+import { ApiError } from '../../../lib/api-client';
+import {
+  getPrivacyExportMetadata,
+  postPrivacyExportAudit,
+} from '../../../lib/privacy/export-client';
+
+const GENERATOR_LABEL = `Kinhale ${process.env['NEXT_PUBLIC_APP_VERSION'] ?? 'v1.0.0-preview'}`;
+
+type UiState =
+  | { kind: 'idle' }
+  | { kind: 'preparing' }
+  | {
+      kind: 'ready';
+      blobUrl: string;
+      filename: string;
+      archiveHash: string;
+      audit: 'synced' | 'pending';
+    }
+  | { kind: 'error'; messageKey: string };
+
+/**
+ * Écran « Paramètres → Confidentialité » — KIN-085, E9-S02, ADR-D14.
+ *
+ * Permet à l'utilisateur d'exercer son droit à la portabilité (RGPD art. 20,
+ * Loi 25 art. 30). L'archive ZIP est entièrement générée côté client :
+ * - sérialisation déterministe du doc Automerge local,
+ * - rapport HTML + CSV produits via `@kinhale/reports`,
+ * - métadonnées non-santé fetchées via `GET /me/privacy/export/metadata`,
+ * - README.txt bilingue avec hashes SHA-256 individuels (intégrité vérifiable).
+ *
+ * Le relais ne voit jamais le contenu — seul un hash global est posté à
+ * `POST /audit/privacy-export` pour la traçabilité conformité.
+ */
+export default function PrivacyExportPage(): React.JSX.Element | null {
+  const { t } = useTranslation('common');
+  const authenticated = useRequireAuth();
+  const householdId = useAuthStore((s) => s.householdId);
+  const doc = useDocStore((s) => s.doc);
+  const initDoc = useDocStore((s) => s.initDoc);
+  const [state, setState] = React.useState<UiState>({ kind: 'idle' });
+
+  React.useEffect(() => {
+    if (authenticated && householdId !== null) {
+      void initDoc(householdId);
+    }
+  }, [authenticated, householdId, initDoc]);
+
+  React.useEffect(
+    () => (): void => {
+      setState((prev) => {
+        if (prev.kind === 'ready') {
+          URL.revokeObjectURL(prev.blobUrl);
+        }
+        return prev;
+      });
+    },
+    [],
+  );
+
+  const handleExport = async (): Promise<void> => {
+    if (doc === null) {
+      setState({ kind: 'error', messageKey: 'privacyExport.errors.notReady' });
+      return;
+    }
+
+    setState((prev) => {
+      if (prev.kind === 'ready') {
+        URL.revokeObjectURL(prev.blobUrl);
+      }
+      return { kind: 'preparing' };
+    });
+
+    try {
+      const metadata: RelayExportMetadata = await getPrivacyExportMetadata();
+      const now = Date.now();
+
+      // Plage maximum (~24 mois — limite de validateDateRange) pour produire
+      // un rapport HTML / CSV exhaustif. C'est une portabilité, donc tout
+      // le périmètre couvert par les rapports doit y être inclus.
+      const TWO_YEARS_MS = 2 * 365 * 24 * 60 * 60 * 1000;
+      const fullRange = { startMs: now - TWO_YEARS_MS, endMs: now };
+
+      const reportResult = await generateMedicalReport({
+        doc,
+        range: fullRange,
+        strings: buildReportStrings((key, fallback) => t(key, fallback ?? key)),
+        generator: GENERATOR_LABEL,
+        generatedAtMs: now,
+        locale: t('home.title') === 'Kinhale' ? 'fr' : 'en',
+      });
+
+      const reportData = aggregateReportData(doc, fullRange);
+      const lookup = buildLookup(doc);
+      const csvDoses = buildCsvDoses(reportData, lookup);
+      const csv = generateMedicalCsv(csvDoses);
+
+      const serializedDoc = serializeDocForExport(doc, now);
+
+      const archive = await buildPrivacyArchive({
+        serializedDoc,
+        relayMetadata: metadata,
+        reportHtml: reportResult.html,
+        reportCsv: csv,
+        generatedAtMs: now,
+        appVersion: GENERATOR_LABEL,
+      });
+
+      // Rappel : `archive.zipBytes` est un Uint8Array. Le passer dans le
+      // constructeur Blob nécessite de transmettre le buffer ; on évite la
+      // copie en passant la vue directement (le constructeur Blob l'accepte).
+      const blob = new Blob([archive.zipBytes.buffer as ArrayBuffer], {
+        type: 'application/zip',
+      });
+      const blobUrl = URL.createObjectURL(blob);
+
+      const iso = new Date(now).toISOString().slice(0, 10);
+      const filename = `kinhale-privacy-export-${iso}.zip`;
+
+      // Audit best-effort — l'archive est déjà disponible côté client.
+      let auditStatus: 'synced' | 'pending' = 'synced';
+      try {
+        await postPrivacyExportAudit({
+          archiveHash: archive.archiveHash,
+          generatedAtMs: now,
+        });
+      } catch (err) {
+        if (err instanceof ApiError || err instanceof TypeError) {
+          auditStatus = 'pending';
+        } else {
+          throw err;
+        }
+      }
+
+      setState({
+        kind: 'ready',
+        blobUrl,
+        filename,
+        archiveHash: archive.archiveHash,
+        audit: auditStatus,
+      });
+    } catch (err) {
+      // On distingue les erreurs metadata réseau (ApiError) des erreurs
+      // pipeline (généralement crypto / WebCrypto). La granularité du
+      // message i18n reste générique pour ne pas leak d'info technique.
+      if (err instanceof ApiError) {
+        setState({ kind: 'error', messageKey: 'privacyExport.errors.metadataFailed' });
+      } else {
+        setState({ kind: 'error', messageKey: 'privacyExport.errors.generationFailed' });
+      }
+    }
+  };
+
+  const triggerDownload = (blobUrl: string, filename: string): void => {
+    const a = document.createElement('a');
+    a.href = blobUrl;
+    a.download = filename;
+    a.style.display = 'none';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  };
+
+  const triggerSystemShare = async (blobUrl: string, filename: string): Promise<void> => {
+    const blob = await fetch(blobUrl).then((r) => r.blob());
+    const file = new File([blob], filename, { type: 'application/zip' });
+    const nav = navigator as Navigator & {
+      canShare?: (data: { files?: File[] }) => boolean;
+      share?: (data: { files?: File[]; title?: string; text?: string }) => Promise<void>;
+    };
+    if (typeof nav.share === 'function' && nav.canShare?.({ files: [file] }) === true) {
+      try {
+        await nav.share({ files: [file], title: t('privacyExport.title') });
+      } catch {
+        // L'utilisateur a annulé — pas d'action supplémentaire.
+      }
+      return;
+    }
+    triggerDownload(blobUrl, filename);
+  };
+
+  if (!authenticated) return null;
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1>{t('privacyExport.title')}</H1>
+      <Text>{t('privacyExport.description')}</Text>
+
+      <Card padded bordered>
+        <YStack gap="$3">
+          <H2>{t('privacyExport.sectionTitle')}</H2>
+          <Text fontSize="$2">{t('privacyExport.contents')}</Text>
+
+          <Button
+            onPress={() => {
+              void handleExport();
+            }}
+            disabled={state.kind === 'preparing' || doc === null}
+            accessibilityLabel={t('privacyExport.exportCta')}
+          >
+            {state.kind === 'preparing'
+              ? t('privacyExport.preparing')
+              : t('privacyExport.exportCta')}
+          </Button>
+
+          {state.kind === 'error' ? (
+            <Text color="$red10" accessibilityLiveRegion="polite">
+              {t(state.messageKey)}
+            </Text>
+          ) : null}
+
+          {state.kind === 'ready' ? (
+            <YStack gap="$3">
+              <Text color="$green10">{t('privacyExport.readyMessage')}</Text>
+              <XStack gap="$2" flexWrap="wrap">
+                <Button onPress={() => triggerDownload(state.blobUrl, state.filename)}>
+                  {t('privacyExport.downloadCta')}
+                </Button>
+                <Button
+                  onPress={() => {
+                    void triggerSystemShare(state.blobUrl, state.filename);
+                  }}
+                >
+                  {t('privacyExport.shareCta')}
+                </Button>
+              </XStack>
+              <Text fontSize="$1" color="$color10" selectable>
+                {t('privacyExport.archiveHashLabel')}
+                {': '}
+                {state.archiveHash}
+              </Text>
+              <Text color={state.audit === 'synced' ? '$color10' : '$orange10'}>
+                {state.audit === 'synced'
+                  ? t('privacyExport.auditNotice')
+                  : t('privacyExport.auditFailed')}
+              </Text>
+            </YStack>
+          ) : null}
+        </YStack>
+      </Card>
+
+      <Text fontSize="$2" color="$color9">
+        {t('privacyExport.disclaimer')}
+      </Text>
+      <Text fontSize="$2" color="$color9">
+        {t('privacyExport.signedLinkComingSoon')}
+      </Text>
+    </YStack>
+  );
+}
+
+function buildLookup(
+  doc: Parameters<typeof projectDoses>[0],
+): (doseId: string) => { pumpId: string; caregiverId: string; dosesAdministered: number } | null {
+  const map = new Map<string, { pumpId: string; caregiverId: string; dosesAdministered: number }>();
+  for (const d of projectDoses(doc)) {
+    map.set(d.doseId, {
+      pumpId: d.pumpId,
+      caregiverId: d.caregiverId,
+      dosesAdministered: d.dosesAdministered,
+    });
+  }
+  return (doseId: string) => map.get(doseId) ?? null;
+}

--- a/apps/web/src/lib/privacy/__tests__/export-client.test.ts
+++ b/apps/web/src/lib/privacy/__tests__/export-client.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @jest-environment jsdom
+ */
+import { getPrivacyExportMetadata, postPrivacyExportAudit } from '../export-client';
+import { useAuthStore } from '../../../stores/auth-store';
+import { ApiError } from '../../api-client';
+
+describe('getPrivacyExportMetadata', () => {
+  const fetchMock = jest.fn();
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    useAuthStore.setState({
+      accessToken: 'test-token',
+      deviceId: 'dev-1',
+      householdId: 'hh-1',
+    });
+  });
+
+  afterAll(() => {
+    global.fetch = realFetch;
+  });
+
+  it('émet GET /me/privacy/export/metadata avec Authorization Bearer', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        accountId: 'acc-1',
+        exportedAtMs: 123,
+        devices: [],
+        auditEvents: [],
+        notificationPreferences: [],
+        quietHours: null,
+        pushTokensCount: 0,
+      }),
+    });
+    const md = await getPrivacyExportMetadata();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/me/privacy/export/metadata');
+    expect(init.method).toBe('GET');
+    expect((init.headers as Record<string, string>)['Authorization']).toBe('Bearer test-token');
+    expect(md.accountId).toBe('acc-1');
+  });
+
+  it('relève une ApiError sur 401', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'unauthorized' }),
+    });
+    await expect(getPrivacyExportMetadata()).rejects.toBeInstanceOf(ApiError);
+  });
+
+  it('relève une ApiError sur 429 (rate-limit)', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 429,
+      json: async () => ({ error: 'rate_limited' }),
+    });
+    await expect(getPrivacyExportMetadata()).rejects.toMatchObject({
+      status: 429,
+    });
+  });
+});
+
+describe('postPrivacyExportAudit', () => {
+  const fetchMock = jest.fn();
+  const realFetch = global.fetch;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    useAuthStore.setState({
+      accessToken: 'test-token',
+      deviceId: 'dev-1',
+      householdId: 'hh-1',
+    });
+  });
+
+  afterAll(() => {
+    global.fetch = realFetch;
+  });
+
+  it('émet POST /audit/privacy-export avec un body strictement minimal', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ ok: true }),
+    });
+    await postPrivacyExportAudit({
+      archiveHash: 'a'.repeat(64),
+      generatedAtMs: 1_700_000_000_000,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('/audit/privacy-export');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({
+      archiveHash: 'a'.repeat(64),
+      generatedAtMs: 1_700_000_000_000,
+    });
+    // Aucun champ santé
+    expect(Object.keys(body)).toEqual(['archiveHash', 'generatedAtMs']);
+  });
+
+  it('ne contient JAMAIS de donnée santé dans le body', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ ok: true }),
+    });
+    await postPrivacyExportAudit({
+      archiveHash: 'b'.repeat(64),
+      generatedAtMs: 1_700_000_000_000,
+    });
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const bodyStr = init.body as string;
+    const forbidden = ['childName', 'pumpName', 'symptom', 'firstName', 'birthYear'];
+    for (const w of forbidden) {
+      expect(bodyStr).not.toContain(w);
+    }
+  });
+
+  it('relève une ApiError sur 4xx', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({ error: 'invalid_body' }),
+    });
+    await expect(
+      postPrivacyExportAudit({
+        archiveHash: 'a'.repeat(64),
+        generatedAtMs: 1,
+      }),
+    ).rejects.toBeInstanceOf(ApiError);
+  });
+});

--- a/apps/web/src/lib/privacy/export-client.ts
+++ b/apps/web/src/lib/privacy/export-client.ts
@@ -1,0 +1,78 @@
+/**
+ * Client web pour l'export de portabilité RGPD/Loi 25 (KIN-085, ADR-D14).
+ *
+ * Encapsule deux appels HTTP au relais :
+ * - `GET /me/privacy/export/metadata` : récupère les métadonnées non-santé
+ *   du compte courant (devices, audit events, prefs, quiet hours, push tokens
+ *   count). Aucune donnée santé n'est jamais retournée par cet endpoint.
+ * - `POST /audit/privacy-export` : trace la génération côté audit. Best-effort.
+ *
+ * Les types retournés sont alignés sur `RelayExportMetadata` du package
+ * `@kinhale/reports` — toute désynchronisation déclenche une erreur de
+ * compilation côté `apps/web`.
+ */
+
+import type { RelayExportMetadata } from '@kinhale/reports';
+import { ApiError } from '../api-client';
+import { useAuthStore } from '../../stores/auth-store';
+
+const API_BASE = process.env['NEXT_PUBLIC_API_URL'] ?? 'http://localhost:3001';
+
+/**
+ * Fetche les métadonnées relais — JWT obligatoire (filtre `WHERE accountId =
+ * sub`). En cas de 401/429/5xx, l'erreur remonte à l'appelant qui peut
+ * afficher un message i18n adéquat.
+ */
+export async function getPrivacyExportMetadata(): Promise<RelayExportMetadata> {
+  const token = useAuthStore.getState().accessToken;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token !== null) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`${API_BASE}/me/privacy/export/metadata`, {
+    method: 'GET',
+    headers,
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    throw new ApiError(
+      res.status,
+      typeof body['error'] === 'string' ? body['error'] : 'metadata_failed',
+    );
+  }
+  return (await res.json()) as RelayExportMetadata;
+}
+
+export interface PrivacyExportAuditPayload {
+  readonly archiveHash: string;
+  readonly generatedAtMs: number;
+}
+
+/**
+ * Trace côté backend la génération locale d'une archive RGPD/Loi 25.
+ *
+ * **Best-effort** : si l'audit échoue (network, rate-limit), l'archive est
+ * déjà sur le device de l'utilisateur — on ne bloque pas l'UX. L'appelant
+ * affiche un message non bloquant.
+ *
+ * **Zero-knowledge** : le payload ne contient AUCUNE donnée santé.
+ */
+export async function postPrivacyExportAudit(payload: PrivacyExportAuditPayload): Promise<void> {
+  const token = useAuthStore.getState().accessToken;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token !== null) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`${API_BASE}/audit/privacy-export`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    throw new ApiError(
+      res.status,
+      typeof body['error'] === 'string' ? body['error'] : 'audit_failed',
+    );
+  }
+}

--- a/docs/architecture/adr/ADR-D14-privacy-export-v1.md
+++ b/docs/architecture/adr/ADR-D14-privacy-export-v1.md
@@ -1,0 +1,166 @@
+# ADR-D14 — Export de portabilité RGPD / Loi 25 v1.0 : archive ZIP générée client-side
+
+**Date** : 2026-04-24
+**Statut** : Accepté
+**Décideurs** : Martial Kaljob (Kamez Conseils)
+
+## Contexte
+
+L'épopée E9 (« Conformité ») du backlog Kinhale couvre l'exercice par l'utilisateur de ses droits RGPD (art. 15 — accès, art. 17 — effacement, art. 20 — **portabilité**) et Loi 25 (art. 27 — accès, art. 28 — rectification, **art. 30 — portabilité**, art. 28.1 — désindexation). La story E9-S02 — « Export de portabilité à la demande » — exige une archive complète CSV + PDF des données de l'utilisateur, livrable « à la demande », avec un SLA réglementaire **≤ 30 jours**.
+
+Le brouillon initial de la story ainsi que les specs §7.2 mentionnent un endpoint `POST /privacy/export` qui produirait l'archive et l'enverrait par e-mail sécurisé via lien signé 7 j (`Critères : E-mail sécurisé + lien signé 7 j`). Cette conception **viole directement** le principe non négociable de zero-knowledge (CLAUDE.md §Principes §1) :
+
+> Aucune donnée santé en clair ne doit jamais quitter les appareils des utilisateurs. Le relais Kamez ne voit que des blobs chiffrés opaques.
+
+Une archive de portabilité CSV + PDF générée côté serveur exigerait que le doc Automerge soit déchiffrable par le relais — donc que la `groupKey` du foyer soit confiée à Kamez. La promesse différenciante du produit (« même nous, les créateurs, ne pouvons pas lire les données de votre enfant ») serait détruite, l'AGPL self-hosting deviendrait dangereuse (image Docker compromise = fuite immédiate), et la base légale Loi 25 / RGPD passerait du modèle « éditeur de logiciel » au modèle « hébergeur de données de santé » — qui exige hébergement HDS (France) ou agrément RPRP renforcé (Québec).
+
+L'**ADR-D12** a déjà acté ce pivot pour le rapport médecin (E8) : génération HTML/PDF 100 % client-side. L'**ADR-D13** a prolongé ce pivot pour le partage du rapport (E8-S04) : download + share sheet OS en v1.0, lien signé 7 j (pattern wormhole) reporté en v1.1. **Cet ADR applique le même raisonnement à l'export de portabilité.**
+
+Le défi spécifique de E9-S02 est la **complétude** de l'export : la portabilité RGPD/Loi 25 ne couvre pas seulement le journal médecin, elle couvre **toutes** les données personnelles que le responsable de traitement détient sur l'utilisateur. Cela inclut :
+
+1. **Données santé** (doc Automerge E2EE local) — projections doses, symptômes, pompes, plan, enfant, aidants. Ces données ne sont **jamais** vues en clair par le relais — seul le device de l'utilisateur peut les exporter.
+2. **Métadonnées relais** qui concernent l'utilisateur — devices enregistrés, audit events `report_generated` / `report_shared`, préférences de notifications, quiet hours, comptage de push tokens. Ces métadonnées ne contiennent pas de données santé (cf. ADR-D12 §Audit trail) mais constituent bien des données personnelles au sens RGPD/Loi 25, et entrent donc dans la portabilité.
+
+Les `mailbox_messages` ne sont **pas** inclus : le contenu est chiffré opaque et n'est pas attribuable individuellement à l'utilisateur (ils sont indexés par `householdId`, pas par `accountId` ; ils sont de toute façon déjà restitués via le doc Automerge synchronisé).
+
+## Options évaluées
+
+### Option A — Export entièrement server-side avec lien signé 7 j (rejetée — viole zero-knowledge)
+
+**Description** : endpoint `POST /privacy/export` qui :
+1. Récupère le doc Automerge déchiffré côté relais (impose une nouvelle architecture où le relais détient la groupKey).
+2. Agrège les métadonnées relais.
+3. Génère le ZIP côté serveur.
+4. Push sur S3 avec ACL signée 7 j.
+5. Envoie un e-mail au RPRP de l'utilisateur avec le lien.
+
+**Avantages** :
+- Conformité « par défaut » au libellé brut de la story E9-S02.
+- UX asynchrone (l'utilisateur n'a pas besoin d'être sur son device).
+- Compatible « sortie de l'écosystème » (l'utilisateur peut récupérer ses données même sans accès à son device, en cliquant le lien e-mail).
+
+**Inconvénients rédhibitoires** :
+- **Violation directe zero-knowledge** (CLAUDE.md §Principes §1) : envoyer au relais le doc déchiffré ou un ZIP en clair = casse la promesse produit. Incident P0 de confiance.
+- **Viol du contrat AGPL** : un self-hoster malveillant ou compromis pourrait lire toutes les données santé.
+- **Hébergement HDS / RPRP requis** : traiter des données santé côté serveur exige un agrément. Hors budget v1.0.
+- **Surface d'attaque énorme** : pipeline ZIP + S3 + worker purge + signature CloudFront. ~5 j de dev + audit crypto externe.
+
+**Risques** :
+- Perte irréversible de la valeur produit. Reputation damage.
+
+### Option B — Export client-side avec archive téléchargée + share sheet OS (retenue)
+
+**Description** : l'écran « Paramètres → Confidentialité » expose un bouton « Exporter mes données (RGPD / Loi 25) ». Le pipeline est :
+
+1. **Fetch des métadonnées relais** via un nouvel endpoint authentifié `GET /me/privacy/export/metadata` :
+   - Authz : `sub` du JWT scope strictement les résultats à l'utilisateur courant.
+   - Rate-limit Redis : 5/h/device (action rare).
+   - Retourne uniquement les données qui concernent l'utilisateur courant : devices, audit events `report_generated` / `report_shared`, notification preferences, quiet hours, comptage push tokens. **Pas** d'identifiants d'autres utilisateurs.
+   - Aucune donnée santé.
+2. **Sérialisation déterministe** du doc Automerge local via `@kinhale/reports/privacy-export/serialize-doc.ts` → JSON plat `{doses, symptoms, pumps, plans, children, caregivers}` (utilise les projections existantes `projectDoses`, `projectPumps`, etc.).
+3. **Génération CSV** complet via `@kinhale/reports.generateMedicalCsv` (réutilise E8-S03) avec une plage maximum (24 mois — limite déjà imposée par `validateDateRange`).
+4. **Génération HTML** rapport complet via `@kinhale/reports.generateMedicalReport` avec la même plage maximum, sans filtre médecin (toutes les prises, y compris `pending_review`).
+5. **Calcul des hashes SHA-256** (`@kinhale/crypto.sha256HexFromString`) de chaque fichier individuel pour l'intégrité.
+6. **Construction du `README.txt`** bilingue FR/EN avec :
+   - Disclaimer non-DM (RM27).
+   - Liste des fichiers de l'archive avec leur hash SHA-256 individuel.
+   - Date d'export, version Kinhale, accountId pseudonymisé.
+   - Note explicite « Le relais Kamez n'a jamais accès à vos données santé. Cette archive a été produite intégralement sur votre appareil. »
+7. **Construction du ZIP** via `fflate` (pure JS, ~12 KB minified, MIT license, fonctionne web + RN sans natif). Pas de compression — `STORE` mode (pas besoin pour des données santé déjà compactes).
+8. **Download / Share** :
+   - Web : `Blob` + `URL.createObjectURL` + `<a download>` ou `navigator.share({ files: [...] })`.
+   - Mobile : `FileSystem.writeAsStringAsync` (base64) + `Sharing.shareAsync` + purge à l'unmount.
+9. **Audit trail** : `POST /audit/privacy-export` (nouveau endpoint, pattern strict identique à `/audit/report-generated`) avec `{archiveHash, generatedAtMs}`.
+
+**Avantages** :
+- **Zero-knowledge préservé strictement** : aucune donnée santé ne quitte le device. Le seul aller-retour réseau est le fetch de métadonnées non-santé scope-isolées par JWT, et un audit minimaliste.
+- **SLA ≤ 30 j respecté trivialement** : l'export est **quasi-instantané** (pipeline pur sur device, < 10 s pour un foyer médian).
+- **Aucune infra serveur ajoutée** : pas de S3, pas de CloudFront, pas de worker purge. La table `audit_events` existante (ADR-D12) accueille un nouveau `event_type = 'privacy_export'` sans migration de schéma.
+- **Compatible AGPL self-hosting** : un self-hoster ne peut pas intercepter l'archive.
+- **Déterministe et testable** : sérialisation pure, hashes reproductibles, tests Vitest sans moteur de rendu.
+- **Conforme RGPD art. 20 / Loi 25 art. 30** : « format structuré, couramment utilisé et lisible par machine » — JSON + CSV + texte FR/EN cochent les trois.
+
+**Inconvénients / dette acceptée** :
+- **Pas d'envoi asynchrone par e-mail** : l'utilisateur doit être sur son device pour exporter. Acceptable car (a) l'app a déjà la contrainte « device requis » pour toutes les fonctions critiques, (b) la share sheet OS permet de transférer l'archive vers n'importe quel client / cloud personnel.
+- **Pas de lien signé 7 j en v1.0** : reporté en v1.1 via un pattern wormhole équivalent à celui du rapport médecin (futur ADR-D15). Issue de suivi `[v1.1] KIN-XXX` ouverte à la création de cet ADR.
+- **Limite de mémoire navigateur** : un foyer extrême avec 24 mois × ~10 prises/jour ≈ 7 000 prises génère un ZIP de l'ordre de 1-2 MB. Largement dans les capacités d'un device moderne.
+- **`fflate` est une dépendance ajoutée au monorepo**. Auditée en kz-securite, MIT, sans deps transitives, ~12 KB minified, gérée par 1 mainteneur actif (101bytes). Risque acceptable pour un usage isolé (pas de chemin critique de sécurité). Vendoring envisageable si le mainteneur disparaît.
+
+### Option C — Export client-side via fragment-as-key wormhole (reporté en v1.1)
+
+**Description** : même pipeline que B mais l'archive est aussi uploadée chiffrée vers le relais et accessible via lien `https://kinhale.health/privacy/:id#key=...`. Le tiers (RPRP du compte) peut ainsi récupérer ses données depuis un autre device en cliquant un lien e-mail.
+
+**Avantages** :
+- Couvre le cas « je veux exporter mais je n'ai pas mon device principal sous la main ».
+- Compatible zero-knowledge si le chiffrement client-side est correct (cf. ADR-D13 wormhole).
+
+**Inconvénients pour v1.0** :
+- Coût ingénierie 2-3 j (pipeline upload chiffré, page web publique, worker purge, audit crypto externe).
+- Pattern à mutualiser avec le wormhole rapport médecin (E8-S04 v1.1) — refactoring nécessaire.
+- Surface d'attaque élargie sans nécessité v1.0 (l'utilisateur peut exporter depuis son device principal et envoyer l'archive par e-mail manuellement).
+
+**Décision** : reporté en v1.1, ADR-D15 dédié à rédiger en même temps que la mutualisation rapport / privacy export wormhole.
+
+## Critères de décision
+
+1. **Conformité zero-knowledge** (CLAUDE.md §1) : priorité absolue. Élimine A.
+2. **Conformité RGPD art. 20 / Loi 25 art. 30** : format structuré + couramment utilisé + lisible par machine — JSON, CSV, texte cochent.
+3. **SLA ≤ 30 j** : trivial dans B et C (export quasi-instantané sur device).
+4. **Coût v1.0** : la v1.0 est cadrée à 13 semaines / ~260 k$. B = 1-1.5 j, C = +2-3 j. B livre la valeur RGPD/Loi 25 dans le budget.
+5. **Compatible AGPL self-hosting** : élimine A.
+6. **Anti-DM (RM8, RM27)** : l'export contient les données brutes telles que saisies par les aidants — aucune interprétation médicale, aucune recommandation. Vérifié par tests.
+
+## Décision
+
+**Choix retenu : Option B — Export client-side avec archive ZIP téléchargée + share sheet OS en v1.0. Le mode wormhole (lien signé 7 j) est reporté en v1.1 via un ticket de suivi dédié et un futur ADR-D15.**
+
+L'ADR-D14 acte que :
+- Le relais ne voit jamais le contenu santé exporté.
+- L'archive est strictement reproductible depuis (doc Automerge local + métadonnées relais à un instant `t`).
+- L'utilisateur **doit** être sur son device pour exporter (acceptable cf. discovery UX).
+- Le SLA réglementaire ≤ 30 j est respecté trivialement (~secondes).
+
+## Conséquences
+
+**Positives** :
+- Zero-knowledge préservé strictement. Aucune nouvelle infra serveur.
+- Architecture cohérente avec ADR-D12 et ADR-D13 (même pivot, mêmes patterns).
+- Audit trail pour `privacy_export` mutualisé avec la table `audit_events` existante (réutilise la migration 0003 sans changement DB).
+- Tests : pipeline pur sérialisation → hash → ZIP testable à 100 % en Vitest Node.
+- Pas de DPIA ajouté (pas de nouveau traitement — un nouveau droit utilisateur exercé).
+- Compatible self-hosting AGPL : un tiers hébergeur ne peut rien intercepter.
+
+**Négatives / dette acceptée** :
+- Pas de lien signé 7 j en v1.0 (reporté v1.1 via issue dédiée — engagement contractuel).
+- L'utilisateur doit être sur son device. Si son device est perdu / volé, il doit d'abord restaurer son compte (recovery seed) puis exporter.
+- Dépendance `fflate` ajoutée au monorepo. Auditée et minimaliste, mais à surveiller pour les CVE.
+
+**Plan d'implémentation (KIN-085)** :
+- `packages/reports/src/privacy-export/serialize-doc.ts` : `serializeDocForExport(doc) → SerializedDoc`. Utilise les projections existantes (`projectDoses`, `projectPumps`, `projectChild`, `projectPlan`, `projectCaregivers`) pour produire un JSON plat déterministe.
+- `packages/reports/src/privacy-export/build-readme.ts` : `buildPrivacyReadme({metadata, hashes, locale, generatedAtMs}) → string`. README.txt bilingue FR + EN avec disclaimer + hashes individuels.
+- `packages/reports/src/privacy-export/build-archive.ts` : `buildPrivacyArchive(args) → Promise<Uint8Array>`. Pipeline orchestrateur : sérialise → hash → README → ZIP via `fflate.zipSync`.
+- `packages/reports/src/privacy-export/types.ts` : interfaces partagées (`RelayExportMetadata`, `BuildArchiveArgs`, `BuildArchiveResult`).
+- `apps/api/src/routes/privacy.ts` : `GET /me/privacy/export/metadata` (authz strict par sub JWT, rate-limit 5/h, retourne uniquement les données scope-isolées).
+- `apps/api/src/routes/audit.ts` : ajout `POST /audit/privacy-export` (Zod `.strict()`, rate-limit 5/h/device).
+- `apps/web/src/app/settings/privacy/page.tsx` : écran Tamagui (bouton « Exporter », état loading, hash de vérif affiché).
+- `apps/web/src/lib/privacy/export-client.ts` : fetch metadata + post audit.
+- `apps/mobile/app/settings/privacy.tsx` : écran symétrique mobile.
+- `apps/mobile/src/lib/privacy/export-client.ts` : pendant mobile.
+- `packages/i18n/src/locales/{fr,en}/common.json` : sous-arbre `privacyExport.*` (~25 clés).
+- Tests Vitest exhaustifs sur le package + tests Fastify sur la route metadata + tests Jest snippets sur les écrans.
+
+**Points à tracer (follow-ups)** :
+- **`[v1.1] KIN-XXX` (à ouvrir)** : « Privacy export par e-mail via wormhole ». Mutualise le pattern fragment-as-key avec le rapport médecin (ADR-D15 à rédiger).
+- **kz-conformite** : valider le contenu du `README.txt` côté formulation juridique avant publication v1.0 (issue de suivi).
+- **Test e2e Maestro / Playwright** sur le parcours complet « Settings → Confidentialité → Export → Téléchargement » (à ajouter en E9-S02-followup ou dans la passe e2e finale du sprint J6).
+
+## Statut futur
+
+ADR **Accepté** pour la v1.0. Revue prévue à l'ouverture de la story v1.1 wormhole — ADR-D15 mutualisera privacy + report sharing dans un seul pattern fragment-as-key.
+
+## Révision prévue
+
+Revue obligatoire si :
+1. Un audit conformité externe (RPRP / DPO sous-traitance) identifie un champ manquant dans l'archive (ex. logs d'authentification détaillés). Réponse probable : ajouter le champ au endpoint `/me/privacy/export/metadata` sans changer l'architecture.
+2. Un nouveau type d'événement `eventType` est ajouté à `audit_events` qui doit aussi entrer dans la portabilité.
+3. Un incident de sécurité dans `fflate` impose un changement de dépendance (fallback : `pako` ou vendoring d'un mini ZIP `STORE`).

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -290,5 +290,27 @@
     "loadError": "Could not load quiet hours.",
     "invalidFormat": "Invalid format. Use HH:MM (e.g. 22:00).",
     "safetyNote": "Missed-dose notifications are still delivered even during quiet hours (safety rule)."
+  },
+  "privacyExport": {
+    "title": "Export my data",
+    "description": "Exercise your right to data portability (GDPR art. 20 / Quebec Law 25 art. 30). The ZIP archive is generated entirely on your device — the Kinhale server never sees your health data.",
+    "sectionTitle": "Portability archive",
+    "contents": "The archive contains: the full journal of doses (JSON + CSV), a printable HTML report, the technical metadata of your account (devices, audit trail, preferences), and a bilingual README with SHA-256 integrity hashes.",
+    "exportCta": "Export my data (GDPR / Law 25)",
+    "preparing": "Preparing archive…",
+    "readyMessage": "Archive ready. Download or share it from your device.",
+    "downloadCta": "Download archive",
+    "shareCta": "Share archive",
+    "shareUnavailable": "System sharing is not available. Use the Download button.",
+    "archiveHashLabel": "Integrity hash (SHA-256)",
+    "auditNotice": "The export is logged locally. Only a hash and a timestamp are sent to the server (no health data).",
+    "auditFailed": "Archive generated locally. Audit synchronization pending connection.",
+    "disclaimer": "Kinhale is a tracking and coordination tool. This archive contains no medical interpretation, no dose recommendation, no diagnosis.",
+    "signedLinkComingSoon": "Sending the archive by email via signed link will be available in v1.1.",
+    "errors": {
+      "notReady": "Your data is not yet loaded. Try again in a few seconds.",
+      "metadataFailed": "Could not retrieve metadata from the server. Check your connection.",
+      "generationFailed": "Could not generate the archive. Please try again."
+    }
   }
 }

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -290,5 +290,27 @@
     "loadError": "Impossible de charger les heures silencieuses.",
     "invalidFormat": "Format invalide. Utilisez HH:MM (ex. 22:00).",
     "safetyNote": "Les notifications de dose manquée restent émises, même pendant les heures silencieuses (règle de sécurité)."
+  },
+  "privacyExport": {
+    "title": "Exporter mes données",
+    "description": "Exercez votre droit à la portabilité (RGPD art. 20 / Loi 25 art. 30). L'archive ZIP est générée intégralement sur votre appareil — le serveur Kinhale ne voit jamais vos données santé.",
+    "sectionTitle": "Archive de portabilité",
+    "contents": "L'archive contient : le journal complet des prises (JSON + CSV), un rapport HTML imprimable, les métadonnées techniques de votre compte (devices, audit trail, préférences), un fichier README bilingue avec hashes SHA-256 d'intégrité.",
+    "exportCta": "Exporter mes données (RGPD / Loi 25)",
+    "preparing": "Préparation de l'archive…",
+    "readyMessage": "Archive prête. Téléchargez-la ou partagez-la depuis votre appareil.",
+    "downloadCta": "Télécharger l'archive",
+    "shareCta": "Partager l'archive",
+    "shareUnavailable": "Le partage système n'est pas disponible. Utilisez le bouton Télécharger.",
+    "archiveHashLabel": "Hash d'intégrité (SHA-256)",
+    "auditNotice": "L'export est tracé localement. Seul un hash et un horodatage sont transmis au serveur (aucune donnée santé).",
+    "auditFailed": "Archive générée localement. Synchronisation de l'audit en attente de connexion.",
+    "disclaimer": "Kinhale est un outil de suivi et de coordination. Cette archive ne contient aucune interprétation médicale, aucune recommandation de dose, aucun diagnostic.",
+    "signedLinkComingSoon": "L'envoi de l'archive par e-mail via lien signé sera disponible en v1.1.",
+    "errors": {
+      "notReady": "Vos données ne sont pas encore chargées. Réessayez dans quelques secondes.",
+      "metadataFailed": "Impossible de récupérer les métadonnées du serveur. Vérifiez votre connexion.",
+      "generationFailed": "Impossible de générer l'archive. Réessayez."
+    }
   }
 }

--- a/packages/reports/package.json
+++ b/packages/reports/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "@kinhale/crypto": "workspace:*",
-    "@kinhale/sync": "workspace:*"
+    "@kinhale/sync": "workspace:*",
+    "fflate": "~0.8.2"
   },
   "devDependencies": {
     "@kinhale/eslint-config": "workspace:*",

--- a/packages/reports/src/index.ts
+++ b/packages/reports/src/index.ts
@@ -52,3 +52,23 @@ export {
   escapeCsvValue,
   generateMedicalCsv,
 } from './csv/generate-csv.js';
+
+// Export de portabilité RGPD/Loi 25 (E9-S02, KIN-085, ADR-D14)
+export type {
+  BuildPrivacyArchiveArgs,
+  BuildPrivacyArchiveResult,
+  RelayAuditEventInfo,
+  RelayDeviceInfo,
+  RelayExportMetadata,
+  RelayNotificationPreferenceInfo,
+  RelayQuietHoursInfo,
+  SerializedCaregiver,
+  SerializedChild,
+  SerializedDoc,
+  SerializedDose,
+  SerializedPlan,
+  SerializedPump,
+} from './privacy-export/types.js';
+export { canonicalJsonStringify, serializeDocForExport } from './privacy-export/serialize-doc.js';
+export { buildPrivacyReadme } from './privacy-export/build-readme.js';
+export { PRIVACY_ARCHIVE_FILENAMES, buildPrivacyArchive } from './privacy-export/build-archive.js';

--- a/packages/reports/src/privacy-export/build-archive.test.ts
+++ b/packages/reports/src/privacy-export/build-archive.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import { unzipSync } from 'fflate';
+import { buildPrivacyArchive, PRIVACY_ARCHIVE_FILENAMES } from './build-archive.js';
+import type { BuildPrivacyArchiveArgs, RelayExportMetadata, SerializedDoc } from './types.js';
+
+const FIXED_MS = Date.UTC(2026, 3, 24, 12, 0, 0);
+
+function makeSerializedDoc(): SerializedDoc {
+  return {
+    householdId: 'hh-1',
+    exportedAtMs: FIXED_MS,
+    schemaVersion: 1,
+    child: {
+      childId: 'child-1',
+      firstName: 'Léa',
+      birthYear: 2020,
+      recordedByDeviceId: 'device-A',
+      recordedAtMs: FIXED_MS - 10_000,
+    },
+    caregivers: [],
+    pumps: [],
+    plans: [],
+    doses: [],
+  };
+}
+
+function makeRelayMetadata(): RelayExportMetadata {
+  return {
+    accountId: 'acc-1',
+    exportedAtMs: FIXED_MS,
+    devices: [{ deviceId: 'device-A', registeredAtMs: FIXED_MS - 86_400_000, lastSeenMs: null }],
+    auditEvents: [],
+    notificationPreferences: [],
+    quietHours: null,
+    pushTokensCount: 1,
+  };
+}
+
+function makeArgs(overrides: Partial<BuildPrivacyArchiveArgs> = {}): BuildPrivacyArchiveArgs {
+  return {
+    serializedDoc: makeSerializedDoc(),
+    relayMetadata: makeRelayMetadata(),
+    reportHtml: '<html><body>report</body></html>',
+    reportCsv: 'col1,col2\nval1,val2\n',
+    generatedAtMs: FIXED_MS,
+    appVersion: 'v1.0.0-test',
+    ...overrides,
+  };
+}
+
+describe('buildPrivacyArchive', () => {
+  it('produit un ZIP qui contient les 5 fichiers attendus', async () => {
+    const result = await buildPrivacyArchive(makeArgs());
+    const unzipped = unzipSync(result.zipBytes);
+    expect(Object.keys(unzipped).sort()).toEqual(
+      [
+        'README.txt',
+        'health-data.csv',
+        'health-data.json',
+        'health-report.html',
+        'relay-metadata.json',
+      ].sort(),
+    );
+  });
+
+  it("renvoie un hash SHA-256 hex 64 chars pour l'archive globale", async () => {
+    const result = await buildPrivacyArchive(makeArgs());
+    expect(result.archiveHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('renvoie un hash SHA-256 par fichier (5 hashes au total)', async () => {
+    const result = await buildPrivacyArchive(makeArgs());
+    expect(Object.keys(result.fileHashes)).toHaveLength(5);
+    for (const hash of Object.values(result.fileHashes)) {
+      expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+
+  it('le ZIP est déterministe pour des inputs identiques (clé de la reproductibilité)', async () => {
+    const a = await buildPrivacyArchive(makeArgs());
+    const b = await buildPrivacyArchive(makeArgs());
+    expect(a.archiveHash).toBe(b.archiveHash);
+    expect(a.fileHashes).toEqual(b.fileHashes);
+  });
+
+  it('le contenu de health-data.json est du JSON canonique parseable', async () => {
+    const result = await buildPrivacyArchive(makeArgs());
+    const unzipped = unzipSync(result.zipBytes);
+    const jsonBytes = unzipped[PRIVACY_ARCHIVE_FILENAMES.healthDataJson];
+    expect(jsonBytes).toBeDefined();
+    const text = new TextDecoder().decode(jsonBytes);
+    const parsed = JSON.parse(text) as { householdId: string };
+    expect(parsed.householdId).toBe('hh-1');
+  });
+
+  it('le contenu de relay-metadata.json est du JSON parseable', async () => {
+    const result = await buildPrivacyArchive(makeArgs());
+    const unzipped = unzipSync(result.zipBytes);
+    const jsonBytes = unzipped[PRIVACY_ARCHIVE_FILENAMES.relayMetadataJson];
+    expect(jsonBytes).toBeDefined();
+    const text = new TextDecoder().decode(jsonBytes);
+    const parsed = JSON.parse(text) as { accountId: string };
+    expect(parsed.accountId).toBe('acc-1');
+  });
+
+  it('le README contient les hashes des 4 autres fichiers (intégrité vérifiable)', async () => {
+    const result = await buildPrivacyArchive(makeArgs());
+    const unzipped = unzipSync(result.zipBytes);
+    const readmeBytes = unzipped[PRIVACY_ARCHIVE_FILENAMES.readme];
+    expect(readmeBytes).toBeDefined();
+    const readme = new TextDecoder().decode(readmeBytes);
+    expect(readme).toContain(result.fileHashes[PRIVACY_ARCHIVE_FILENAMES.healthDataJson]!);
+    expect(readme).toContain(result.fileHashes[PRIVACY_ARCHIVE_FILENAMES.healthDataCsv]!);
+    expect(readme).toContain(result.fileHashes[PRIVACY_ARCHIVE_FILENAMES.healthReportHtml]!);
+    expect(readme).toContain(result.fileHashes[PRIVACY_ARCHIVE_FILENAMES.relayMetadataJson]!);
+  });
+
+  it('le README ne contient PAS son propre hash (évite le cycle de référence)', async () => {
+    const result = await buildPrivacyArchive(makeArgs());
+    const readmeHash = result.fileHashes[PRIVACY_ARCHIVE_FILENAMES.readme]!;
+    const unzipped = unzipSync(result.zipBytes);
+    const readmeBytes = unzipped[PRIVACY_ARCHIVE_FILENAMES.readme];
+    const readme = new TextDecoder().decode(readmeBytes);
+    expect(readme).not.toContain(readmeHash);
+  });
+
+  it('le hash de health-data.json correspond bien au contenu décompressé', async () => {
+    const { sha256HexFromString } = await import('@kinhale/crypto');
+    const result = await buildPrivacyArchive(makeArgs());
+    const unzipped = unzipSync(result.zipBytes);
+    const jsonBytes = unzipped[PRIVACY_ARCHIVE_FILENAMES.healthDataJson];
+    const text = new TextDecoder().decode(jsonBytes);
+    const recomputed = await sha256HexFromString(text);
+    expect(recomputed).toBe(result.fileHashes[PRIVACY_ARCHIVE_FILENAMES.healthDataJson]);
+  });
+
+  it('le hash global est différent si une dose est ajoutée (non-trivial check)', async () => {
+    const a = await buildPrivacyArchive(makeArgs());
+    const argsB = makeArgs({
+      serializedDoc: {
+        ...makeSerializedDoc(),
+        doses: [
+          {
+            doseId: 'dose-1',
+            pumpId: 'pump-1',
+            childId: 'child-1',
+            caregiverId: 'cg-1',
+            administeredAtMs: FIXED_MS,
+            doseType: 'rescue',
+            dosesAdministered: 1,
+            symptoms: [],
+            circumstances: [],
+            freeFormTag: null,
+            status: 'recorded',
+            recordedByDeviceId: 'device-A',
+            recordedAtMs: FIXED_MS,
+          },
+        ],
+      },
+    });
+    const b = await buildPrivacyArchive(argsB);
+    expect(a.archiveHash).not.toBe(b.archiveHash);
+  });
+
+  it("aucun nom de fichier ne contient '..' ou '/' absolu (anti zip slip)", async () => {
+    const result = await buildPrivacyArchive(makeArgs());
+    const unzipped = unzipSync(result.zipBytes);
+    for (const name of Object.keys(unzipped)) {
+      expect(name).not.toContain('..');
+      expect(name.startsWith('/')).toBe(false);
+    }
+  });
+
+  it('le ZIP utilise le mode STORE (level 0 — pas de compression, sécurité auditée)', async () => {
+    const result = await buildPrivacyArchive(makeArgs());
+    // Le mode STORE place les bytes UTF-8 bruts. La taille du ZIP doit être
+    // approximativement égale à la somme des contenus + overhead headers.
+    const totalContentBytes =
+      JSON.stringify(makeSerializedDoc()).length +
+      JSON.stringify(makeRelayMetadata()).length +
+      makeArgs().reportHtml.length +
+      makeArgs().reportCsv.length;
+    // STORE : taille ZIP > taille contenus (overhead headers ≥ 0). Et pas
+    // significativement plus petite (donc pas de compression).
+    expect(result.zipBytes.byteLength).toBeGreaterThan(totalContentBytes / 4);
+  });
+});

--- a/packages/reports/src/privacy-export/build-archive.ts
+++ b/packages/reports/src/privacy-export/build-archive.ts
@@ -1,0 +1,96 @@
+/**
+ * Builder principal de l'archive de portabilité (KIN-085, ADR-D14).
+ *
+ * Orchestre le pipeline :
+ * 1. Sérialise le doc Automerge local en JSON canonique.
+ * 2. Sérialise les métadonnées relais en JSON canonique.
+ * 3. Hashe individuellement chaque fichier (intégrité reproductible).
+ * 4. Construit le `README.txt` bilingue avec le tableau de hashes.
+ * 5. Hashe le README (le tableau du README ne contient pas son propre hash —
+ *    on le calcule en dernier pour éviter le cycle).
+ * 6. Empaquette tout dans un ZIP **STORE** (pas de compression, données
+ *    déjà compactes ; évite tout risque CVE lié à un zlib/inflate buggé).
+ * 7. Calcule le hash global de l'archive (utilisé pour l'audit trail relais).
+ *
+ * **Pure** : pas d'I/O, pas de réseau, pas de `Date.now()` caché. Toutes
+ * les sources de variabilité (timestamp, version) sont passées en arguments.
+ *
+ * Refs: ADR-D14, KIN-085, RM24, RM27.
+ */
+
+import { sha256Hex, sha256HexFromString } from '@kinhale/crypto';
+import { zipSync, type Zippable } from 'fflate';
+import { buildPrivacyReadme } from './build-readme.js';
+import { canonicalJsonStringify } from './serialize-doc.js';
+import type { BuildPrivacyArchiveArgs, BuildPrivacyArchiveResult } from './types.js';
+
+/** Nom des fichiers de l'archive — exposé pour les tests et clients. */
+export const PRIVACY_ARCHIVE_FILENAMES = {
+  healthDataJson: 'health-data.json',
+  healthDataCsv: 'health-data.csv',
+  healthReportHtml: 'health-report.html',
+  relayMetadataJson: 'relay-metadata.json',
+  readme: 'README.txt',
+} as const;
+
+/**
+ * Construit l'archive de portabilité prête à télécharger / partager.
+ *
+ * @param args - Doc local sérialisé, métadonnées relais, HTML/CSV, version.
+ * @returns ZIP bytes + hashes (archive globale + par fichier).
+ */
+export async function buildPrivacyArchive(
+  args: BuildPrivacyArchiveArgs,
+): Promise<BuildPrivacyArchiveResult> {
+  const healthDataJson = canonicalJsonStringify(args.serializedDoc);
+  const relayMetadataJson = canonicalJsonStringify(args.relayMetadata);
+
+  // Hashes individuels — calculés AVANT le README pour qu'il les liste tous.
+  const fileHashesWithoutReadme: Record<string, string> = {
+    [PRIVACY_ARCHIVE_FILENAMES.healthDataJson]: await sha256HexFromString(healthDataJson),
+    [PRIVACY_ARCHIVE_FILENAMES.healthDataCsv]: await sha256HexFromString(args.reportCsv),
+    [PRIVACY_ARCHIVE_FILENAMES.healthReportHtml]: await sha256HexFromString(args.reportHtml),
+    [PRIVACY_ARCHIVE_FILENAMES.relayMetadataJson]: await sha256HexFromString(relayMetadataJson),
+  };
+
+  const readmeText = buildPrivacyReadme({
+    accountId: args.relayMetadata.accountId,
+    householdId: args.serializedDoc.householdId,
+    generatedAtMs: args.generatedAtMs,
+    appVersion: args.appVersion,
+    fileHashes: fileHashesWithoutReadme,
+  });
+
+  // Hash du README (calculé après — il référence les autres hashes mais
+  // pas le sien, donc pas de cycle).
+  const readmeHash = await sha256HexFromString(readmeText);
+
+  const fileHashes: Record<string, string> = {
+    ...fileHashesWithoutReadme,
+    [PRIVACY_ARCHIVE_FILENAMES.readme]: readmeHash,
+  };
+
+  const encoder = new TextEncoder();
+  // Toutes les entrées sont en mode STORE (level: 0) — pas de compression.
+  // Les données santé sont déjà compactes, et le mode STORE élimine toute
+  // surface d'attaque liée à un déflateur buggé (CVE potentielles).
+  const zipInput: Zippable = {
+    [PRIVACY_ARCHIVE_FILENAMES.healthDataJson]: [encoder.encode(healthDataJson), { level: 0 }],
+    [PRIVACY_ARCHIVE_FILENAMES.healthDataCsv]: [encoder.encode(args.reportCsv), { level: 0 }],
+    [PRIVACY_ARCHIVE_FILENAMES.healthReportHtml]: [encoder.encode(args.reportHtml), { level: 0 }],
+    [PRIVACY_ARCHIVE_FILENAMES.relayMetadataJson]: [
+      encoder.encode(relayMetadataJson),
+      { level: 0 },
+    ],
+    [PRIVACY_ARCHIVE_FILENAMES.readme]: [encoder.encode(readmeText), { level: 0 }],
+  };
+
+  const zipBytes = zipSync(zipInput);
+  const archiveHash = await sha256Hex(zipBytes);
+
+  return {
+    zipBytes,
+    archiveHash,
+    fileHashes,
+  };
+}

--- a/packages/reports/src/privacy-export/build-readme.test.ts
+++ b/packages/reports/src/privacy-export/build-readme.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import { buildPrivacyReadme } from './build-readme.js';
+
+const FIXED_MS = Date.UTC(2026, 3, 24, 12, 0, 0);
+
+describe('buildPrivacyReadme', () => {
+  it('inclut une section FR ET une section EN (i18n bilingue obligatoire)', () => {
+    const out = buildPrivacyReadme({
+      accountId: 'acc-1',
+      householdId: 'hh-1',
+      generatedAtMs: FIXED_MS,
+      appVersion: 'v1.0.0',
+      fileHashes: { 'health-data.json': 'a'.repeat(64) },
+    });
+
+    expect(out).toContain('Archive de portabilité');
+    expect(out).toContain('Data portability archive');
+    expect(out).toContain('RGPD art. 20');
+    expect(out).toContain('GDPR art. 20');
+  });
+
+  it('inclut le disclaimer non-DM (RM27) en FR et EN', () => {
+    const out = buildPrivacyReadme({
+      accountId: 'acc-1',
+      householdId: 'hh-1',
+      generatedAtMs: FIXED_MS,
+      appVersion: 'v1.0.0',
+      fileHashes: {},
+    });
+
+    expect(out).toContain('ne remplace pas');
+    expect(out).toContain('aucune interprétation');
+    expect(out).toContain('does not replace');
+    expect(out).toContain('no medical interpretation');
+  });
+
+  it("affiche le tableau d'intégrité avec les hashes triés alphabétiquement", () => {
+    const out = buildPrivacyReadme({
+      accountId: 'acc-1',
+      householdId: 'hh-1',
+      generatedAtMs: FIXED_MS,
+      appVersion: 'v1.0.0',
+      fileHashes: {
+        'zfile.txt': 'z'.repeat(64),
+        'afile.txt': 'a'.repeat(64),
+        'mfile.txt': 'm'.repeat(64),
+      },
+    });
+
+    const aIdx = out.indexOf('afile.txt');
+    const mIdx = out.indexOf('mfile.txt');
+    const zIdx = out.indexOf('zfile.txt');
+    expect(aIdx).toBeGreaterThan(-1);
+    expect(aIdx).toBeLessThan(mIdx);
+    expect(mIdx).toBeLessThan(zIdx);
+  });
+
+  it('inclut accountId et householdId en clair (transparence vers le sujet)', () => {
+    const out = buildPrivacyReadme({
+      accountId: 'pseudo-12345',
+      householdId: 'hh-67890',
+      generatedAtMs: FIXED_MS,
+      appVersion: 'v1.0.0',
+      fileHashes: {},
+    });
+    expect(out).toContain('pseudo-12345');
+    expect(out).toContain('hh-67890');
+  });
+
+  it('inclut la version Kinhale dans les deux sections', () => {
+    const out = buildPrivacyReadme({
+      accountId: 'acc-1',
+      householdId: 'hh-1',
+      generatedAtMs: FIXED_MS,
+      appVersion: 'v1.0.0-rc1',
+      fileHashes: {},
+    });
+    // Compte les occurrences — au moins 2 (FR + EN).
+    const matches = out.match(/v1\.0\.0-rc1/g);
+    expect(matches).not.toBeNull();
+    expect(matches?.length ?? 0).toBeGreaterThanOrEqual(2);
+  });
+
+  it('affiche un message dédié si aucun fichier (cas dégénéré)', () => {
+    const out = buildPrivacyReadme({
+      accountId: 'acc-1',
+      householdId: 'hh-1',
+      generatedAtMs: FIXED_MS,
+      appVersion: 'v1.0.0',
+      fileHashes: {},
+    });
+    expect(out).toContain('aucun fichier');
+    expect(out).toContain('no file');
+  });
+
+  it('affiche une URL de contact security@kinhale.health', () => {
+    const out = buildPrivacyReadme({
+      accountId: 'acc-1',
+      householdId: 'hh-1',
+      generatedAtMs: FIXED_MS,
+      appVersion: 'v1.0.0',
+      fileHashes: {},
+    });
+    expect(out).toContain('security@kinhale.health');
+  });
+
+  it('mentionne explicitement la promesse zero-knowledge en FR et EN', () => {
+    const out = buildPrivacyReadme({
+      accountId: 'acc-1',
+      householdId: 'hh-1',
+      generatedAtMs: FIXED_MS,
+      appVersion: 'v1.0.0',
+      fileHashes: {},
+    });
+    expect(out).toContain("n'a JAMAIS accès");
+    expect(out).toContain('NEVER accesses');
+  });
+
+  it('est déterministe — mêmes inputs → mêmes outputs', () => {
+    const args = {
+      accountId: 'acc-1',
+      householdId: 'hh-1',
+      generatedAtMs: FIXED_MS,
+      appVersion: 'v1.0.0',
+      fileHashes: { 'a.txt': 'x'.repeat(64), 'b.txt': 'y'.repeat(64) },
+    };
+    expect(buildPrivacyReadme(args)).toBe(buildPrivacyReadme(args));
+  });
+
+  it('ne contient aucun mot interprétatif médical (anti-DM)', () => {
+    const out = buildPrivacyReadme({
+      accountId: 'acc-1',
+      householdId: 'hh-1',
+      generatedAtMs: FIXED_MS,
+      appVersion: 'v1.0.0',
+      fileHashes: {},
+    });
+    // Liste blanche : ces mots ne doivent JAMAIS apparaître dans un README produit
+    // (ils signaleraient une dérive vers du DM).
+    const forbiddenFr = ['augmenter dose', 'consulter médecin urgent', 'sévère', 'critique'];
+    const forbiddenEn = ['increase dose', 'urgently see your doctor', 'severe', 'critical'];
+    for (const w of forbiddenFr) expect(out.toLowerCase()).not.toContain(w);
+    for (const w of forbiddenEn) expect(out.toLowerCase()).not.toContain(w);
+  });
+});

--- a/packages/reports/src/privacy-export/build-readme.ts
+++ b/packages/reports/src/privacy-export/build-readme.ts
@@ -1,0 +1,167 @@
+/**
+ * Builder du `README.txt` bilingue inclus dans l'archive de portabilité.
+ *
+ * Le README a deux rôles :
+ * 1. **Conformité RGPD/Loi 25** : informer l'utilisateur du contenu, du
+ *    contexte et de ses droits. Il sert aussi de preuve d'exercice du
+ *    droit à la portabilité.
+ * 2. **Intégrité** : énumère le hash SHA-256 individuel de chaque autre
+ *    fichier de l'archive. Un consommateur tiers peut recalculer ces hashes
+ *    et vérifier qu'aucun fichier n'a été altéré pendant le transit.
+ *
+ * Le README ne contient **aucune** donnée santé, **aucune** interprétation
+ * médicale (RM27 — disclaimer), **aucune** clé cryptographique.
+ *
+ * Refs: ADR-D14, KIN-085, RM27.
+ */
+
+/**
+ * Métadonnées passées au builder. Pas d'i18next ici — on inline les deux
+ * langues pour garder cette fonction pure et facilement testable. C'est
+ * cohérent avec le critère d'acceptation E9-S02 (i18n FR + EN).
+ */
+export interface BuildReadmeArgs {
+  readonly accountId: string;
+  readonly householdId: string;
+  readonly generatedAtMs: number;
+  readonly appVersion: string;
+  /** Hashes individuels par nom de fichier — recopiés tels quels dans le README. */
+  readonly fileHashes: Readonly<Record<string, string>>;
+}
+
+/**
+ * Construit la chaîne UTF-8 finale du `README.txt`.
+ *
+ * Format :
+ * - Section FR — disclaimer + contenu + intégrité.
+ * - Séparateur visible.
+ * - Section EN — symétrique.
+ *
+ * Pure : pas de `Date.now()` caché, pas d'I/O, retour string déterministe
+ * pour des inputs déterministes.
+ */
+export function buildPrivacyReadme(args: BuildReadmeArgs): string {
+  const dateIso = new Date(args.generatedAtMs).toISOString();
+  const hashTable = renderHashTable(args.fileHashes);
+
+  const fr = [
+    '=============================================================',
+    'Kinhale — Archive de portabilité (RGPD art. 20 / Loi 25 art. 30)',
+    '=============================================================',
+    '',
+    `Date d'export      : ${dateIso}`,
+    `Version Kinhale    : ${args.appVersion}`,
+    `Identifiant compte : ${args.accountId}`,
+    `Identifiant foyer  : ${args.householdId}`,
+    '',
+    '--- À propos de cette archive ---------------------------------',
+    '',
+    "Cette archive contient l'intégralité des données personnelles que",
+    'vous avez saisies dans Kinhale, ainsi que les métadonnées techniques',
+    'que le service relais Kamez Conseils détient à votre sujet.',
+    '',
+    "Le service relais n'a JAMAIS accès à vos données de santé. Cette",
+    'archive a été produite intégralement sur votre appareil ; le serveur',
+    "n'a fourni que les métadonnées non-santé qui vous concernent",
+    '(devices enregistrés, audit trail, préférences de notification).',
+    '',
+    "--- Contenu de l'archive --------------------------------------",
+    '',
+    '- health-data.json     : journal complet des prises, pompes, plan,',
+    '                         enfant et aidants (format JSON).',
+    '- health-data.csv      : même journal en format CSV (compatible',
+    '                         tableurs).',
+    '- health-report.html   : rapport synthétique (à imprimer en PDF).',
+    '- relay-metadata.json  : métadonnées non-santé du serveur Kamez.',
+    '- README.txt           : le présent fichier.',
+    '',
+    '--- Disclaimer ------------------------------------------------',
+    '',
+    'Kinhale est un outil de suivi et de coordination. Il ne remplace pas',
+    'un avis médical. Cette archive ne contient aucune interprétation',
+    'médicale, aucune recommandation de dose, aucun diagnostic.',
+    '',
+    '--- Intégrité (SHA-256) ---------------------------------------',
+    '',
+    hashTable,
+    '',
+    '--- Vos droits ------------------------------------------------',
+    '',
+    "Vous pouvez demander à tout moment l'effacement de vos données",
+    'depuis l\'écran "Paramètres → Confidentialité → Supprimer mon',
+    'compte". L\'effacement est effectif sous 30 jours maximum (délai',
+    'technique de purge des sauvegardes rotatives).',
+    '',
+    'Pour toute question : security@kinhale.health',
+    '',
+  ].join('\n');
+
+  const en = [
+    '=============================================================',
+    'Kinhale — Data portability archive (GDPR art. 20 / Quebec Law 25 art. 30)',
+    '=============================================================',
+    '',
+    `Export date    : ${dateIso}`,
+    `Kinhale version: ${args.appVersion}`,
+    `Account ID     : ${args.accountId}`,
+    `Household ID   : ${args.householdId}`,
+    '',
+    '--- About this archive ----------------------------------------',
+    '',
+    'This archive contains all the personal data you entered into',
+    'Kinhale, as well as the technical metadata held about you by',
+    'the Kamez Conseils relay service.',
+    '',
+    'The relay service NEVER accesses your health data. This archive',
+    'was generated entirely on your device; the server only provided',
+    'the non-health metadata that concerns you (registered devices,',
+    'audit trail, notification preferences).',
+    '',
+    '--- Archive contents -----------------------------------------',
+    '',
+    '- health-data.json    : complete journal of doses, pumps, plan,',
+    '                        child and caregivers (JSON format).',
+    '- health-data.csv     : same journal in CSV format (spreadsheet',
+    '                        compatible).',
+    '- health-report.html  : summary report (printable to PDF).',
+    '- relay-metadata.json : non-health metadata from the Kamez relay.',
+    '- README.txt          : this file.',
+    '',
+    '--- Disclaimer -----------------------------------------------',
+    '',
+    'Kinhale is a tracking and coordination tool. It does not replace',
+    'medical advice. This archive contains no medical interpretation,',
+    'no dose recommendation, no diagnosis.',
+    '',
+    '--- Integrity (SHA-256) --------------------------------------',
+    '',
+    hashTable,
+    '',
+    '--- Your rights ----------------------------------------------',
+    '',
+    'You can request deletion of your data at any time from the',
+    'in-app screen "Settings → Privacy → Delete my account". Deletion',
+    'is effective within 30 days maximum (technical delay for rolling',
+    'backup purges).',
+    '',
+    'For any question: security@kinhale.health',
+    '',
+  ].join('\n');
+
+  return `${fr}\n\n${en}`;
+}
+
+/**
+ * Tableau aligné `nom_de_fichier  hash`. Trie par nom de fichier pour la
+ * reproductibilité.
+ */
+function renderHashTable(fileHashes: Readonly<Record<string, string>>): string {
+  const entries = Object.keys(fileHashes)
+    .sort()
+    .map((name): [string, string] => [name, fileHashes[name] ?? '']);
+  if (entries.length === 0) {
+    return '(aucun fichier / no file)';
+  }
+  const maxNameLen = Math.max(...entries.map(([name]) => name.length));
+  return entries.map(([name, hash]) => `${name.padEnd(maxNameLen, ' ')}  ${hash}`).join('\n');
+}

--- a/packages/reports/src/privacy-export/serialize-doc.test.ts
+++ b/packages/reports/src/privacy-export/serialize-doc.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'vitest';
+import type { KinhaleDoc, SignedEventRecord } from '@kinhale/sync';
+import { canonicalJsonStringify, serializeDocForExport } from './serialize-doc.js';
+
+/**
+ * Fabrique d'événement signé en clair pour les tests. Les champs
+ * signature/publicKey sont fictifs — les projections ne les vérifient pas.
+ */
+function makeEvent(args: {
+  id: string;
+  type: SignedEventRecord['type'];
+  payload: unknown;
+  occurredAtMs: number;
+  deviceId?: string;
+}): SignedEventRecord {
+  return {
+    id: args.id,
+    type: args.type,
+    payloadJson: JSON.stringify(args.payload),
+    signerPublicKeyHex: 'a'.repeat(64),
+    signatureHex: 'b'.repeat(128),
+    deviceId: args.deviceId ?? 'device-1',
+    occurredAtMs: args.occurredAtMs,
+  };
+}
+
+const BASE_MS = Date.UTC(2026, 3, 24, 12, 0, 0);
+
+describe('serializeDocForExport', () => {
+  it('retourne une structure squelette sur doc vide', () => {
+    const doc: KinhaleDoc = { householdId: 'hh-1', events: [] };
+    const out = serializeDocForExport(doc, BASE_MS);
+
+    expect(out.householdId).toBe('hh-1');
+    expect(out.exportedAtMs).toBe(BASE_MS);
+    expect(out.schemaVersion).toBe(1);
+    expect(out.child).toBeNull();
+    expect(out.caregivers).toEqual([]);
+    expect(out.pumps).toEqual([]);
+    expect(out.plans).toEqual([]);
+    expect(out.doses).toEqual([]);
+  });
+
+  it('projette tous les domaines avec les champs attendus', () => {
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        makeEvent({
+          id: 'e-child',
+          type: 'ChildRegistered',
+          payload: { childId: 'child-1', firstName: 'Léa', birthYear: 2020 },
+          occurredAtMs: BASE_MS - 1000,
+          deviceId: 'device-A',
+        }),
+        makeEvent({
+          id: 'e-pump',
+          type: 'PumpReplaced',
+          payload: {
+            pumpId: 'pump-1',
+            name: 'Bleue',
+            pumpType: 'rescue',
+            totalDoses: 200,
+            expiresAtMs: BASE_MS + 60 * 86_400_000,
+          },
+          occurredAtMs: BASE_MS - 800,
+        }),
+        makeEvent({
+          id: 'e-plan',
+          type: 'PlanUpdated',
+          payload: {
+            planId: 'plan-1',
+            pumpId: 'pump-1',
+            scheduledHoursUtc: [8, 20],
+            startAtMs: BASE_MS - 30 * 86_400_000,
+            endAtMs: null,
+          },
+          occurredAtMs: BASE_MS - 700,
+        }),
+        makeEvent({
+          id: 'e-cg-inv',
+          type: 'CaregiverInvited',
+          payload: { caregiverId: 'cg-1', role: 'admin', displayName: 'Sophie' },
+          occurredAtMs: BASE_MS - 600,
+        }),
+        makeEvent({
+          id: 'e-dose',
+          type: 'DoseAdministered',
+          payload: {
+            doseId: 'dose-1',
+            pumpId: 'pump-1',
+            childId: 'child-1',
+            caregiverId: 'cg-1',
+            administeredAtMs: BASE_MS - 100,
+            doseType: 'rescue',
+            dosesAdministered: 2,
+            symptoms: ['cough'],
+            circumstances: ['exercise'],
+            freeFormTag: 'Note libre privée',
+          },
+          occurredAtMs: BASE_MS - 100,
+          deviceId: 'device-A',
+        }),
+      ],
+    };
+
+    const out = serializeDocForExport(doc, BASE_MS);
+
+    expect(out.child).toEqual({
+      childId: 'child-1',
+      firstName: 'Léa',
+      birthYear: 2020,
+      recordedByDeviceId: 'device-A',
+      recordedAtMs: BASE_MS - 1000,
+    });
+    expect(out.pumps).toHaveLength(1);
+    expect(out.pumps[0]?.name).toBe('Bleue');
+    expect(out.plans).toHaveLength(1);
+    expect(out.plans[0]?.scheduledHoursUtc).toEqual([8, 20]);
+    expect(out.caregivers).toHaveLength(1);
+    expect(out.caregivers[0]?.displayName).toBe('Sophie');
+    expect(out.doses).toHaveLength(1);
+    expect(out.doses[0]?.freeFormTag).toBe('Note libre privée');
+  });
+
+  it('inclut explicitement freeFormTag (contraste avec rapport médecin RM8)', () => {
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        makeEvent({
+          id: 'e-dose',
+          type: 'DoseAdministered',
+          payload: {
+            doseId: 'dose-1',
+            pumpId: 'pump-1',
+            childId: 'child-1',
+            caregiverId: 'cg-1',
+            administeredAtMs: BASE_MS,
+            doseType: 'maintenance',
+            dosesAdministered: 1,
+            symptoms: [],
+            circumstances: [],
+            freeFormTag: "Note de l'aidant : reste à l'école aujourd'hui",
+          },
+          occurredAtMs: BASE_MS,
+        }),
+      ],
+    };
+
+    const out = serializeDocForExport(doc, BASE_MS);
+    expect(out.doses[0]?.freeFormTag).toBe("Note de l'aidant : reste à l'école aujourd'hui");
+  });
+
+  it('trie les caregivers par caregiverId pour la reproductibilité', () => {
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        makeEvent({
+          id: 'e1',
+          type: 'CaregiverInvited',
+          payload: { caregiverId: 'cg-zebra', role: 'admin', displayName: 'Zoé' },
+          occurredAtMs: BASE_MS - 1000,
+        }),
+        makeEvent({
+          id: 'e2',
+          type: 'CaregiverInvited',
+          payload: { caregiverId: 'cg-alpha', role: 'contributor', displayName: 'Alex' },
+          occurredAtMs: BASE_MS - 500,
+        }),
+      ],
+    };
+
+    const out = serializeDocForExport(doc, BASE_MS);
+    expect(out.caregivers.map((c) => c.caregiverId)).toEqual(['cg-alpha', 'cg-zebra']);
+  });
+
+  it('trie les doses par administeredAtMs ascendant puis doseId', () => {
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        makeEvent({
+          id: 'e1',
+          type: 'DoseAdministered',
+          payload: {
+            doseId: 'dose-z',
+            pumpId: 'pump-1',
+            childId: 'child-1',
+            caregiverId: 'cg-1',
+            administeredAtMs: BASE_MS,
+            doseType: 'rescue',
+            dosesAdministered: 1,
+            symptoms: [],
+            circumstances: [],
+            freeFormTag: null,
+          },
+          occurredAtMs: BASE_MS,
+        }),
+        makeEvent({
+          id: 'e2',
+          type: 'DoseAdministered',
+          payload: {
+            doseId: 'dose-a',
+            pumpId: 'pump-1',
+            childId: 'child-1',
+            caregiverId: 'cg-1',
+            administeredAtMs: BASE_MS - 1000,
+            doseType: 'rescue',
+            dosesAdministered: 1,
+            symptoms: [],
+            circumstances: [],
+            freeFormTag: null,
+          },
+          occurredAtMs: BASE_MS - 1000,
+        }),
+        makeEvent({
+          id: 'e3',
+          type: 'DoseAdministered',
+          payload: {
+            doseId: 'dose-b',
+            pumpId: 'pump-1',
+            childId: 'child-1',
+            caregiverId: 'cg-1',
+            administeredAtMs: BASE_MS,
+            doseType: 'maintenance',
+            dosesAdministered: 1,
+            symptoms: [],
+            circumstances: [],
+            freeFormTag: null,
+          },
+          occurredAtMs: BASE_MS,
+        }),
+      ],
+    };
+
+    const out = serializeDocForExport(doc, BASE_MS);
+    expect(out.doses.map((d) => d.doseId)).toEqual(['dose-a', 'dose-b', 'dose-z']);
+  });
+
+  it('est déterministe — même doc → même sortie (clé de la reproductibilité du hash)', () => {
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        makeEvent({
+          id: 'e1',
+          type: 'DoseAdministered',
+          payload: {
+            doseId: 'dose-1',
+            pumpId: 'pump-1',
+            childId: 'child-1',
+            caregiverId: 'cg-1',
+            administeredAtMs: BASE_MS,
+            doseType: 'maintenance',
+            dosesAdministered: 1,
+            symptoms: ['cough', 'wheezing'],
+            circumstances: ['exercise'],
+            freeFormTag: null,
+          },
+          occurredAtMs: BASE_MS,
+        }),
+      ],
+    };
+
+    const a = serializeDocForExport(doc, BASE_MS);
+    const b = serializeDocForExport(doc, BASE_MS);
+    expect(canonicalJsonStringify(a)).toBe(canonicalJsonStringify(b));
+  });
+
+  it('produit un JSON canonique avec clés triées par ordre alphabétique', () => {
+    const out = canonicalJsonStringify({ z: 1, a: 2, m: { y: 3, x: 4 } });
+    // Les clés sont triées (a, m, z) et l'objet imbriqué aussi (x, y)
+    expect(out).toBe('{\n  "a": 2,\n  "m": {\n    "x": 4,\n    "y": 3\n  },\n  "z": 1\n}\n');
+  });
+
+  it('sérialisation déterministe — la chaîne hashée est identique à chaque appel', () => {
+    const obj = { foo: { bar: [1, 2, 3], baz: 'test' } };
+    expect(canonicalJsonStringify(obj)).toBe(canonicalJsonStringify(obj));
+  });
+});

--- a/packages/reports/src/privacy-export/serialize-doc.ts
+++ b/packages/reports/src/privacy-export/serialize-doc.ts
@@ -1,0 +1,184 @@
+/**
+ * Sérialisation déterministe du document Automerge pour l'export RGPD/Loi 25.
+ *
+ * Cette fonction lit le doc local et produit un `SerializedDoc` plat qui :
+ * - couvre **toutes** les données saisies par l'utilisateur (art. 20 RGPD —
+ *   contrairement au rapport médecin qui filtre `freeFormTag` cf. RM8) ;
+ * - est trié de façon stable pour garantir la **reproductibilité** du hash
+ *   SHA-256 (un médecin / RPRP peut recalculer depuis le doc Automerge).
+ *
+ * Pure : aucun effet de bord, aucun appel réseau, aucun `Date.now()` caché.
+ *
+ * Refs: ADR-D14, KIN-085, E9-S02.
+ */
+
+import type { KinhaleDoc } from '@kinhale/sync';
+import {
+  projectCaregivers,
+  projectChild,
+  projectDoses,
+  projectPlan,
+  projectPumps,
+} from '@kinhale/sync';
+import type {
+  SerializedCaregiver,
+  SerializedChild,
+  SerializedDoc,
+  SerializedDose,
+  SerializedPlan,
+  SerializedPump,
+} from './types.js';
+
+/**
+ * Construit le snapshot sérialisable du document Automerge.
+ *
+ * @param doc - Document Automerge déchiffré localement.
+ * @param exportedAtMs - Horodatage UTC ms d'export (recopié dans le snapshot).
+ *   Ne pas appeler `Date.now()` ici pour préserver la pureté.
+ */
+export function serializeDocForExport(doc: KinhaleDoc, exportedAtMs: number): SerializedDoc {
+  return {
+    householdId: doc.householdId,
+    exportedAtMs,
+    schemaVersion: 1,
+    child: serializeChild(doc),
+    caregivers: serializeCaregivers(doc),
+    pumps: serializePumps(doc),
+    plans: serializePlans(doc),
+    doses: serializeDoses(doc),
+  };
+}
+
+function serializeChild(doc: KinhaleDoc): SerializedChild | null {
+  const projected = projectChild(doc);
+  if (projected === null) return null;
+  return {
+    childId: projected.childId,
+    firstName: projected.firstName,
+    birthYear: projected.birthYear,
+    recordedByDeviceId: projected.deviceId,
+    recordedAtMs: projected.occurredAtMs,
+  };
+}
+
+/**
+ * Caregivers triés par `caregiverId` (UUID lexicographique stable).
+ * Le tri par `invitedAtMs` ne suffirait pas — deux invitations à la
+ * même milliseconde donneraient un ordre instable.
+ */
+function serializeCaregivers(doc: KinhaleDoc): ReadonlyArray<SerializedCaregiver> {
+  const projected = projectCaregivers(doc);
+  return projected
+    .map(
+      (c): SerializedCaregiver => ({
+        caregiverId: c.caregiverId,
+        role: c.role,
+        displayName: c.displayName,
+        status: c.status,
+        invitedAtMs: c.invitedAtMs,
+        acceptedAtMs: c.acceptedAtMs,
+      }),
+    )
+    .sort((a, b) => (a.caregiverId < b.caregiverId ? -1 : a.caregiverId > b.caregiverId ? 1 : 0));
+}
+
+/**
+ * Pompes triées par `pumpId`. `registeredAtMs` est l'`occurredAtMs` de
+ * l'événement `PumpReplaced` correspondant (la pompe a été enregistrée /
+ * remplacée à ce moment-là). Note : `projectPumps` n'expose pas cet
+ * `occurredAtMs` directement — on lit le doc.
+ */
+function serializePumps(doc: KinhaleDoc): ReadonlyArray<SerializedPump> {
+  const projected = projectPumps(doc);
+  return projected
+    .map(
+      (p): SerializedPump => ({
+        pumpId: p.pumpId,
+        name: p.name,
+        pumpType: p.pumpType,
+        totalDoses: p.totalDoses,
+        dosesRemaining: p.dosesRemaining,
+        expiresAtMs: p.expiresAtMs,
+        registeredAtMs: p.occurredAtMs,
+      }),
+    )
+    .sort((a, b) => (a.pumpId < b.pumpId ? -1 : a.pumpId > b.pumpId ? 1 : 0));
+}
+
+/**
+ * Plan unique projeté (RM13 → un seul plan actif). Le retour est un tableau
+ * pour cohérence avec une éventuelle évolution v1.1 multi-plans, et pour
+ * un consommateur RGPD qui s'attend à une liste.
+ */
+function serializePlans(doc: KinhaleDoc): ReadonlyArray<SerializedPlan> {
+  const projected = projectPlan(doc);
+  if (projected === null) return [];
+  return [
+    {
+      planId: projected.planId,
+      pumpId: projected.pumpId,
+      // Recopie défensive (évite la fuite de référence vers la projection).
+      scheduledHoursUtc: [...projected.scheduledHoursUtc],
+      startAtMs: projected.startAtMs,
+      endAtMs: projected.endAtMs,
+      recordedAtMs: projected.occurredAtMs,
+    },
+  ];
+}
+
+/**
+ * Doses triées par `(administeredAtMs ASC, doseId ASC)`. L'ordre ascendant
+ * est plus naturel pour un consommateur tiers (lecture chronologique) que
+ * celui de `projectDoses` qui retourne du décroissant pour l'UI.
+ */
+function serializeDoses(doc: KinhaleDoc): ReadonlyArray<SerializedDose> {
+  const projected = projectDoses(doc);
+  return projected
+    .map(
+      (d): SerializedDose => ({
+        doseId: d.doseId,
+        pumpId: d.pumpId,
+        childId: d.childId,
+        caregiverId: d.caregiverId,
+        administeredAtMs: d.administeredAtMs,
+        doseType: d.doseType,
+        dosesAdministered: d.dosesAdministered,
+        symptoms: [...d.symptoms],
+        circumstances: [...d.circumstances],
+        freeFormTag: d.freeFormTag,
+        status: d.status,
+        recordedByDeviceId: d.deviceId,
+        recordedAtMs: d.occurredAtMs,
+      }),
+    )
+    .sort((a, b) => {
+      if (a.administeredAtMs !== b.administeredAtMs) return a.administeredAtMs - b.administeredAtMs;
+      return a.doseId < b.doseId ? -1 : a.doseId > b.doseId ? 1 : 0;
+    });
+}
+
+/**
+ * Sérialise un objet en JSON canonique avec :
+ * - clés triées alphabétiquement à chaque niveau,
+ * - indentation 2 espaces (lisibilité humaine),
+ * - terminateur `\n` final pour un diff git friendly.
+ *
+ * Cette représentation est **déterministe** — appelée deux fois sur le même
+ * objet, elle produit la même chaîne, donc le même hash SHA-256.
+ */
+export function canonicalJsonStringify(value: unknown): string {
+  return JSON.stringify(value, sortKeysReplacer, 2) + '\n';
+}
+
+function sortKeysReplacer(_key: string, value: unknown): unknown {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+  const obj = value as Record<string, unknown>;
+  const sorted: Record<string, unknown> = {};
+  const keys = Object.keys(obj).sort();
+  for (const k of keys) {
+    sorted[k] = obj[k];
+  }
+  return sorted;
+}

--- a/packages/reports/src/privacy-export/types.ts
+++ b/packages/reports/src/privacy-export/types.ts
@@ -1,0 +1,208 @@
+/**
+ * Types partagés du module privacy-export (KIN-085, ADR-D14).
+ *
+ * Ces interfaces décrivent :
+ * - le format JSON déterministe produit par `serializeDocForExport`,
+ * - le payload attendu en provenance du backend (`/me/privacy/export/metadata`),
+ * - le résultat retourné par `buildPrivacyArchive`.
+ *
+ * Toutes les structures sont **plates et sérialisables JSON** sans
+ * conversion supplémentaire — un consommateur tiers (médecin, RPRP, autre
+ * appli compatible RGPD) peut les lire directement.
+ */
+
+import type { ProjectedCaregiver } from '@kinhale/sync';
+
+/**
+ * Sous-ensemble de la projection `ProjectedDose` exposé dans l'archive.
+ *
+ * On exclut volontairement `signerPublicKeyHex`, `signatureHex` et
+ * `eventId` (sous-jacents à `SignedEventRecord`) qui sont des détails
+ * d'implémentation Automerge non utiles à un consommateur RGPD.
+ *
+ * `freeFormTag` est conservé : contrairement au rapport médecin (RM8) qui
+ * filtre les notes libres, l'export de portabilité doit inclure **toutes**
+ * les données saisies par l'utilisateur (art. 20 RGPD : « les données la
+ * concernant »).
+ */
+export interface SerializedDose {
+  readonly doseId: string;
+  readonly pumpId: string;
+  readonly childId: string;
+  readonly caregiverId: string;
+  readonly administeredAtMs: number;
+  readonly doseType: 'maintenance' | 'rescue';
+  readonly dosesAdministered: number;
+  readonly symptoms: ReadonlyArray<string>;
+  readonly circumstances: ReadonlyArray<string>;
+  readonly freeFormTag: string | null;
+  readonly status: 'recorded' | 'pending_review';
+  readonly recordedByDeviceId: string;
+  readonly recordedAtMs: number;
+}
+
+/**
+ * Pompe sérialisée pour l'export. Contient toutes les propriétés calculables
+ * depuis le doc Automerge ; `dosesRemaining` est une projection dérivée des
+ * `DoseAdministered` (voir `projectPumps`).
+ */
+export interface SerializedPump {
+  readonly pumpId: string;
+  readonly name: string;
+  readonly pumpType: 'maintenance' | 'rescue';
+  readonly totalDoses: number;
+  readonly dosesRemaining: number;
+  readonly expiresAtMs: number | null;
+  readonly registeredAtMs: number;
+}
+
+export interface SerializedPlan {
+  readonly planId: string;
+  readonly pumpId: string;
+  readonly scheduledHoursUtc: ReadonlyArray<number>;
+  readonly startAtMs: number;
+  readonly endAtMs: number | null;
+  readonly recordedAtMs: number;
+}
+
+export interface SerializedChild {
+  readonly childId: string;
+  readonly firstName: string;
+  readonly birthYear: number;
+  readonly recordedByDeviceId: string;
+  readonly recordedAtMs: number;
+}
+
+/**
+ * Aidant sérialisé : sous-ensemble de `ProjectedCaregiver`. Tous les champs
+ * sont déjà non sensibles en dehors de `displayName` qui est nécessaire à
+ * la portabilité (l'utilisateur a saisi ce nom, donc il a le droit de le
+ * récupérer).
+ */
+export type SerializedCaregiver = Pick<
+  ProjectedCaregiver,
+  'caregiverId' | 'role' | 'displayName' | 'status' | 'invitedAtMs' | 'acceptedAtMs'
+>;
+
+/**
+ * Document Kinhale sérialisé pour l'export RGPD/Loi 25.
+ *
+ * Toutes les listes sont **triées de façon déterministe** (par identifiant
+ * stable ou timestamp) afin que `serializeDocForExport(doc) === serializeDocForExport(doc)`
+ * produise toujours le même JSON — propriété indispensable pour reproduire
+ * le hash SHA-256 du fichier `health-data.json`.
+ *
+ * `householdId` est conservé en clair : c'est un UUID opaque, déjà connu
+ * du relais (au sens qu'il est l'index principal de la mailbox), et il
+ * permet à l'utilisateur d'auditer l'archive.
+ *
+ * `exportedAtMs` est l'horodatage de génération côté client. Un export
+ * regénéré 1 ms plus tard produira un autre hash — c'est attendu.
+ */
+export interface SerializedDoc {
+  readonly householdId: string;
+  readonly exportedAtMs: number;
+  readonly schemaVersion: 1;
+  readonly child: SerializedChild | null;
+  readonly caregivers: ReadonlyArray<SerializedCaregiver>;
+  readonly pumps: ReadonlyArray<SerializedPump>;
+  readonly plans: ReadonlyArray<SerializedPlan>;
+  readonly doses: ReadonlyArray<SerializedDose>;
+}
+
+/**
+ * Résumé d'un device enregistré côté relais. **Aucune donnée santé.**
+ *
+ * `lastSeenMs` est null si le relais ne suit pas la dernière activité —
+ * ce qui est le cas en v1.0 (l'info n'est pas tracée pour minimisation,
+ * mais le champ est prévu pour une évolution v1.1).
+ */
+export interface RelayDeviceInfo {
+  readonly deviceId: string;
+  readonly registeredAtMs: number;
+  readonly lastSeenMs: number | null;
+}
+
+/**
+ * Résumé d'un audit event concernant l'utilisateur. `eventData` est
+ * volontairement typé `unknown` côté contrat — c'est un JSONB opaque côté
+ * relais qui peut évoluer au fil des features (`report_generated`,
+ * `report_shared`, `privacy_export`, futur `account_deletion_requested`).
+ *
+ * Le format précis est documenté dans `audit_events` (schema.ts).
+ */
+export interface RelayAuditEventInfo {
+  readonly eventType: string;
+  readonly eventData: unknown;
+  readonly createdAtMs: number;
+}
+
+/**
+ * Préférences de notifications connues du relais. Les types absents de la
+ * liste sont implicitement `enabled: true` (cf. SPECS §9 — sanctuarisation
+ * des `missed_dose` et `security_alert`).
+ */
+export interface RelayNotificationPreferenceInfo {
+  readonly notificationType: string;
+  readonly enabled: boolean;
+  readonly updatedAtMs: number;
+}
+
+export interface RelayQuietHoursInfo {
+  readonly enabled: boolean;
+  readonly startLocalTime: string;
+  readonly endLocalTime: string;
+  readonly timezone: string;
+  readonly updatedAtMs: number;
+}
+
+/**
+ * Métadonnées relais retournées par `GET /me/privacy/export/metadata`.
+ *
+ * Toutes les propriétés sont **scope-isolées** par `accountId` (le `sub` du
+ * JWT) côté API. **Aucune** donnée d'autres utilisateurs n'est jamais incluse
+ * — c'est testé en kz-securite.
+ */
+export interface RelayExportMetadata {
+  /** UUID du compte (pseudonyme — l'email n'est jamais exposé en clair). */
+  readonly accountId: string;
+  /** Horodatage de réponse serveur (ms UTC). */
+  readonly exportedAtMs: number;
+  /** Devices enregistrés du compte. */
+  readonly devices: ReadonlyArray<RelayDeviceInfo>;
+  /** Audit events concernant le compte (report_generated, report_shared, …). */
+  readonly auditEvents: ReadonlyArray<RelayAuditEventInfo>;
+  /** Préférences de notifications matérialisées (les défauts implicites sont absents). */
+  readonly notificationPreferences: ReadonlyArray<RelayNotificationPreferenceInfo>;
+  /** Quiet hours ou null si jamais configurées. */
+  readonly quietHours: RelayQuietHoursInfo | null;
+  /** Nombre de push tokens enregistrés (pas le contenu — RM16 minimisation). */
+  readonly pushTokensCount: number;
+}
+
+/**
+ * Arguments du builder d'archive — assemble doc local + métadonnées relais
+ * + traduction du README.
+ */
+export interface BuildPrivacyArchiveArgs {
+  readonly serializedDoc: SerializedDoc;
+  readonly relayMetadata: RelayExportMetadata;
+  readonly reportHtml: string;
+  readonly reportCsv: string;
+  readonly generatedAtMs: number;
+  readonly appVersion: string;
+}
+
+/**
+ * Résultat de `buildPrivacyArchive`. Le hash de l'archive complète est
+ * recalculable côté serveur via `sha256Hex(zipBytes)` — c'est cette valeur
+ * qui est postée à `POST /audit/privacy-export`.
+ */
+export interface BuildPrivacyArchiveResult {
+  /** Bytes du ZIP — STORE mode (pas de compression, données déjà compactes). */
+  readonly zipBytes: Uint8Array;
+  /** Hash SHA-256 hex (64 chars) du ZIP entier. */
+  readonly archiveHash: string;
+  /** Hashes individuels de chaque fichier de l'archive (clé = nom de fichier). */
+  readonly fileHashes: Readonly<Record<string, string>>;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,6 +436,9 @@ importers:
       '@kinhale/sync':
         specifier: workspace:*
         version: link:../sync
+      fflate:
+        specifier: ~0.8.2
+        version: 0.8.2
     devDependencies:
       '@kinhale/eslint-config':
         specifier: workspace:*
@@ -5588,6 +5591,9 @@ packages:
 
   fetch-retry@4.1.1:
     resolution: {integrity: sha512-e6eB7zN6UBSwGVwrbWVH+gdLnkW9WwHhmq2YDK1Sh30pzx1onRVGBvogTlUeWxwTa+L86NYdo4hFkh7O8ZjSnA==}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -16160,6 +16166,8 @@ snapshots:
       picomatch: 4.0.4
 
   fetch-retry@4.1.1: {}
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:


### PR DESCRIPTION
## Contexte

KIN-085 livre la story **E9-S02 — Export de portabilité à la demande** (RGPD art. 20 / Loi 25 art. 30) et marque sa story comme **partiellement fermée** (le lien signé 7 j est reporté en v1.1, pattern wormhole partagé avec E8-S04).

L'archive ZIP est entièrement générée **côté client** — le relais n'a jamais accès au contenu santé, conforme au pivot zero-knowledge des **ADR-D12** et **ADR-D13**. Le SLA RGPD/Loi 25 ≤ 30 jours est respecté trivialement (export quasi-instantané sur device).

## ADR

[`docs/architecture/adr/ADR-D14-privacy-export-v1.md`](../blob/feature/KIN-085-privacy-export-rgpd/docs/architecture/adr/ADR-D14-privacy-export-v1.md) — Export de portabilité v1.0 : archive ZIP côté client, share sheet OS / download. Le wormhole v1.1 ouvrira un futur ADR-D15.

## Contenu

### Module `@kinhale/reports/privacy-export`
- `serialize-doc.ts` — projection déterministe du doc Automerge en JSON plat (tri stable par identifiant).
- `build-readme.ts` — `README.txt` bilingue FR + EN avec disclaimer non-DM, hashes SHA-256 individuels, mention des droits, contact `security@kinhale.health`.
- `build-archive.ts` — pipeline ZIP **STORE** (mode `level: 0` — réduit la surface CVE des déflateurs) via `fflate~0.8.2`. Hashes individuels + global.
- `types.ts` — interfaces partagées `RelayExportMetadata`, `BuildPrivacyArchiveArgs`, etc.
- **30 tests Vitest** (déterminisme, intégrité, anti zip-slip, anti-DM).

### Backend Fastify
- `GET /me/privacy/export/metadata` — retourne devices, audit events, notification preferences, quiet hours, push tokens **count** (RM16 minimisation). **Authz strict** : `WHERE accountId = sub JWT` partout, pas de jointure cross-account, `limit(10_000)` sur audit events. Rate-limit Redis 5/h/device. **Aucune donnée santé.** 7 tests dont scope strict, anti-leak, rate-limit.
- `POST /audit/privacy-export` — Zod `.strict()`, 2 champs (`archiveHash`, `generatedAtMs`), rate-limit 5/h/device avec key Redis dédiée. 9 tests anti-fuite santé.
- **Pas de migration DB** : réutilise `audit_events.event_type` JSONB.

### UI
- **Web** (`apps/web/src/app/settings/privacy/page.tsx`) — bouton « Exporter mes données (RGPD/Loi 25) », pipeline complet (metadata → serialize → report HTML/CSV → ZIP), download direct + `navigator.share`, audit best-effort, hash affiché en `selectable`.
- **Mobile** (`apps/mobile/app/settings/privacy.tsx`) — symétrique via `expo-file-system` (base64 → cache) + `Sharing.shareAsync` + **purge à l'unmount**.
- **Clients** : `apps/{web,mobile}/src/lib/privacy/export-client.ts` — fetch metadata + post audit.
- **i18n FR + EN** (`packages/i18n/.../privacyExport.*`) — 22 clés, parité parfaite.

## Tests

| Package        | Avant | Après | Delta |
|----------------|------:|------:|------:|
| `@kinhale/reports` | 64    | 94    | +30   |
| `@kinhale/api`     | 156   | 172   | +16   |
| `apps/web`         | 119   | 125   | +6    |
| `apps/mobile`      | 80    | 80    | (inchangé) |

Tous verts, aucun test existant cassé.

## Impact sécurité (kz-securite — APPROUVÉ)

**Risque global : FAIBLE.** 0 critique, 0 élevé, 1 modéré, 4 info.

- **Zero-knowledge strict** : aucune donnée santé ne quitte le device. Tests dédiés vérifiant l'absence de mots santé dans les payloads serveur (`childName`, `pumpName`, `symptom`, `firstName`, `birthYear`).
- **Authz scope-isolé** : `sub` JWT scope strictement toutes les requêtes Drizzle. Test « scope strict », pas d'IDOR identifiable.
- **RM16 minimisation** : `pushTokensCount` (nombre), jamais les tokens APNs/FCM.
- **Anti zip-slip** : noms de fichiers constants statiques, pas d'input dynamique.
- **fflate@~0.8.2** : MIT, sideEffects:false, aucune dep prod, aucune CVE connue. Pinning `~` (patches uniquement, lockfile fige). Surveillance Dependabot recommandée (finding modéré M-1).

## Revues

- **kz-review** : APPROUVÉ avec mineurs (suggestions docs self-hosting + e2e en follow-up).
- **kz-securite** : APPROUVÉ, 0 finding bloquant. Voir `.agents/current-run/kz-securite-KIN-085.md`.

## Migration DB

**Aucune.** La table `audit_events` (migration `0003_audit_events.sql`) accepte déjà tout `event_type` (text). Ajout opaque `event_type='privacy_export'` sans schéma supplémentaire.

## Vérifs locales (toutes vertes)

- `pnpm format:check` ✓
- `pnpm lint:root` ✓
- `pnpm lint` ✓
- `pnpm typecheck` ✓
- `pnpm test` ✓

## Suivi v1.1 et follow-ups

- **[v1.1]** Privacy export par e-mail via wormhole — pattern fragment-as-key, mutualisé avec E8-S04 v1.1 sous futur ADR-D15.
- **[Follow-up KIN-085]** Test e2e Playwright/Maestro sur le parcours `Settings → Privacy → Export`.
- **[Follow-up KIN-085]** kz-conformite review du `README.txt` (formulation juridique).
- **[Follow-up KIN-085]** Doc self-hosting pour le endpoint metadata.
- **[Follow-up KIN-085]** Audit Postgres réel (deux comptes distincts) pour pen-test J6.

## Test plan

- [ ] CI verte sur la branche.
- [ ] Tests Vitest `@kinhale/reports/privacy-export/*` (30 tests).
- [ ] Tests Fastify `apps/api/src/routes/__tests__/privacy.test.ts` (7 tests).
- [ ] Tests Fastify `apps/api/src/routes/__tests__/audit.test.ts` (27 tests dont 9 nouveaux).
- [ ] Tests Jest web `apps/web/src/lib/privacy/__tests__/export-client.test.ts` (6 tests).
- [ ] Test manuel web : Settings → Privacy → Export → ZIP téléchargé, intégrité du `health-data.json` (hash recalculé) match le README.
- [ ] Test manuel iOS / Android : génération + share sheet + purge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)