### PR TITLE
feat(ui,i18n): disclaimer non-dispositif-médical omniprésent (RM27)

### DIFF
--- a/apps/mobile/app/auth/index.tsx
+++ b/apps/mobile/app/auth/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, type JSX } from 'react';
 import { useTranslation } from 'react-i18next';
 import { YStack, H1, Input, Button, Text } from 'tamagui';
 import { apiFetch } from '../../src/lib/api-client';
+import { DisclaimerFooter } from '../../src/components/DisclaimerFooter';
 
 export default function AuthScreen(): JSX.Element {
   const { t } = useTranslation('common');
@@ -31,6 +32,7 @@ export default function AuthScreen(): JSX.Element {
     return (
       <YStack padding="$4" gap="$4" alignItems="center" justifyContent="center" flex={1}>
         <Text fontSize="$5">{t('auth.linkSent')}</Text>
+        <DisclaimerFooter />
       </YStack>
     );
   }
@@ -61,6 +63,8 @@ export default function AuthScreen(): JSX.Element {
       >
         {loading ? t('common.loading') : t('auth.submit')}
       </Button>
+      {/* Pied E1 auth : disclaimer discret RM27. */}
+      <DisclaimerFooter />
     </YStack>
   );
 }

--- a/apps/mobile/app/journal/add.tsx
+++ b/apps/mobile/app/journal/add.tsx
@@ -7,6 +7,7 @@ import { useDocStore } from '../../src/stores/doc-store';
 import { getOrCreateDevice, getGroupKey } from '../../src/lib/device';
 import { useRelay } from '../../src/hooks/use-relay';
 import { projectChild, projectPumps } from '@kinhale/sync';
+import { DisclaimerFooter } from '../../src/components/DisclaimerFooter';
 
 const SYMPTOMS = ['cough', 'wheezing', 'shortness_of_breath', 'chest_tightness'] as const;
 const CIRCUMSTANCES = ['exercise', 'allergen', 'cold_air', 'night', 'infection', 'stress'] as const;
@@ -189,6 +190,8 @@ export default function AddDoseScreen(): JSX.Element {
       >
         {loading ? t('journal.saving') : t('journal.save')}
       </Button>
+      {/* Pied E4 saisie : disclaimer discret RM27. */}
+      <DisclaimerFooter />
     </YStack>
   );
 }

--- a/apps/mobile/app/onboarding/__tests__/child.test.tsx
+++ b/apps/mobile/app/onboarding/__tests__/child.test.tsx
@@ -56,6 +56,12 @@ describe('OnboardingChildScreen', () => {
     expect(screen.getAllByRole('header').length).toBeGreaterThanOrEqual(1);
   });
 
+  it("affiche le DisclaimerBanner complet (RM27, KIN-088) sur l'écran 1", () => {
+    renderWithProviders(<OnboardingChildScreen />);
+    expect(screen.getByTestId('disclaimer-banner-full')).toBeTruthy();
+    expect(screen.getByTestId('disclaimer-footer-short')).toBeTruthy();
+  });
+
   it('navigue vers /onboarding/pump après sauvegarde réussie', async () => {
     renderWithProviders(<OnboardingChildScreen />);
     fireEvent.changeText(screen.getByPlaceholderText(/prénom|first name/i), 'Emma');

--- a/apps/mobile/app/onboarding/child.tsx
+++ b/apps/mobile/app/onboarding/child.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '../../src/stores/auth-store';
 import { useDocStore } from '../../src/stores/doc-store';
 import { getOrCreateDevice } from '../../src/lib/device';
 import { useOnlineGuard } from '../../src/hooks/useOnlineGuard';
+import { DisclaimerBanner, DisclaimerFooter } from '../../src/components/DisclaimerFooter';
 
 export default function OnboardingChildScreen(): JSX.Element {
   const { t } = useTranslation('common');
@@ -46,6 +47,8 @@ export default function OnboardingChildScreen(): JSX.Element {
 
   return (
     <YStack padding="$4" gap="$4">
+      {/* Onboarding écran 1 : disclaimer complet RM27 affiché d'entrée. */}
+      <DisclaimerBanner />
       <H1>{t('onboarding.child.title')}</H1>
       <Text fontWeight="600">{t('onboarding.child.firstNameLabel')}</Text>
       <Input
@@ -83,6 +86,8 @@ export default function OnboardingChildScreen(): JSX.Element {
       >
         {loading ? t('onboarding.child.saving') : t('onboarding.child.save')}
       </Button>
+      {/* Pied E10 : version discrète sur chaque étape onboarding. */}
+      <DisclaimerFooter />
     </YStack>
   );
 }

--- a/apps/mobile/app/onboarding/plan.tsx
+++ b/apps/mobile/app/onboarding/plan.tsx
@@ -7,6 +7,7 @@ import { useAuthStore } from '../../src/stores/auth-store';
 import { useDocStore } from '../../src/stores/doc-store';
 import { getOrCreateDevice } from '../../src/lib/device';
 import { useOnlineGuard } from '../../src/hooks/useOnlineGuard';
+import { DisclaimerFooter } from '../../src/components/DisclaimerFooter';
 
 export default function OnboardingPlanScreen(): JSX.Element {
   const { t } = useTranslation('common');
@@ -113,6 +114,8 @@ export default function OnboardingPlanScreen(): JSX.Element {
       >
         {loading ? t('onboarding.plan.saving') : t('onboarding.plan.save')}
       </Button>
+      {/* Pied E10 : disclaimer discret omniprésent (RM27). */}
+      <DisclaimerFooter />
     </YStack>
   );
 }

--- a/apps/mobile/app/onboarding/pump.tsx
+++ b/apps/mobile/app/onboarding/pump.tsx
@@ -5,6 +5,7 @@ import { YStack, H1, Button, Text, Input, XStack } from 'tamagui';
 import { useAuthStore } from '../../src/stores/auth-store';
 import { useDocStore } from '../../src/stores/doc-store';
 import { getOrCreateDevice } from '../../src/lib/device';
+import { DisclaimerFooter } from '../../src/components/DisclaimerFooter';
 
 export default function OnboardingPumpScreen(): JSX.Element {
   const { t } = useTranslation('common');
@@ -107,6 +108,8 @@ export default function OnboardingPumpScreen(): JSX.Element {
       >
         {loading ? t('onboarding.pump.saving') : t('onboarding.pump.save')}
       </Button>
+      {/* Pied E10 : disclaimer discret omniprésent (RM27). */}
+      <DisclaimerFooter />
     </YStack>
   );
 }

--- a/apps/mobile/app/settings/__tests__/about.test.tsx
+++ b/apps/mobile/app/settings/__tests__/about.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react-native';
+import SettingsAboutScreen from '../about';
+import { renderWithProviders } from '../../../src/test-utils/render';
+
+describe('SettingsAboutScreen (mobile)', () => {
+  jest.setTimeout(15000);
+
+  it('affiche le DisclaimerBanner complet (RM27)', async () => {
+    renderWithProviders(<SettingsAboutScreen />);
+    await waitFor(() => {
+      expect(screen.getByTestId('disclaimer-banner-full')).toBeTruthy();
+    });
+  });
+
+  it('affiche la version applicative et la licence AGPL v3', async () => {
+    renderWithProviders(<SettingsAboutScreen />);
+    await waitFor(() => {
+      expect(screen.getByTestId('settings-about-version')).toBeTruthy();
+    });
+    expect(screen.getByText(/AGPL v3/)).toBeTruthy();
+  });
+
+  it('affiche les liens licence + source + politique de confidentialité', async () => {
+    renderWithProviders(<SettingsAboutScreen />);
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/voir le texte de la licence|read the licence text/i),
+      ).toBeTruthy();
+    });
+    expect(screen.getByLabelText(/dépôt public|public repository/i)).toBeTruthy();
+    expect(screen.getByLabelText(/politique de confidentialité|privacy policy/i)).toBeTruthy();
+  });
+});

--- a/apps/mobile/app/settings/about.tsx
+++ b/apps/mobile/app/settings/about.tsx
@@ -1,0 +1,106 @@
+import React, { type JSX } from 'react';
+import { Linking } from 'react-native';
+import { useTranslation } from 'react-i18next';
+import { YStack, XStack, H1, H2, Text, Button, Card } from 'tamagui';
+import { DisclaimerBanner } from '../../src/components/DisclaimerFooter';
+
+/**
+ * Écran « Paramètres → À propos » mobile — KIN-088, E9-S05, RM27.
+ *
+ * Symétrique de `apps/web/src/app/settings/about/page.tsx` :
+ * - DisclaimerBanner (texte complet RM27),
+ * - version applicative (`EXPO_PUBLIC_APP_VERSION` avec fallback),
+ * - mention licence AGPL v3 + lien web vers le texte de licence,
+ * - éditeur Kamez Conseils + adresse RPRP `privacy@kinhale.health`,
+ * - lien vers la politique de confidentialité (placeholder en v1.0).
+ *
+ * Aucune chaîne hardcodée, aucune recommandation médicale (RM8 + RM27),
+ * aucune donnée santé.
+ */
+const APP_VERSION = process.env['EXPO_PUBLIC_APP_VERSION'] ?? 'v1.0.0-preview';
+const LICENSE_URL = 'https://www.gnu.org/licenses/agpl-3.0.html';
+const SOURCE_URL = 'https://github.com/kamez/kinhale';
+// TODO(KIN-???): remplacer par la page statique dédiée mineurs lorsque
+// disponible. Pour l'instant on renvoie vers privacy@kinhale.health.
+const PRIVACY_POLICY_URL = 'https://kinhale.health/legal/privacy';
+
+export default function SettingsAboutScreen(): JSX.Element {
+  const { t } = useTranslation('common');
+
+  const openExternal = (url: string): void => {
+    void Linking.openURL(url).catch(() => undefined);
+  };
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1>{t('settingsAbout.heading')}</H1>
+      <Text fontSize="$3" color="$color11">
+        {t('settingsAbout.description')}
+      </Text>
+
+      <DisclaimerBanner />
+
+      <Card padded bordered>
+        <YStack gap="$3">
+          <H2>{t('settingsAbout.title')}</H2>
+
+          <XStack justifyContent="space-between" gap="$3" flexWrap="wrap">
+            <Text fontWeight="600">{t('settingsAbout.versionLabel')}</Text>
+            <Text testID="settings-about-version" selectable>
+              {APP_VERSION}
+            </Text>
+          </XStack>
+
+          <XStack justifyContent="space-between" gap="$3" flexWrap="wrap">
+            <Text fontWeight="600">{t('settingsAbout.licenseLabel')}</Text>
+            <Text>{t('settingsAbout.licenseValue')}</Text>
+          </XStack>
+
+          <Button
+            onPress={() => openExternal(LICENSE_URL)}
+            accessibilityRole="link"
+            accessibilityLabel={t('settingsAbout.licenseLink')}
+            theme="alt2"
+          >
+            {t('settingsAbout.licenseLink')}
+          </Button>
+
+          <Button
+            onPress={() => openExternal(SOURCE_URL)}
+            accessibilityRole="link"
+            accessibilityLabel={t('settingsAbout.sourceLink')}
+            theme="alt2"
+          >
+            {t('settingsAbout.sourceLink')}
+          </Button>
+
+          <XStack justifyContent="space-between" gap="$3" flexWrap="wrap">
+            <Text fontWeight="600">{t('settingsAbout.publisherLabel')}</Text>
+            <Text>{t('settingsAbout.publisherValue')}</Text>
+          </XStack>
+
+          <XStack justifyContent="space-between" gap="$3" flexWrap="wrap">
+            <Text fontWeight="600">{t('settingsAbout.contactLabel')}</Text>
+            <Text selectable>{t('settingsAbout.contactValue')}</Text>
+          </XStack>
+        </YStack>
+      </Card>
+
+      <Card padded bordered>
+        <YStack gap="$2">
+          <H2>{t('settingsAbout.privacyPolicy')}</H2>
+          <Text fontSize="$2" color="$color11">
+            {t('settingsAbout.privacyPolicyDescription')}
+          </Text>
+          <Button
+            onPress={() => openExternal(PRIVACY_POLICY_URL)}
+            accessibilityRole="link"
+            accessibilityLabel={t('settingsAbout.privacyPolicy')}
+          >
+            {t('settingsAbout.privacyPolicy')}
+          </Button>
+        </YStack>
+      </Card>
+    </YStack>
+  );
+}

--- a/apps/mobile/src/components/DisclaimerFooter.tsx
+++ b/apps/mobile/src/components/DisclaimerFooter.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { YStack, Text } from 'tamagui';
+
+/**
+ * Composants disclaimer non-dispositif-médical (RM27) — version mobile.
+ *
+ * Symétrique de `apps/web/src/components/DisclaimerFooter.tsx`. La
+ * duplication est volontaire : pas de package `@kinhale/ui` partagé en
+ * v1.0 (cf. CLAUDE.md). Les deux versions consomment les mêmes clés i18n
+ * (`disclaimer.full` / `disclaimer.short`) — le texte reste la source de
+ * vérité unique.
+ *
+ * Accessibilité native : `accessibilityRole="text"` (équivalent rôle
+ * informatif) + `accessibilityLabel` i18n.
+ *
+ * Refs: KIN-088 / E9-S05 / RM27.
+ */
+
+export interface DisclaimerFooterProps {
+  readonly accessibilityLabel?: string;
+}
+
+export function DisclaimerFooter({ accessibilityLabel }: DisclaimerFooterProps): React.JSX.Element {
+  const { t } = useTranslation('common');
+  const label = accessibilityLabel ?? t('disclaimer.ariaLabel');
+  return (
+    <Text
+      testID="disclaimer-footer-short"
+      accessible
+      accessibilityRole="text"
+      accessibilityLabel={label}
+      fontSize="$2"
+      color="$color11"
+      textAlign="center"
+      paddingVertical="$2"
+      paddingHorizontal="$3"
+    >
+      {t('disclaimer.short')}
+    </Text>
+  );
+}
+
+export function DisclaimerBanner({ accessibilityLabel }: DisclaimerFooterProps): React.JSX.Element {
+  const { t } = useTranslation('common');
+  const label = accessibilityLabel ?? t('disclaimer.ariaLabel');
+  return (
+    <YStack
+      testID="disclaimer-banner-full"
+      accessible
+      accessibilityRole="text"
+      accessibilityLabel={label}
+      backgroundColor="$backgroundStrong"
+      borderColor="$borderColor"
+      borderWidth={1}
+      borderRadius="$3"
+      padding="$3"
+    >
+      <Text fontSize="$3" color="$color12" lineHeight="$3">
+        {t('disclaimer.full')}
+      </Text>
+    </YStack>
+  );
+}

--- a/apps/mobile/src/components/__tests__/DisclaimerFooter.test.tsx
+++ b/apps/mobile/src/components/__tests__/DisclaimerFooter.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react-native';
+import { DisclaimerFooter, DisclaimerBanner } from '../DisclaimerFooter';
+import { renderWithProviders } from '../../test-utils/render';
+
+describe('DisclaimerFooter (mobile)', () => {
+  jest.setTimeout(15000);
+
+  it('affiche la version courte avec accessibilityLabel i18n', async () => {
+    renderWithProviders(<DisclaimerFooter />);
+    await waitFor(() => {
+      expect(screen.getByTestId('disclaimer-footer-short')).toBeTruthy();
+    });
+    expect(screen.getByText(/journal d.aidants|caregiver journal/i)).toBeTruthy();
+    // Le label vocal doit être traduit (pas la chaîne brute "ariaLabel").
+    const node = screen.getByLabelText(
+      /avertissement non.dispositif|non.medical.device disclaimer/i,
+    );
+    expect(node).toBeTruthy();
+  });
+});
+
+describe('DisclaimerBanner (mobile)', () => {
+  jest.setTimeout(15000);
+
+  it('affiche le texte complet RM27', async () => {
+    renderWithProviders(<DisclaimerBanner />);
+    await waitFor(() => {
+      expect(screen.getByTestId('disclaimer-banner-full')).toBeTruthy();
+    });
+    expect(
+      screen.getByText(/ne remplace pas un avis médical|does not replace medical advice/i),
+    ).toBeTruthy();
+    expect(screen.getByText(/dispositif médical|medical device/i)).toBeTruthy();
+  });
+
+  it('ne contient aucune recommandation médicale (RM8 + RM27)', async () => {
+    renderWithProviders(<DisclaimerBanner />);
+    await waitFor(() => {
+      expect(screen.getByTestId('disclaimer-banner-full')).toBeTruthy();
+    });
+    // Le texte affiché ne doit comporter aucune injonction médicale type
+    // « appelez votre médecin / call your doctor / seek emergency ».
+    expect(screen.queryByText(/appelez|call your|consult.+immediately|seek emergency/i)).toBeNull();
+  });
+});

--- a/apps/web/src/app/auth/__tests__/page.test.tsx
+++ b/apps/web/src/app/auth/__tests__/page.test.tsx
@@ -26,6 +26,11 @@ describe('AuthPage', () => {
     expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument();
   });
 
+  it('affiche le DisclaimerFooter discret (RM27, KIN-088)', () => {
+    renderWithProviders(<AuthPage />);
+    expect(screen.getByTestId('disclaimer-footer-short')).toBeTruthy();
+  });
+
   it('appelle apiFetch /auth/magic-link au clic sur soumettre', async () => {
     const { apiFetch } = jest.requireMock('../../../lib/api-client') as { apiFetch: jest.Mock };
     apiFetch.mockResolvedValue({ message: 'ok' });

--- a/apps/web/src/app/auth/page.tsx
+++ b/apps/web/src/app/auth/page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { YStack, H1, Input, Button, Text } from 'tamagui';
 import { apiFetch } from '../../lib/api-client';
+import { DisclaimerFooter } from '../../components/DisclaimerFooter';
 
 export default function AuthPage(): React.JSX.Element {
   const { t } = useTranslation('common');
@@ -32,6 +33,7 @@ export default function AuthPage(): React.JSX.Element {
     return (
       <YStack padding="$4" gap="$4" alignItems="center" justifyContent="center" flex={1}>
         <Text fontSize="$5">{t('auth.linkSent')}</Text>
+        <DisclaimerFooter />
       </YStack>
     );
   }
@@ -62,6 +64,8 @@ export default function AuthPage(): React.JSX.Element {
       >
         {loading ? t('common.loading') : t('auth.submit')}
       </Button>
+      {/* Pied E1 auth : disclaimer discret RM27. */}
+      <DisclaimerFooter />
     </YStack>
   );
 }

--- a/apps/web/src/app/journal/add/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/add/__tests__/page.test.tsx
@@ -94,6 +94,12 @@ describe('AddDosePage', () => {
     expect(screen.getAllByRole('button').length).toBeGreaterThanOrEqual(3); // maintenance + rescue + save
   });
 
+  it('affiche le DisclaimerFooter discret (RM27, KIN-088)', async () => {
+    renderWithProviders(<AddDosePage />);
+    await waitFor(() => expect(mockGetGroupKey).toHaveBeenCalledWith('hh-1'));
+    expect(screen.getByTestId('disclaimer-footer-short')).toBeTruthy();
+  });
+
   it('navigue vers /journal après sauvegarde réussie', async () => {
     // Fake timers : empêche Tamagui de scheduler des setState via setTimeout hors act(),
     // ce qui crée une boucle MutationObserver dans RTL v16 + React 19 + jsdom (CI Docker).

--- a/apps/web/src/app/journal/add/page.tsx
+++ b/apps/web/src/app/journal/add/page.tsx
@@ -10,6 +10,7 @@ import { projectChild, projectPumps } from '@kinhale/sync';
 import { getOrCreateDevice, getGroupKey } from '../../../lib/device';
 import { useRelay } from '../../../hooks/use-relay';
 import { useRequireAuth } from '../../../lib/useRequireAuth';
+import { DisclaimerFooter } from '../../../components/DisclaimerFooter';
 
 const SYMPTOMS = ['cough', 'wheezing', 'shortness_of_breath', 'chest_tightness'] as const;
 const CIRCUMSTANCES = ['exercise', 'allergen', 'cold_air', 'night', 'infection', 'stress'] as const;
@@ -192,6 +193,8 @@ export default function AddDosePage(): React.JSX.Element | null {
       <Button onPress={() => void handleSave()} disabled={loading} marginTop="$2">
         {loading ? t('journal.saving') : t('journal.save')}
       </Button>
+      {/* Pied E4 saisie : disclaimer discret RM27. */}
+      <DisclaimerFooter />
     </YStack>
   );
 }

--- a/apps/web/src/app/onboarding/child/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/child/__tests__/page.test.tsx
@@ -63,6 +63,13 @@ describe('OnboardingChildPage', () => {
     expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
   });
 
+  it("affiche le DisclaimerBanner complet (RM27, KIN-088) sur l'écran 1", () => {
+    renderWithProviders(<OnboardingChildPage />);
+    // Onboarding écran 1 → version complète + footer discret en pied.
+    expect(screen.getByTestId('disclaimer-banner-full')).toBeTruthy();
+    expect(screen.getByTestId('disclaimer-footer-short')).toBeTruthy();
+  });
+
   it('redirige vers /auth si non authentifié (#181)', async () => {
     mockAccessToken = null;
     jest.useFakeTimers();

--- a/apps/web/src/app/onboarding/child/page.tsx
+++ b/apps/web/src/app/onboarding/child/page.tsx
@@ -9,6 +9,7 @@ import { useDocStore } from '../../../stores/doc-store';
 import { getOrCreateDevice } from '../../../lib/device';
 import { useRequireAuth } from '../../../lib/useRequireAuth';
 import { useOnlineGuard } from '../../../hooks/useOnlineGuard';
+import { DisclaimerBanner, DisclaimerFooter } from '../../../components/DisclaimerFooter';
 
 export default function OnboardingChildPage(): React.JSX.Element | null {
   const { t } = useTranslation('common');
@@ -52,6 +53,8 @@ export default function OnboardingChildPage(): React.JSX.Element | null {
 
   return (
     <YStack padding="$4" gap="$4">
+      {/* Onboarding écran 1 : disclaimer complet RM27 affiché d'entrée. */}
+      <DisclaimerBanner />
       <H1>{t('onboarding.child.title')}</H1>
       <Text fontWeight="600">{t('onboarding.child.firstNameLabel')}</Text>
       <Input
@@ -78,6 +81,8 @@ export default function OnboardingChildPage(): React.JSX.Element | null {
       <Button onPress={() => void handleSave()} disabled={loading || !online} marginTop="$2">
         {loading ? t('onboarding.child.saving') : t('onboarding.child.save')}
       </Button>
+      {/* Pied E10 : version discrète sur chaque étape onboarding. */}
+      <DisclaimerFooter />
     </YStack>
   );
 }

--- a/apps/web/src/app/onboarding/plan/page.tsx
+++ b/apps/web/src/app/onboarding/plan/page.tsx
@@ -10,6 +10,7 @@ import { useDocStore } from '../../../stores/doc-store';
 import { getOrCreateDevice } from '../../../lib/device';
 import { useRequireAuth } from '../../../lib/useRequireAuth';
 import { useOnlineGuard } from '../../../hooks/useOnlineGuard';
+import { DisclaimerFooter } from '../../../components/DisclaimerFooter';
 
 export default function OnboardingPlanPage(): React.JSX.Element | null {
   const { t } = useTranslation('common');
@@ -93,6 +94,8 @@ export default function OnboardingPlanPage(): React.JSX.Element | null {
             {t('onboarding.plan.goToPumpCta')}
           </Button>
         </Card>
+        {/* Pied E10 : disclaimer discret omniprésent (RM27). */}
+        <DisclaimerFooter />
       </YStack>
     );
   }
@@ -143,6 +146,8 @@ export default function OnboardingPlanPage(): React.JSX.Element | null {
       <Button onPress={() => void handleSave()} disabled={loading || !online} marginTop="$2">
         {loading ? t('onboarding.plan.saving') : t('onboarding.plan.save')}
       </Button>
+      {/* Pied E10 : disclaimer discret omniprésent (RM27). */}
+      <DisclaimerFooter />
     </YStack>
   );
 }

--- a/apps/web/src/app/onboarding/pump/page.tsx
+++ b/apps/web/src/app/onboarding/pump/page.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from '../../../stores/auth-store';
 import { useDocStore } from '../../../stores/doc-store';
 import { getOrCreateDevice } from '../../../lib/device';
 import { useRequireAuth } from '../../../lib/useRequireAuth';
+import { DisclaimerFooter } from '../../../components/DisclaimerFooter';
 
 export default function OnboardingPumpPage(): React.JSX.Element | null {
   const { t } = useTranslation('common');
@@ -108,6 +109,8 @@ export default function OnboardingPumpPage(): React.JSX.Element | null {
       <Button onPress={() => void handleSave()} disabled={loading} marginTop="$2">
         {loading ? t('onboarding.pump.saving') : t('onboarding.pump.save')}
       </Button>
+      {/* Pied E10 : disclaimer discret omniprésent (RM27). */}
+      <DisclaimerFooter />
     </YStack>
   );
 }

--- a/apps/web/src/app/settings/about/__tests__/page.test.tsx
+++ b/apps/web/src/app/settings/about/__tests__/page.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { screen, act } from '@testing-library/react';
+import SettingsAboutPage from '../page';
+import { renderWithProviders } from '../../../../test-utils/render';
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('SettingsAboutPage (web)', () => {
+  jest.setTimeout(15000);
+
+  it('affiche le DisclaimerBanner complet (RM27)', async () => {
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<SettingsAboutPage />);
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(screen.getByTestId('disclaimer-banner-full')).toBeTruthy();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('affiche la version applicative et la licence AGPL v3', async () => {
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<SettingsAboutPage />);
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(screen.getByTestId('settings-about-version')).toBeTruthy();
+      expect(screen.getByText(/AGPL v3/)).toBeTruthy();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('affiche le lien vers la politique de confidentialité', async () => {
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<SettingsAboutPage />);
+      await act(async () => {
+        await flushPromises();
+      });
+      // Le label est unique entre Card heading + lien — au moins une occurrence.
+      expect(
+        screen.getAllByText(/politique de confidentialité|privacy policy/i).length,
+      ).toBeGreaterThan(0);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/web/src/app/settings/about/page.tsx
+++ b/apps/web/src/app/settings/about/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { YStack, XStack, H1, H2, Text, Card, Anchor } from 'tamagui';
+import { DisclaimerBanner } from '../../../components/DisclaimerFooter';
+
+/**
+ * Écran « Paramètres → À propos » — KIN-088, E9-S05, RM27.
+ *
+ * Affiche :
+ * - le disclaimer complet (DisclaimerBanner) — version RM27 source de vérité,
+ * - la version applicative lue depuis `NEXT_PUBLIC_APP_VERSION`
+ *   (avec fallback `v1.0.0-preview`),
+ * - la mention licence AGPL v3 + lien vers le texte de licence,
+ * - l'éditeur Kamez Conseils + l'adresse RPRP `privacy@kinhale.health`,
+ * - le lien vers la politique de confidentialité (placeholder local en
+ *   v1.0 — à remplacer par la page statique dédiée mineurs cf. KIN-???).
+ *
+ * Cet écran NE contient :
+ * - aucune chaîne hardcodée (toutes les libellés via i18n),
+ * - aucune recommandation médicale (RM8 + RM27),
+ * - aucune donnée santé (page statique).
+ */
+const APP_VERSION = process.env['NEXT_PUBLIC_APP_VERSION'] ?? 'v1.0.0-preview';
+const LICENSE_URL = 'https://www.gnu.org/licenses/agpl-3.0.html';
+const SOURCE_URL = 'https://github.com/kamez/kinhale';
+// TODO(KIN-???): remplacer par la page statique dédiée mineurs lorsque
+// disponible. Pour l'instant on renvoie vers privacy@kinhale.health.
+const PRIVACY_POLICY_URL = '/legal/privacy';
+
+export default function SettingsAboutPage(): React.JSX.Element {
+  const { t } = useTranslation('common');
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1>{t('settingsAbout.heading')}</H1>
+      <Text fontSize="$3" color="$color11">
+        {t('settingsAbout.description')}
+      </Text>
+
+      <DisclaimerBanner />
+
+      <Card padded bordered>
+        <YStack gap="$3">
+          <H2>{t('settingsAbout.title')}</H2>
+
+          <XStack justifyContent="space-between" gap="$3" flexWrap="wrap">
+            <Text fontWeight="600">{t('settingsAbout.versionLabel')}</Text>
+            <Text testID="settings-about-version" selectable>
+              {APP_VERSION}
+            </Text>
+          </XStack>
+
+          <XStack justifyContent="space-between" gap="$3" flexWrap="wrap">
+            <Text fontWeight="600">{t('settingsAbout.licenseLabel')}</Text>
+            <Text>{t('settingsAbout.licenseValue')}</Text>
+          </XStack>
+
+          <Anchor
+            href={LICENSE_URL}
+            target="_blank"
+            rel="noreferrer noopener"
+            color="$blue11"
+            textDecorationLine="underline"
+          >
+            {t('settingsAbout.licenseLink')}
+          </Anchor>
+
+          <XStack justifyContent="space-between" gap="$3" flexWrap="wrap">
+            <Text fontWeight="600">{t('settingsAbout.sourceLabel')}</Text>
+            <Anchor
+              href={SOURCE_URL}
+              target="_blank"
+              rel="noreferrer noopener"
+              color="$blue11"
+              textDecorationLine="underline"
+            >
+              {t('settingsAbout.sourceLink')}
+            </Anchor>
+          </XStack>
+
+          <XStack justifyContent="space-between" gap="$3" flexWrap="wrap">
+            <Text fontWeight="600">{t('settingsAbout.publisherLabel')}</Text>
+            <Text>{t('settingsAbout.publisherValue')}</Text>
+          </XStack>
+
+          <XStack justifyContent="space-between" gap="$3" flexWrap="wrap">
+            <Text fontWeight="600">{t('settingsAbout.contactLabel')}</Text>
+            <Text selectable>{t('settingsAbout.contactValue')}</Text>
+          </XStack>
+        </YStack>
+      </Card>
+
+      <Card padded bordered>
+        <YStack gap="$2">
+          <H2>{t('settingsAbout.privacyPolicy')}</H2>
+          <Text fontSize="$2" color="$color11">
+            {t('settingsAbout.privacyPolicyDescription')}
+          </Text>
+          <Anchor href={PRIVACY_POLICY_URL} color="$blue11" textDecorationLine="underline">
+            {t('settingsAbout.privacyPolicy')}
+          </Anchor>
+        </YStack>
+      </Card>
+    </YStack>
+  );
+}

--- a/apps/web/src/components/DisclaimerFooter.tsx
+++ b/apps/web/src/components/DisclaimerFooter.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { YStack, Text } from 'tamagui';
+
+/**
+ * Composants disclaimer non-dispositif-médical (RM27).
+ *
+ * Deux variantes :
+ * - {@link DisclaimerFooter} : version discrète d'une ligne pour les pieds
+ *   d'écran (E1 auth, E4 saisie, étapes E10 onboarding).
+ * - {@link DisclaimerBanner} : version complète à intégrer en haut de
+ *   l'onboarding (écran 1) et dans Settings → À propos.
+ *
+ * Source de vérité texte : `disclaimer.full` / `disclaimer.short` dans
+ * `packages/i18n/src/locales/{fr,en}/common.json`. Aucune chaîne hardcodée.
+ *
+ * Accessibilité : rôle ARIA `note`, `aria-label` i18n explicite, contraste
+ * WCAG AA via tokens Tamagui (`$color11` sur fond), taille minimale 12 px
+ * pour `short`, 14 px pour `full`.
+ *
+ * Refs: KIN-088 / E9-S05 / RM27.
+ */
+
+export interface DisclaimerFooterProps {
+  /** Override du label vocal (sinon `disclaimer.ariaLabel`). */
+  readonly accessibilityLabel?: string;
+}
+
+/**
+ * Disclaimer discret (une ligne) à placer en pied d'écran.
+ */
+export function DisclaimerFooter({ accessibilityLabel }: DisclaimerFooterProps): React.JSX.Element {
+  const { t } = useTranslation('common');
+  const label = accessibilityLabel ?? t('disclaimer.ariaLabel');
+  return (
+    <Text
+      testID="disclaimer-footer-short"
+      role="note"
+      aria-label={label}
+      fontSize="$2"
+      color="$color11"
+      textAlign="center"
+      paddingVertical="$2"
+      paddingHorizontal="$3"
+    >
+      {t('disclaimer.short')}
+    </Text>
+  );
+}
+
+/**
+ * Disclaimer complet (bandeau) — onboarding écran 1 et Settings → À propos.
+ */
+export function DisclaimerBanner({ accessibilityLabel }: DisclaimerFooterProps): React.JSX.Element {
+  const { t } = useTranslation('common');
+  const label = accessibilityLabel ?? t('disclaimer.ariaLabel');
+  return (
+    <YStack
+      testID="disclaimer-banner-full"
+      role="note"
+      aria-label={label}
+      backgroundColor="$backgroundStrong"
+      borderColor="$borderColor"
+      borderWidth={1}
+      borderRadius="$3"
+      padding="$3"
+    >
+      <Text fontSize="$3" color="$color12" lineHeight="$3">
+        {t('disclaimer.full')}
+      </Text>
+    </YStack>
+  );
+}

--- a/apps/web/src/components/__tests__/DisclaimerFooter.test.tsx
+++ b/apps/web/src/components/__tests__/DisclaimerFooter.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { screen, act } from '@testing-library/react';
+import { DisclaimerFooter, DisclaimerBanner } from '../DisclaimerFooter';
+import { renderWithProviders } from '../../test-utils/render';
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe('DisclaimerFooter (web)', () => {
+  jest.setTimeout(15000);
+
+  it('affiche la version courte par défaut avec un rôle status', async () => {
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<DisclaimerFooter />);
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(screen.getByTestId('disclaimer-footer-short')).toBeTruthy();
+      expect(screen.getByText(/journal d.aidants|caregiver journal/i)).toBeTruthy();
+      // Rôle ARIA permettant la lecture par lecteurs d'écran sans interrompre.
+      expect(screen.getByRole('note')).toBeTruthy();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it("expose un aria-label i18n pour les lecteurs d'écran", async () => {
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<DisclaimerFooter />);
+      await act(async () => {
+        await flushPromises();
+      });
+      const node = screen.getByLabelText(
+        /avertissement non.dispositif|non.medical.device disclaimer/i,
+      );
+      expect(node).toBeTruthy();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('DisclaimerBanner (web)', () => {
+  jest.setTimeout(15000);
+
+  it('affiche le texte complet RM27', async () => {
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<DisclaimerBanner />);
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(screen.getByTestId('disclaimer-banner-full')).toBeTruthy();
+      expect(
+        screen.getByText(/ne remplace pas un avis médical|does not replace medical advice/i),
+      ).toBeTruthy();
+      expect(screen.getByText(/dispositif médical|medical device/i)).toBeTruthy();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  it('ne contient aucune recommandation médicale (RM8 + RM27)', async () => {
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<DisclaimerBanner />);
+      await act(async () => {
+        await flushPromises();
+      });
+      const banner = screen.getByTestId('disclaimer-banner-full');
+      const text = banner.textContent ?? '';
+      // Aucune phrase imperative type « appelez votre médecin / call your doctor »
+      // ne doit apparaître. Le disclaimer reste strictement informatif.
+      expect(text).not.toMatch(/appelez|call your|consult.+immediately|seek emergency/i);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+});

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -226,7 +226,7 @@
       "week": "Week of",
       "none": "None"
     },
-    "disclaimer": "This document is a journal provided by the child's caregivers. It contains no medical interpretation, no dose recommendation, no diagnosis. It is intended to support the discussion with the healthcare professional.",
+    "disclaimer": "Kinhale is a cooperative journal kept by caregivers. It does not replace medical advice, does not diagnose, and does not recommend any treatment. It is not certified as a medical device under Health Canada, FDA, or CE rules. Your data stays under your exclusive control on your devices.",
     "integrity": {
       "label": "Document integrity",
       "hashLabel": "SHA-256 hash",
@@ -344,6 +344,28 @@
       "errorNotPending": "No deletion in progress for this account.",
       "errorGeneric": "Could not cancel. Please retry."
     }
+  },
+  "disclaimer": {
+    "full": "Kinhale is a cooperative journal kept by caregivers. It does not replace medical advice, does not diagnose, and does not recommend any treatment. It is not certified as a medical device under Health Canada, FDA, or CE rules. Your data stays under your exclusive control on your devices.",
+    "short": "Caregiver journal, not medical advice.",
+    "ariaLabel": "Non-medical-device disclaimer"
+  },
+  "settingsAbout": {
+    "title": "About",
+    "heading": "About Kinhale",
+    "description": "Kinhale is an open-source project by Kamez Conseils. The app is a cooperative journal and coordination tool between caregivers — not a medical device.",
+    "versionLabel": "Version",
+    "licenseLabel": "Licence",
+    "licenseValue": "AGPL v3 — open source",
+    "licenseLink": "Read the licence text",
+    "sourceLabel": "Source code",
+    "sourceLink": "Public repository",
+    "publisherLabel": "Publisher",
+    "publisherValue": "Kamez Conseils",
+    "privacyPolicy": "Privacy policy",
+    "privacyPolicyDescription": "Read the privacy policy dedicated to minors.",
+    "contactLabel": "Privacy officer",
+    "contactValue": "privacy@kinhale.health"
   },
   "privacyExport": {
     "title": "Export my data",

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -226,7 +226,7 @@
       "week": "Semaine du",
       "none": "Aucun"
     },
-    "disclaimer": "Ce document est un journal fourni par les aidants. Il ne contient aucune interprétation médicale, aucune recommandation de dose, aucun diagnostic. Il est destiné à faciliter le dialogue avec le professionnel de santé.",
+    "disclaimer": "Kinhale est un journal coopératif fourni par des aidants. Il ne remplace pas un avis médical, ne diagnostique pas et ne recommande aucun traitement. Il n'est pas certifié comme dispositif médical au sens de Santé Canada, de la FDA ou du marquage CE. Vos données restent sous votre contrôle exclusif sur vos appareils.",
     "integrity": {
       "label": "Intégrité du document",
       "hashLabel": "Hash SHA-256",
@@ -344,6 +344,28 @@
       "errorNotPending": "Aucune suppression en cours sur ce compte.",
       "errorGeneric": "Impossible d'annuler. Réessayez."
     }
+  },
+  "disclaimer": {
+    "full": "Kinhale est un journal coopératif fourni par des aidants. Il ne remplace pas un avis médical, ne diagnostique pas et ne recommande aucun traitement. Il n'est pas certifié comme dispositif médical au sens de Santé Canada, de la FDA ou du marquage CE. Vos données restent sous votre contrôle exclusif sur vos appareils.",
+    "short": "Journal d'aidants, pas un avis médical.",
+    "ariaLabel": "Avertissement non-dispositif-médical"
+  },
+  "settingsAbout": {
+    "title": "À propos",
+    "heading": "À propos de Kinhale",
+    "description": "Kinhale est un projet open source porté par Kamez Conseils. L'application est un journal coopératif et un outil de coordination entre aidants — pas un dispositif médical.",
+    "versionLabel": "Version",
+    "licenseLabel": "Licence",
+    "licenseValue": "AGPL v3 — code source ouvert",
+    "licenseLink": "Voir le texte de la licence",
+    "sourceLabel": "Code source",
+    "sourceLink": "Dépôt public",
+    "publisherLabel": "Éditeur",
+    "publisherValue": "Kamez Conseils",
+    "privacyPolicy": "Politique de confidentialité",
+    "privacyPolicyDescription": "Consulter la politique de confidentialité dédiée mineurs.",
+    "contactLabel": "Contact RPRP",
+    "contactValue": "privacy@kinhale.health"
   },
   "privacyExport": {
     "title": "Exporter mes données",


### PR DESCRIPTION
## Summary

- Implémente **E9-S05 / RM27** : disclaimer non-dispositif-médical visible sur toutes les zones critiques (onboarding écran 1, pied E1 auth, pied E4 saisie, pieds E10 onboarding, page Settings → À propos), avec une **source de vérité i18n unique** (`disclaimer.full` / `disclaimer.short`) consommée également par le PDF rapport médecin (KIN-083).
- Composants partagés `DisclaimerBanner` (complet) + `DisclaimerFooter` (discret) sur web et mobile, dupliqués intentionnellement (pas de package `@kinhale/ui` en v1.0). Texte centralisé en i18n FR + EN.
- Nouvelle page **Settings → À propos** avec version applicative, licence AGPL v3 + lien GNU, éditeur Kamez Conseils, contact RPRP, lien politique de confidentialité (placeholder v1.0).

## Texte retenu (validé par `kz-conformite`)

**FR (full)** : *« Kinhale est un journal coopératif fourni par des aidants. Il ne remplace pas un avis médical, ne diagnostique pas et ne recommande aucun traitement. Il n'est pas certifié comme dispositif médical au sens de Santé Canada, de la FDA ou du marquage CE. Vos données restent sous votre contrôle exclusif sur vos appareils. »*

**EN (full)** : *"Kinhale is a cooperative journal kept by caregivers. It does not replace medical advice, does not diagnose, and does not recommend any treatment. It is not certified as a medical device under Health Canada, FDA, or CE rules. Your data stays under your exclusive control on your devices."*

**FR (short)** : *« Journal d'aidants, pas un avis médical. »*
**EN (short)** : *"Caregiver journal, not medical advice."*

Aucune phrase à ligne rouge RM8 (« appelez votre médecin », recommandation thérapeutique). Un test automatisé scanne le rendu pour interdire toute injonction médicale.

## Revues

| Revue | Verdict |
|---|---|
| `kz-review` | Approuvé après correction du majeur (migration `<Text><a>` → Tamagui `Anchor` dans `settings/about/page.tsx`). Rapport : `.agents/current-run/05-kz-review.md`. |
| `kz-conformite` | Validé sous réserve de 3 actions de suivi (issues GitHub à créer). Rapport : `.agents/current-run/05-kz-conformite-KIN-088.md`. |
| `kz-securite` | Non requis — UI pure, aucun ajout d'I/O ni d'auth ni de logique sensible. |

## Tests ajoutés (17, tous verts)

- **Web (10)** : 4 unit `DisclaimerFooter` (web) + 3 page `Settings → À propos` + 3 d'intégration (présence cross-écran onboarding/child, auth, journal/add).
- **Mobile (7)** : 3 unit `DisclaimerFooter` (mobile) + 3 page `Settings → À propos` + 1 d'intégration onboarding/child.

## Test plan

- [x] `pnpm format:check` vert
- [x] `pnpm lint:root` vert
- [x] `pnpm lint` vert (turbo, 9/9 packages)
- [x] `pnpm typecheck` vert (turbo, 9/9 packages)
- [x] `pnpm test` vert : web 141/141, mobile 91/91, reports 94/94 (Jest + Vitest)
- [ ] e2e Playwright/Maestro à valider en CI sur cette PR
- [ ] Revue humaine + 1 approbation
- [ ] Suivi : 3 issues à créer post-merge (AGPL repo, page privacy statique, COPPA US)

## Acceptance criteria E9-S05

- [x] GIVEN onboarding écran 1 THEN disclaimer complet (DisclaimerBanner sur `onboarding/child`)
- [x] GIVEN pied E1 (auth), E4 (saisie), E10 (chaque étape onboarding) THEN disclaimer discret (DisclaimerFooter)
- [x] GIVEN PDF rapport médecin THEN disclaimer en pied (clé `report.disclaimer` harmonisée sur `disclaimer.full`)
- [x] GIVEN Settings → À propos THEN disclaimer complet + version + AGPL v3 + privacy
- [x] i18n FR + EN, aucune chaîne hardcodée
- [x] Accessibilité : `role="note"` (web) / `accessibilityRole="text"` (mobile), `aria-label` / `accessibilityLabel` i18n, contraste WCAG AA via tokens Tamagui
- [x] Aucune recommandation médicale (RM8) — verrou test automatisé inclus

## Suivi (issues à créer post-merge)

1. Vérifier que `github.com/kamez/kinhale` est un repo public actif (obligation AGPL §13).
2. Créer la page statique `/legal/privacy` dédiée mineurs (bloquant conformité v1.0 — Loi 25 art. 8 + RGPD art. 13).
3. Disclaimer d'exclusion US à l'inscription (cf. cadre conformité §2.4 + §12.1, hors périmètre KIN-088).

Refs: KIN-088
Closes: E9-S05

🤖 Generated with [Claude Code](https://claude.com/claude-code)