### PR TITLE
docs(open-source): LICENSE AGPL v3 + README public + guide self-hosting (KIN-089)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,12 +76,19 @@ logs/
 *.pem
 *.key
 *.p12
+*.p8
 *.keystore
 *.jks
 !google-services.json.example
 !GoogleService-Info.plist.example
 google-services.json
 GoogleService-Info.plist
+secrets/
+private/
+
+# Self-hosting production env files (only the *.example template is committed)
+infra/docker/.env.prod
+infra/docker/.env.production
 
 # AWS
 .aws-sam/
@@ -100,6 +107,7 @@ temp/
 *.swo
 *~
 
-# Claude Code runtime
+# Claude Code runtime — local-only, never publish
+.claude/
 .claude/scheduled_tasks.lock
 .claude/session-*.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,139 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail
+address, posting via an official social media account, or acting as an
+appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**community@kinhale.health**. All complaints will be reviewed and investigated
+promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+When the reported behavior involves a child or a vulnerable family situation —
+which is a real possibility for an asthma-care community — the maintainers will
+treat the report with extra care and discretion. Reports involving immediate
+risk to a person should additionally be escalated to the appropriate local
+authorities by the reporter; the maintainers do not, and cannot, act as a
+crisis service.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Thank you for considering contributing to Kinhale! This project exists because p
 
 ### Code of Conduct
 
-This project adheres to the [Contributor Covenant](./CODE_OF_CONDUCT.md). By participating, you are expected to uphold it. Report unacceptable behaviour to `conduct@kinhale.app`.
+This project adheres to the [Contributor Covenant](./CODE_OF_CONDUCT.md). By participating, you are expected to uphold it. Report unacceptable behaviour to `community@kinhale.health`.
 
 ### How can I contribute?
 
@@ -106,7 +106,7 @@ Merci d'envisager une contribution à Kinhale ! Ce projet existe parce que des p
 
 ### Code de conduite
 
-Ce projet adhère au [Contributor Covenant](./CODE_OF_CONDUCT.md). En participant, vous vous engagez à le respecter. Signalez tout comportement inacceptable à `conduct@kinhale.app`.
+Ce projet adhère au [Contributor Covenant](./CODE_OF_CONDUCT.md). En participant, vous vous engagez à le respecter. Signalez tout comportement inacceptable à `community@kinhale.health`.
 
 ### Comment contribuer ?
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -3,7 +3,7 @@
 > _Un journal de suivi des pompes d'asthme pour enfant, chiffré de bout en bout et local d'abord — pensé par des aidants, pour les aidants._
 
 [![Licence : AGPL v3](https://img.shields.io/badge/Licence-AGPL_v3-blue.svg)](./LICENSE)
-[![Statut](https://img.shields.io/badge/statut-pré--alpha-orange.svg)]()
+[![Statut](https://img.shields.io/badge/statut-aperçu_v1.0-orange.svg)]()
 [![EN](https://img.shields.io/badge/lang-english-blue.svg)](./README.md)
 
 > **English: [read this README in English →](./README.md)**
@@ -57,17 +57,49 @@ Kinhale est un **outil de journalisation, de rappel et de partage**. Il ne recom
 
 ## État du projet
 
-Kinhale est en **pré-alpha**. Le développement actif commence au Sprint 0 du plan de livraison Kamez Conseils.
+Kinhale est en **aperçu v1.0**. Le code est en développement actif ; une
+instance officielle hébergée par Kamez Conseils en `ca-central-1` est prévue
+avec la sortie de la v1.0. Le self-hosting est supporté en *best effort* —
+voir le guide ci-dessous.
 
-## Démarrer
+## Démarrage rapide — développement
 
-La documentation développeur arrive dans `/docs/` dès l'ouverture du Sprint 0. Pour l'instant :
+```bash
+git clone https://github.com/kamez-conseils/kinhale.git
+cd kinhale
+pnpm install
+docker compose -f infra/docker/docker-compose.yml up -d
+pnpm dev
+```
 
-- Vue d'architecture : `docs/architecture/` *(à venir)*
+Le compose de développement embarque PostgreSQL, Redis, Mailpit (SMTP) et
+MinIO (S3) sur des ports locaux — voir
+[`infra/docker/README.md`](./infra/docker/README.md).
+
+## Démarrage rapide — self-hosting
+
+Si vous voulez exécuter votre propre relais (clinique, collectif
+d'auto-hébergement, déploiement familial), le guide complet est dans
+[`docs/user/SELF_HOSTING.md`](./docs/user/SELF_HOSTING.md). Version courte :
+
+```bash
+git clone https://github.com/kamez-conseils/kinhale.git
+cd kinhale
+git checkout v1.0.0
+cp infra/docker/.env.prod.example infra/docker/.env.prod
+# éditer infra/docker/.env.prod avec vos secrets et noms d'hôte
+docker compose -f infra/docker/docker-compose.prod.yml --env-file infra/docker/.env.prod up -d
+```
+
+## Documentation
+
+- Vue d'architecture : [`docs/architecture/ARCHITECTURE.md`](./docs/architecture/ARCHITECTURE.md)
+- Décisions d'architecture : [`docs/architecture/adr/`](./docs/architecture/adr/)
 - Guide de contribution : [CONTRIBUTING.md](./CONTRIBUTING.md)
-- Workflow Git (Gitflow) : `docs/contributing/GITFLOW.md`
+- Workflow Git (Gitflow) : [`docs/contributing/GITFLOW.md`](./docs/contributing/GITFLOW.md)
 - Politique de divulgation de vulnérabilités : [SECURITY.md](./SECURITY.md)
 - Code de conduite : [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+- Guide de self-hosting : [`docs/user/SELF_HOSTING.md`](./docs/user/SELF_HOSTING.md)
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > _A local-first, end-to-end encrypted asthma inhaler tracker for kids — built for caregivers, by caregivers._
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](./LICENSE)
-[![Status](https://img.shields.io/badge/status-pre--alpha-orange.svg)]()
+[![Status](https://img.shields.io/badge/status-v1.0--preview-orange.svg)]()
 [![FR](https://img.shields.io/badge/lang-français-blue.svg)](./README.fr.md)
 
 > **Français : [lire ce README en français →](./README.fr.md)**
@@ -57,17 +57,48 @@ Kinhale is a **logging, reminder and sharing tool**. It never recommends doses, 
 
 ## Project status
 
-Kinhale is **pre-alpha**. Active development begins Sprint 0 of the Kamez Conseils delivery plan.
+Kinhale is **v1.0 preview**. The codebase is under active development; an
+official production instance hosted by Kamez Conseils in `ca-central-1` is
+planned with the v1.0 release. Self-hosting is supported on a best-effort
+basis — see the guide below.
 
-## Getting started
+## Quickstart — development
 
-Developer documentation will land in `/docs/` once Sprint 0 opens. For now:
+```bash
+git clone https://github.com/kamez-conseils/kinhale.git
+cd kinhale
+pnpm install
+docker compose -f infra/docker/docker-compose.yml up -d
+pnpm dev
+```
 
-- Architecture overview: `docs/architecture/` _(coming soon)_
+The dev compose ships PostgreSQL, Redis, Mailpit (SMTP) and MinIO (S3) on
+local ports — see [`infra/docker/README.md`](./infra/docker/README.md).
+
+## Quickstart — self-hosting
+
+If you want to run your own relay (clinic, self-hosting collective, family
+deployment) the full guide is in [`docs/user/SELF_HOSTING.md`](./docs/user/SELF_HOSTING.md).
+Short version:
+
+```bash
+git clone https://github.com/kamez-conseils/kinhale.git
+cd kinhale
+git checkout v1.0.0
+cp infra/docker/.env.prod.example infra/docker/.env.prod
+# edit infra/docker/.env.prod with your secrets and hostnames
+docker compose -f infra/docker/docker-compose.prod.yml --env-file infra/docker/.env.prod up -d
+```
+
+## Documentation
+
+- Architecture overview: [`docs/architecture/ARCHITECTURE.md`](./docs/architecture/ARCHITECTURE.md)
+- Architecture decisions: [`docs/architecture/adr/`](./docs/architecture/adr/)
 - Contribution guide: [CONTRIBUTING.md](./CONTRIBUTING.md)
-- Git workflow (Gitflow): `docs/contributing/GITFLOW.md`
+- Git workflow (Gitflow): [`docs/contributing/GITFLOW.md`](./docs/contributing/GITFLOW.md)
 - Security disclosure policy: [SECURITY.md](./SECURITY.md)
 - Code of conduct: [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
+- Self-hosting guide: [`docs/user/SELF_HOSTING.md`](./docs/user/SELF_HOSTING.md)
 
 ## Licence
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,146 @@
+# Security policy
+
+> Kinhale is a journal for caregivers of an asthmatic child. It is **not a
+> medical device** — but it carries health-adjacent data and a strong
+> zero-knowledge promise. We take security reports seriously.
+
+## Reporting a vulnerability
+
+**Please do not open a public GitHub issue for a security vulnerability.**
+
+Instead, email **security@kinhale.health** with:
+
+- A description of the issue
+- Steps to reproduce, ideally a minimal proof of concept
+- The version / commit SHA you tested against
+- Your name or handle if you wish to be credited (optional)
+
+If you require encryption, request our PGP fingerprint in a first contact email
+without sensitive details and we will reply with the public key.
+
+We acknowledge every report **within 5 business days**. For confirmed
+vulnerabilities we aim to ship a fix within:
+
+| Severity                                     | Target fix window |
+| -------------------------------------------- | ----------------- |
+| Critical (RCE, key extraction, data leak)    | 7 calendar days   |
+| High (auth bypass, IDOR, privilege escalat.) | 30 calendar days  |
+| Medium                                       | 60 calendar days  |
+| Low / informational                          | Best effort       |
+
+These windows apply to the **official Kamez Conseils relay**. Self-hosted
+instances run by third parties are responsible for applying patches once
+released.
+
+## Coordinated disclosure
+
+We follow a **coordinated disclosure** model:
+
+1. You report privately by email.
+2. We confirm reception within 5 business days, agree on severity, and propose
+   a fix timeline.
+3. We develop and validate a patch, with you in the loop if useful.
+4. We release the patch (security advisory, GitHub Security Advisory when
+   applicable).
+5. Public disclosure happens **after** users have had a reasonable window to
+   update — typically 7 to 14 days after release for a Critical / High issue.
+
+We will not pursue legal action against researchers who:
+
+- Report findings privately and in good faith.
+- Avoid privacy violations (no probing of real user data).
+- Avoid degradation of service for others (no DoS, no data destruction, no
+  spam).
+- Give us a reasonable window to address the issue before disclosure.
+
+## Hall of Fame
+
+Kinhale is a small, community-funded project. We do not run a paid bug bounty
+program in v1.0. We recognise responsible disclosure with a public thank-you
+in `SECURITY-THANKS.md` (added with the first valid report) and, where
+appropriate, in release notes. If you'd rather stay anonymous, that's fine too.
+
+## Scope
+
+### In scope
+
+The following code paths are in scope for security reports:
+
+- The Kinhale **API relay**: `apps/api/`
+- The mobile app: `apps/mobile/`
+- The web app: `apps/web/`
+- Cryptographic libraries: `packages/crypto/`
+- Sync engine: `packages/sync/`
+- Domain rules: `packages/domain/`
+- Reports / PDF / CSV generation: `packages/reports/`
+- CI/CD pipelines and release artifacts in `.github/`
+- The official relay we operate at the production hostname (announced at v1.0
+  release).
+
+### Out of scope
+
+- **Self-hosted instances run by third parties.** Bugs reproducible only on a
+  third-party deployment must be reported to that operator first; we will help
+  triage if the root cause is in upstream code, but operational issues
+  (misconfigured TLS, weak SMTP credentials, failed backups…) are the
+  operator's responsibility.
+- **Social engineering** of Kamez Conseils staff or community contributors.
+- **Physical access** attacks against staff devices.
+- **Denial-of-service** that requires significant resources (e.g. volumetric
+  DDoS), unless it stems from an algorithmic complexity bug.
+- **Vulnerabilities in third-party dependencies** without a working
+  proof-of-concept against Kinhale (please report those upstream).
+- **Spam / abuse** of forms (we have rate limiting; please don't try to bypass
+  it for fun).
+- Findings that boil down to **missing security headers** without a concrete
+  exploitation path.
+- **Best-practice opinions** without a reproducible weakness (e.g. "you should
+  use AES-GCM instead of XChaCha20-Poly1305"). The crypto choices have been
+  reviewed; we welcome principled debate, but those are not vulnerabilities.
+
+## What we promise (and what we don't)
+
+We promise:
+
+- **Zero-knowledge for health data.** The relay never sees plaintext puffs,
+  symptoms, child names, or pump types. Any deviation is a P0 incident.
+- **No health data in logs, metrics, push payloads, or emails.** Any leak is a
+  reportable bug.
+- A best-effort response within the windows above.
+
+We do not promise:
+
+- That the official relay is the right tool for clinical use. Kinhale is **not
+  a medical device**.
+- That self-hosted instances are equally hardened. Operators are responsible
+  for their own threat model.
+- Cash bounties.
+
+## Sensitive areas
+
+The following modules are flagged as **2-reviewer mandatory**:
+
+- `packages/crypto/`
+- `packages/sync/`
+- Anything under `apps/api/src/` that touches authentication, group key
+  distribution, mailbox routing, or push fan-out.
+
+Pull requests touching these areas must pass both an automated `kz-securite`
+review and a human security-trained reviewer (Martial Kaljob or a delegated
+maintainer).
+
+## Privacy and Loi 25 / GDPR
+
+Kinhale is operated from `ca-central-1` (Quebec, Canada) by Kamez Conseils.
+Privacy reports — distinct from technical vulnerabilities — should go to
+**privacy@kinhale.health**. We will involve the Office of the Privacy
+Commissioner of Canada (OPC) and the Commission d'accès à l'information du
+Québec (CAI) where required by law.
+
+## Contact
+
+- Security reports: **security@kinhale.health**
+- Privacy reports: **privacy@kinhale.health**
+- Code of Conduct reports: **community@kinhale.health**
+
+Thank you for helping keep families using Kinhale safe.

--- a/apps/api/src/__tests__/repo-hygiene.test.ts
+++ b/apps/api/src/__tests__/repo-hygiene.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Repo hygiene checks (KIN-089, E14-S01).
+ *
+ * These tests guard the open-source foundation of the repository:
+ *
+ * 1. Mandatory community files (LICENSE, README.md, CONTRIBUTING.md,
+ *    CODE_OF_CONDUCT.md, SECURITY.md) must exist at the root and have
+ *    non-trivial content. They are the surface that any first-time
+ *    contributor or self-hoster sees; deleting one by accident must
+ *    fail CI loudly.
+ *
+ * 2. The LICENSE must be the verbatim AGPL v3 text. We assert on a few
+ *    canonical phrases rather than the byte hash to allow normalising
+ *    line endings between editors.
+ *
+ * 3. The .gitignore must ignore the patterns that protect us from
+ *    committing secrets:
+ *      - .env / .env.* (with the .example escape hatch)
+ *      - .agents/ and .claude/ (internal workspaces)
+ *      - private key extensions (*.pem, *.key, *.p8 for APNs)
+ *      - secrets/ and private/
+ *      - infra/docker/.env.prod
+ *
+ * If you intentionally remove a pattern below, also update the corresponding
+ * security policy and reasoning — these checks are a backstop, not a
+ * substitute for code review.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../..');
+
+function readRoot(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+describe('repo hygiene — community files', () => {
+  it.each(['LICENSE', 'README.md', 'CONTRIBUTING.md', 'CODE_OF_CONDUCT.md', 'SECURITY.md'])(
+    '%s exists with non-trivial content',
+    (file) => {
+      const content = readRoot(file);
+      // Loose floor: 200 bytes filters out empty / placeholder files without
+      // pinning a specific document length.
+      expect(content.length).toBeGreaterThan(200);
+    },
+  );
+});
+
+describe('repo hygiene — LICENSE is AGPL v3 verbatim', () => {
+  const license = readRoot('LICENSE');
+
+  it('declares "GNU AFFERO GENERAL PUBLIC LICENSE"', () => {
+    expect(license).toContain('GNU AFFERO GENERAL PUBLIC LICENSE');
+  });
+
+  it('declares "Version 3, 19 November 2007"', () => {
+    expect(license).toContain('Version 3, 19 November 2007');
+  });
+
+  it('contains the §13 "Remote Network Interaction" clause', () => {
+    // §13 is the AGPL-specific clause that distinguishes it from the GPL —
+    // network operators must offer source. Removing it = silently
+    // downgrading the licence.
+    expect(license).toContain('Remote Network Interaction');
+  });
+
+  it('contains the closing FSF reference', () => {
+    expect(license).toContain('https://www.gnu.org/licenses/');
+  });
+});
+
+describe('repo hygiene — README mentions zero-knowledge & not-a-medical-device', () => {
+  const readme = readRoot('README.md');
+
+  it('references the zero-knowledge promise', () => {
+    expect(readme.toLowerCase()).toContain('zero-knowledge');
+  });
+
+  it('contains the not-a-medical-device disclaimer (RM27)', () => {
+    expect(readme.toLowerCase()).toContain('not a medical device');
+  });
+
+  it('points to SECURITY.md and CODE_OF_CONDUCT.md', () => {
+    expect(readme).toContain('SECURITY.md');
+    expect(readme).toContain('CODE_OF_CONDUCT.md');
+  });
+
+  it('points to the self-hosting guide', () => {
+    expect(readme).toContain('docs/user/SELF_HOSTING.md');
+  });
+});
+
+describe('repo hygiene — SECURITY.md surface', () => {
+  const security = readRoot('SECURITY.md');
+
+  it('exposes a contact email', () => {
+    expect(security).toContain('security@kinhale.health');
+  });
+
+  it('declares an acknowledgement window (5 business days)', () => {
+    expect(security).toMatch(/5 business days/i);
+  });
+
+  it('lists in-scope and out-of-scope sections', () => {
+    expect(security).toMatch(/in scope/i);
+    expect(security).toMatch(/out of scope/i);
+  });
+});
+
+describe('repo hygiene — .gitignore blocks secret-prone patterns', () => {
+  const gitignore = readRoot('.gitignore');
+  const requiredPatterns = [
+    '.env',
+    '.env.*',
+    '.agents/',
+    '.claude/',
+    '*.pem',
+    '*.key',
+    '*.p8',
+    'secrets/',
+    'private/',
+    'infra/docker/.env.prod',
+  ];
+
+  it.each(requiredPatterns)('ignores "%s"', (pattern) => {
+    // Match on a line boundary to avoid false positives inside comments.
+    const lineMatcher = new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'm');
+    expect(gitignore).toMatch(lineMatcher);
+  });
+
+  it('keeps an escape hatch for *.example env files', () => {
+    expect(gitignore).toMatch(/^!\.env\.example\s*$/m);
+  });
+});

--- a/docs/contributing/GITFLOW.md
+++ b/docs/contributing/GITFLOW.md
@@ -1,0 +1,191 @@
+# Gitflow — branching model for Kinhale
+
+> Authoritative reference. The short version lives in
+> [`CONTRIBUTING.md`](../../CONTRIBUTING.md); this document fills in the
+> details, edge cases, and the rationale.
+
+Kinhale uses a **Gitflow** branching model with linear history on `main`.
+The model balances three goals:
+
+1. **Stability of `main`** — only tagged releases reach production.
+2. **Continuous integration on `develop`** — feature work stays in flight
+   without waiting for a release window.
+3. **Auditability** — every change to a sensitive package
+   (`packages/crypto`, `packages/sync`, `apps/api/src/`) carries a clear
+   review trail.
+
+---
+
+## 1. Branch types
+
+### `main`
+
+- Production. Always deployable.
+- Tagged `vX.Y.Z` at every release.
+- Direct commits forbidden by branch protection.
+- Merge sources: `release/vX.Y.Z`, `hotfix/<id>-<slug>`.
+- Linear history enforced (rebase or fast-forward only).
+- Signed commits required.
+
+### `develop`
+
+- Integration branch.
+- Direct commits forbidden by branch protection.
+- Merge sources: `feature/<id>-<slug>`, `release/vX.Y.Z` (back-merge),
+  `hotfix/<id>-<slug>` (back-merge).
+- Squash-merge preferred for `feature/*`.
+- CI green is mandatory before merge.
+
+### `feature/<id>-<slug>`
+
+- Branched from `develop`. Merged into `develop`.
+- Naming: `feature/KIN-042-recovery-seed-bip39`.
+- Lifetime: ideally < 5 days. Long-lived features should be split.
+- Squash-merge into `develop`.
+
+### `release/vX.Y.Z`
+
+- Stabilisation branch.
+- Branched from `develop` once feature freeze is declared.
+- Allowed: bug fixes, version bumps, changelog entries, doc fixups.
+- Merged into **`main` AND `develop`**, then tagged `vX.Y.Z` on `main`.
+- Merge-commit (not squash) into `main` to preserve the stabilisation
+  history.
+
+### `hotfix/<id>-<slug>`
+
+- Urgent production fix.
+- Branched from `main`.
+- Merged into **`main` AND `develop`**, tagged `vX.Y.(Z+1)` on `main`.
+- Merge-commit into `main`. Optional squash into `develop`.
+
+### `support/vX.Y.x`
+
+- Long-term maintenance after v1.0 (security backports for older minors).
+- Branched from a tag.
+- Receives only `hotfix/*` cherry-picks.
+
+---
+
+## 2. Branch protection (configured at repository settings)
+
+| Rule                                                        | `main`           | `develop`        |
+| ----------------------------------------------------------- | ---------------- | ---------------- |
+| Direct push                                                 | Blocked          | Blocked          |
+| Pull request required                                       | Yes              | Yes              |
+| Approving reviews required                                  | 1 (2 if crypto)  | 1 (2 if crypto)  |
+| Stale approvals dismissed on new push                       | Yes              | Yes              |
+| Status checks required (`CI`, `Docker · node:20-alpine`)    | Yes              | Yes              |
+| Conversation resolution required                            | Yes              | Yes              |
+| Linear history                                              | Enforced         | Optional         |
+| Signed commits                                              | Required         | Required         |
+| Force push                                                  | Blocked          | Blocked          |
+| Admin bypass                                                | Disabled         | Disabled         |
+
+---
+
+## 3. Commit conventions
+
+We use [Conventional Commits 1.0](https://www.conventionalcommits.org/).
+The full rules live in [`CLAUDE.md`](../../CLAUDE.md). Highlights:
+
+- Subject ≤ 72 chars, imperative present, no trailing punctuation.
+- Type from: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `perf`,
+  `build`, `ci`, `security`, `revert`.
+- Scope optional but recommended (`crypto`, `sync`, `api`, `mobile`,
+  `web`, `ui`, `i18n`, `infra`, `ci`, `auth`, `push`, `offline`, …).
+- Body **mandatory** for any non-trivial commit. Explain *why*.
+- Footers for traceability: `Refs: KIN-042`, `Closes: #137`,
+  `Co-Authored-By: …`.
+- `BREAKING CHANGE:` footer plus `!` after the scope for breaking
+  changes (`feat(api)!: …`).
+- `security(<scope>)` for crypto / security changes; the body must
+  reference the relevant ADR and the test vectors added.
+
+---
+
+## 4. Pull request workflow
+
+1. **Branch** from up-to-date `develop`:
+   ```bash
+   git fetch origin
+   git checkout develop && git pull --ff-only
+   git checkout -b feature/KIN-042-recovery-seed-bip39
+   ```
+2. **TDD**: red test first, then minimal code, then refactor. Coverage
+   thresholds (`packages/crypto`, `packages/sync`, `packages/domain`) are
+   enforced in CI.
+3. **Local checks** before push:
+   ```bash
+   pnpm format:check
+   pnpm lint:root
+   pnpm lint
+   pnpm typecheck
+   pnpm test
+   ```
+4. **Automated review** (mandatory before opening a PR):
+   - `kz-review` on the diff.
+   - `kz-securite` if the change touches `packages/crypto`,
+     `packages/sync`, authentication, I/O, secrets, health data, push or
+     email payloads, or dependencies.
+   - Save the report to `.agents/current-run/kz-review-KIN-XXX.md`
+     and reference it in the PR description.
+5. **Address blockers and majors** in the same branch before opening the
+   PR. Minor follow-ups can land in a tracked ticket.
+6. **Open the PR** against `develop` (or `main` for hotfixes) with:
+   - A 1-2 sentence summary of *why*.
+   - A test plan (manual or automated).
+   - Links to ADRs / tickets.
+   - The `kz-review` / `kz-securite` verdict.
+7. **Human review** — at least 1 approval, 2 for sensitive zones. CI must
+   be green.
+8. **Squash-merge** into `develop` (the only mode allowed by the
+   repository settings for feature branches).
+
+---
+
+## 5. Releases
+
+1. Branch `release/vX.Y.Z` from `develop`.
+2. Bump version in `package.json` and run `pnpm changeset version` if
+   relevant; update `CHANGELOG.md`.
+3. Run the full local pipeline (`pnpm lint && pnpm typecheck && pnpm test
+   && pnpm e2e:web`) on the release branch.
+4. PR `release/vX.Y.Z` → `main`. Merge-commit (not squash). Tag `vX.Y.Z`
+   on `main` immediately after merge.
+5. Back-merge `release/vX.Y.Z` → `develop`. Delete the release branch.
+
+---
+
+## 6. Hotfixes
+
+1. Branch `hotfix/KIN-XXX-<slug>` from the latest tag on `main`.
+2. Fix + add a regression test.
+3. PR into `main`. Squash or merge-commit (your call, document in PR
+   description). Tag `vX.Y.(Z+1)`.
+4. Back-merge into `develop`. Delete the hotfix branch.
+
+---
+
+## 7. Signed commits
+
+Branch protection requires signed commits. We accept either:
+
+- **GPG**: see GitHub's
+  [signing commits with GPG](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
+  guide.
+- **SSH**: same as the SSH key used to push, configured via
+  `git config --global gpg.format ssh`. See
+  [signing commits with SSH](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification#ssh-commit-signature-verification).
+
+If your environment can't sign at all (e.g. some sandboxed CI agents),
+ask a maintainer to land the patch on your behalf.
+
+---
+
+## 8. Reverting
+
+- For a feature on `develop` that hasn't shipped: open a `revert: …` PR.
+- For a release that has shipped: prefer a `hotfix/*` rolling forward
+  with the corrective change. Reverting a release tag is a last resort
+  and must be documented in `CHANGELOG.md` plus an ADR.

--- a/docs/user/SELF_HOSTING.md
+++ b/docs/user/SELF_HOSTING.md
@@ -1,0 +1,418 @@
+# Self-hosting Kinhale
+
+> **Status (v1.0 preview).** Self-hosting is supported on a best-effort basis.
+> The official Kamez Conseils relay (announced at v1.0 release) remains the
+> recommended option for most families. If you want to operate your own
+> instance — for a clinic, a self-hosting collective, or simply because you
+> prefer it — this guide walks you through it end-to-end.
+
+---
+
+## Why self-host?
+
+Kinhale is **local-first and end-to-end encrypted**. Your child's health data
+never leaves the caregivers' devices in plaintext. The relay only routes
+opaque encrypted blobs.
+
+Self-hosting gives you:
+
+- **Full operational sovereignty.** You control the metadata (which device
+  talked to which device, when) on top of the existing zero-knowledge
+  guarantee on health content.
+- **Compliance flexibility.** You decide the jurisdiction, retention, and
+  backup policy.
+- **Independence from Kamez.** If Kamez Conseils ever shuts down its hosted
+  instance, your families keep working.
+
+What you **do not gain** by self-hosting:
+
+- Less crypto. The end-to-end encryption is the same on the official relay.
+- Less work. You take on TLS, backups, monitoring, and patching.
+
+---
+
+## What you are taking on (read this before installing)
+
+Self-hosting Kinhale means you become the **operator** of a service that
+caregivers use to coordinate care for an asthmatic child. That comes with
+responsibilities:
+
+- Apply security updates promptly. Subscribe to GitHub security advisories.
+- Maintain working **backups** (PostgreSQL + S3-compatible blob storage) and
+  **test restores**. Without backups, a disk loss erases authentication state
+  and the routing mailbox — devices will need to re-pair.
+- Maintain valid **TLS certificates**. Without TLS, login magic links and
+  WebSocket sync are insecure and the apps will refuse to connect.
+- Comply with **local privacy law** (GDPR in EU, Loi 25 in Québec, COPPA in
+  the US, etc.). The relay only sees pseudonymous identifiers and encrypted
+  blobs, but you are still a data controller for the metadata you store.
+- Be reachable. Provide a `security@` and `privacy@` email contact for the
+  caregivers using your instance.
+
+Kinhale is **not a medical device**. It does not recommend doses, does not
+diagnose, and does not generate "call your doctor" alerts. Self-hosting does
+not change that — your instance is still a journal + reminders + sharing tool.
+
+If any of the above feels like too much, please use the official relay
+instead.
+
+---
+
+## 1. Prerequisites
+
+| Item            | Minimum                                                  | Recommended |
+| --------------- | -------------------------------------------------------- | ----------- |
+| OS              | Linux x86_64 with `cgroups v2` (Ubuntu 22.04+, Debian 12) | Ubuntu 24.04 LTS |
+| Docker          | Docker Engine 24.0+ with Compose v2 plugin                | Latest stable |
+| RAM             | 2 GB                                                     | 4 GB |
+| Disk            | 20 GB SSD                                                | 50 GB SSD with daily snapshots |
+| CPU             | 2 vCPU                                                   | 4 vCPU |
+| Public hostname | A FQDN you control (e.g. `kinhale.example.org`)          | Wildcard cert friendly |
+| Outbound ports  | 80, 443 (TLS), 587/465 (SMTP), 5228 (FCM optional)       | — |
+| Inbound ports   | 80, 443                                                  | — |
+
+You also need:
+
+- A **domain name** with DNS pointing to the host (one A/AAAA record for the
+  relay; optionally a second one for the web app).
+- An **SMTP relay** (Postmark, Resend, AWS SES, your own mail server). Magic
+  link login depends on it.
+- *(Optional, recommended for prod)* an **S3-compatible bucket** for encrypted
+  blob storage. The bundled MinIO works but you may want object-level backups.
+- *(Optional)* APNs and FCM credentials if you want native push for iOS /
+  Android. Without them, in-app reminders still work but won't fire when the
+  app is fully closed.
+
+---
+
+## 2. Get the code
+
+```bash
+git clone https://github.com/kamez-conseils/kinhale.git
+cd kinhale
+git checkout v1.0.0    # pin to a release tag, not develop
+```
+
+> **Why pin?** `develop` is integration; only tagged releases are considered
+> production-ready. Watch the `Releases` tab on GitHub.
+
+---
+
+## 3. Generate secrets
+
+You will need three random values:
+
+```bash
+# JWT signing key (≥ 32 random bytes, base64)
+openssl rand -base64 48
+
+# PostgreSQL password
+openssl rand -base64 32
+
+# Redis password
+openssl rand -base64 32
+```
+
+Save these in a password manager. **Do not commit them.** The provided
+`.gitignore` blocks `.env` and `.env.*` exactly because of this.
+
+---
+
+## 4. Configure the environment
+
+Copy the example file and fill in the values:
+
+```bash
+cp infra/docker/.env.prod.example infra/docker/.env.prod
+$EDITOR infra/docker/.env.prod
+```
+
+Required variables:
+
+| Variable                | Purpose                                                                 | Example |
+| ----------------------- | ----------------------------------------------------------------------- | ------- |
+| `KINHALE_HOSTNAME`      | Public FQDN that caregivers will use to reach the relay                 | `kinhale.example.org` |
+| `KINHALE_WEB_URL`       | Public URL of the web app (used in magic links)                         | `https://app.kinhale.example.org` |
+| `POSTGRES_PASSWORD`     | Strong random password (≥ 32 bytes)                                     | output of `openssl rand -base64 32` |
+| `REDIS_PASSWORD`        | Strong random password (≥ 32 bytes)                                     | output of `openssl rand -base64 32` |
+| `JWT_SECRET`            | ≥ 32 bytes random, base64-friendly                                      | output of `openssl rand -base64 48` |
+| `JWT_ACCESS_TTL`        | Access token TTL                                                        | `15m` |
+| `JWT_REFRESH_TTL`       | Refresh token TTL                                                       | `14d` |
+| `SMTP_HOST`             | SMTP server hostname                                                    | `smtp.postmarkapp.com` |
+| `SMTP_PORT`             | SMTP port (`587` STARTTLS or `465` TLS)                                 | `587` |
+| `SMTP_USER`             | SMTP username                                                            | (provider token) |
+| `SMTP_PASS`             | SMTP password / token                                                   | (provider token) |
+| `SMTP_SECURE`           | `false` for STARTTLS (587), `true` for TLS (465)                        | `false` |
+| `MAIL_FROM`             | "From" address for transactional mail                                   | `Kinhale <noreply@kinhale.example.org>` |
+| `STORAGE_ENDPOINT`      | S3-compatible endpoint (or `http://minio:9000` for bundled MinIO)       | `https://s3.eu-west-1.amazonaws.com` |
+| `STORAGE_BUCKET`        | Bucket name (must exist before first start)                             | `kinhale-relay-blobs` |
+| `STORAGE_ACCESS_KEY_ID` | S3 access key                                                           | (provider value) |
+| `STORAGE_SECRET_ACCESS_KEY` | S3 secret key                                                       | (provider value) |
+| `STORAGE_REGION`        | S3 region                                                               | `eu-west-1` |
+
+Optional (push notifications):
+
+| Variable               | Purpose                                                                  |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `APNS_KEY_ID`          | Apple Push key id                                                        |
+| `APNS_TEAM_ID`         | Apple Developer team id                                                  |
+| `APNS_BUNDLE_ID`       | iOS bundle id                                                            |
+| `APNS_PRIVATE_KEY`     | Path or PEM contents of the `.p8` Apple key                              |
+| `FCM_SERVICE_ACCOUNT`  | Path or JSON contents of the Firebase service account                    |
+
+> **Reminder.** Push payloads remain `{title: "Kinhale", body: "Nouvelle activité"}`
+> regardless of platform. Health data never leaves the device in clear, even
+> for push.
+
+---
+
+## 5. Configure TLS (Caddy is the simplest path)
+
+We recommend [Caddy](https://caddyserver.com) because it negotiates Let's
+Encrypt certificates automatically and reverse-proxies WebSocket without
+configuration. A minimal `Caddyfile` for Kinhale looks like:
+
+```Caddyfile
+kinhale.example.org {
+    encode zstd gzip
+    reverse_proxy api:3002
+}
+
+app.kinhale.example.org {
+    encode zstd gzip
+    reverse_proxy web:3000
+}
+```
+
+Place that file at `infra/docker/Caddyfile`. The provided
+`docker-compose.prod.yml` uses it automatically.
+
+If you prefer Traefik, nginx, or a managed load balancer, point it at:
+
+- Port **3002** of the `api` service (HTTP/1.1 + WebSocket upgrade).
+- Port **3000** of the `web` service.
+
+---
+
+## 6. Initialise blob storage
+
+If you use the bundled MinIO, create the bucket on first run:
+
+```bash
+docker compose -f infra/docker/docker-compose.prod.yml up -d minio
+docker exec -it kinhale_minio_prod \
+    mc alias set local http://localhost:9000 "$STORAGE_ACCESS_KEY_ID" "$STORAGE_SECRET_ACCESS_KEY"
+docker exec -it kinhale_minio_prod mc mb "local/$STORAGE_BUCKET"
+```
+
+If you use AWS S3 / Cloudflare R2 / Backblaze B2, create the bucket with your
+provider's console and grant the access key `Read+Write+List` on it. The
+bucket only stores **encrypted** blobs.
+
+---
+
+## 7. Start the stack
+
+```bash
+docker compose -f infra/docker/docker-compose.prod.yml --env-file infra/docker/.env.prod up -d
+```
+
+The first start does the following automatically:
+
+1. Pulls `postgres:16-alpine`, `redis:7-alpine`, and Caddy images.
+2. Builds the `api` and `web` images from the local source.
+3. Brings up PostgreSQL with healthcheck.
+4. Applies database schema synchronisation via the API entrypoint.
+5. Starts the API on port 3002 and the web app on port 3000 behind Caddy.
+
+> **v1.0 preview note.** The compose currently reuses the workspace
+> `apps/api/Dockerfile` and `apps/web/Dockerfile` (also used in dev). Hardened
+> multi-stage production Dockerfiles with smaller runtime images and Next.js
+> standalone output land under E14-S04 (CI/CD pipeline). The current images
+> are functional for self-hosting but larger than necessary.
+
+Verify everything is healthy:
+
+```bash
+docker compose -f infra/docker/docker-compose.prod.yml ps
+curl -fsSL https://$KINHALE_HOSTNAME/health
+```
+
+You should get `{"status":"ok"}` from the health endpoint within a minute of
+the first start.
+
+---
+
+## 8. Create the first administrator account
+
+For v1.0 preview, account creation goes through the standard magic-link flow:
+
+1. Open `https://app.kinhale.example.org`.
+2. Enter the email of your administrator (the first caregiver).
+3. Click the magic link delivered by your SMTP provider.
+4. Complete the household creation flow on the device.
+
+> No bootstrap shell command is needed — the relay is intentionally agnostic
+> about which user is "admin"; it never sees plaintext household data.
+
+Operational admin (you, the operator) is a different role. Database access for
+operational tasks goes through `psql` on the running container; see
+**Operational tasks** below.
+
+---
+
+## 9. Backups
+
+The relay holds two kinds of state worth backing up:
+
+1. **PostgreSQL** — accounts, devices, mailbox routing pointers, encrypted
+   blob references, push tokens. Loss = devices need to re-pair.
+2. **S3-compatible bucket** — opaque encrypted blobs. Loss = devices may need
+   to re-sync from their local copies.
+
+**Recommended cadence**:
+
+- PostgreSQL: daily logical backup (`pg_dump`) + weekly full file system
+  snapshot. Encrypt at rest with your own key (KMS / age / rage).
+- S3 bucket: enable versioning + lifecycle policy on the provider side.
+
+Example daily Postgres dump (cron, every day at 03:00):
+
+```bash
+docker exec kinhale_postgres_prod \
+    pg_dump -U kinhale -d kinhale \
+    | gzip \
+    | age -r age1examplerecipient... \
+    > /var/backups/kinhale/$(date +%F).sql.gz.age
+```
+
+**Test restores quarterly.** A backup that has never been restored is not a
+backup.
+
+---
+
+## 10. Restore
+
+To restore from a `pg_dump` snapshot:
+
+```bash
+docker compose -f infra/docker/docker-compose.prod.yml stop api
+gunzip -c /var/backups/kinhale/2026-04-24.sql.gz \
+    | docker exec -i kinhale_postgres_prod psql -U kinhale -d kinhale
+docker compose -f infra/docker/docker-compose.prod.yml start api
+```
+
+For S3 buckets, follow your provider's restore procedure.
+
+---
+
+## 11. Updates
+
+```bash
+# 1. Pull the new release
+git fetch --tags
+git checkout v1.0.1
+
+# 2. Rebuild images and apply migrations
+docker compose -f infra/docker/docker-compose.prod.yml --env-file infra/docker/.env.prod build
+docker compose -f infra/docker/docker-compose.prod.yml --env-file infra/docker/.env.prod up -d
+
+# 3. Verify
+curl -fsSL https://$KINHALE_HOSTNAME/health
+```
+
+The API entrypoint runs migrations forward automatically. **Always read the
+release notes** before upgrading across major versions — breaking changes are
+called out explicitly.
+
+---
+
+## 12. Monitoring
+
+For v1.0 preview, the minimum monitoring is:
+
+- `docker compose ... ps` — exits non-zero if any container is unhealthy.
+- `docker compose ... logs --tail 200 api web` — application logs (already
+  pseudonymised; no health data leaks).
+- Disk space monitoring on the volume that holds PostgreSQL and (if local)
+  MinIO data.
+
+If you operate at scale, point an external monitor (UptimeRobot, healthchecks.io)
+at `https://$KINHALE_HOSTNAME/health` with a 1-minute interval.
+
+Sentry / OpenTelemetry exporters can be enabled by setting `SENTRY_DSN` and
+`OTEL_EXPORTER_OTLP_ENDPOINT` in `.env.prod`. The Kinhale logger pseudonymises
+identifiers before they leave the process — you do not need to filter again at
+your collector.
+
+---
+
+## 13. Operational tasks
+
+Open a `psql` shell inside the running stack:
+
+```bash
+docker exec -it kinhale_postgres_prod psql -U kinhale -d kinhale
+```
+
+List active sessions:
+
+```sql
+SELECT account_id, last_seen_at, user_agent FROM sessions ORDER BY last_seen_at DESC LIMIT 50;
+```
+
+Revoke a session (in case of suspected device compromise reported by a
+caregiver):
+
+```sql
+UPDATE sessions SET revoked_at = now() WHERE id = 'session-uuid';
+```
+
+Even with database access, you cannot decrypt health data. The relay only
+holds encrypted blobs and pseudonymous routing metadata.
+
+---
+
+## 14. Disclaimer
+
+By self-hosting Kinhale you accept that:
+
+- **Health data zero-knowledge** is a property of the protocol, **not of the
+  operator**. The encryption keeps Kamez out and keeps you, the operator, out
+  too — but you remain responsible for keeping the system available, backed
+  up, patched, and legally compliant.
+- The Kinhale UI is a **journal + reminders + sharing tool**, not a medical
+  device. Caregivers must continue to follow their physician's prescription.
+- AGPL v3 applies to your deployment. If you make modifications and offer the
+  service over a network, you must make the modified source available to the
+  users of that service. See `LICENSE` and §13 of AGPL v3.
+
+If any of this is unclear, email **community@kinhale.health** before going to
+production.
+
+---
+
+## Appendix A — Production environment variables, complete list
+
+The complete list lives in `infra/docker/.env.prod.example`. This guide names
+the **required** variables; the example file documents every optional knob.
+
+## Appendix B — Architecture references
+
+- `docs/architecture/ARCHITECTURE.md` — high-level design.
+- `docs/architecture/adr/ADR-D4-relay-hosting.md` — relay architecture choices.
+- `docs/architecture/adr/ADR-D10-push-expo-v1-migration-native-v1-1.md` — push
+  pipeline.
+- `docs/architecture/adr/ADR-D11-peer-ping-zero-knowledge.md` — zero-knowledge
+  peer presence.
+- `docs/architecture/adr/ADR-D12-report-pdf-client-side.md` — PDF reports
+  generated client-side (the relay never sees a report).
+- `docs/architecture/adr/ADR-D13-report-sharing-v1.md` — report sharing v1.
+- `docs/architecture/adr/ADR-D14-privacy-export-v1.md` — privacy /
+  portability export.
+
+## Appendix C — Getting help
+
+- GitHub issues for non-security bugs.
+- `security@kinhale.health` for vulnerabilities (see `SECURITY.md`).
+- `community@kinhale.health` for community / Code of Conduct concerns.

--- a/infra/docker/.env.prod.example
+++ b/infra/docker/.env.prod.example
@@ -1,0 +1,69 @@
+# Kinhale — production environment file (self-hosting).
+# Copy to infra/docker/.env.prod and fill in real values.
+# Never commit a populated .env.prod — the .gitignore at the repo root blocks
+# all .env / .env.* files except *.example.
+
+# ---------------------------------------------------------------------------
+# Public hostnames (no scheme, no trailing slash for KINHALE_HOSTNAME)
+# ---------------------------------------------------------------------------
+KINHALE_HOSTNAME=kinhale.example.org
+KINHALE_WEB_HOSTNAME=app.kinhale.example.org
+KINHALE_WEB_URL=https://app.kinhale.example.org
+
+# ---------------------------------------------------------------------------
+# Database — generated, never reuse a default
+# ---------------------------------------------------------------------------
+# Generate: openssl rand -base64 32
+POSTGRES_PASSWORD=__REPLACE_ME__
+
+# ---------------------------------------------------------------------------
+# Redis — generated, never reuse a default
+# ---------------------------------------------------------------------------
+# Generate: openssl rand -base64 32
+REDIS_PASSWORD=__REPLACE_ME__
+
+# ---------------------------------------------------------------------------
+# JWT — ≥ 32 random bytes, base64-friendly
+# ---------------------------------------------------------------------------
+# Generate: openssl rand -base64 48
+JWT_SECRET=__REPLACE_ME__
+JWT_ACCESS_TTL=15m
+JWT_REFRESH_TTL=14d
+
+# ---------------------------------------------------------------------------
+# SMTP — required for magic-link login.
+# Use a transactional provider (Postmark, Resend, SES, etc.) or your own MTA.
+# ---------------------------------------------------------------------------
+SMTP_HOST=smtp.postmarkapp.com
+SMTP_PORT=587
+SMTP_USER=__PROVIDER_TOKEN__
+SMTP_PASS=__PROVIDER_TOKEN__
+# false = STARTTLS (587), true = TLS (465)
+SMTP_SECURE=false
+MAIL_FROM=Kinhale <noreply@kinhale.example.org>
+
+# ---------------------------------------------------------------------------
+# Blob storage (S3-compatible). For the bundled MinIO, leave STORAGE_ENDPOINT
+# pointing to http://minio:9000.
+# ---------------------------------------------------------------------------
+STORAGE_ENDPOINT=http://minio:9000
+STORAGE_BUCKET=kinhale-relay-blobs
+STORAGE_ACCESS_KEY_ID=__REPLACE_ME__
+STORAGE_SECRET_ACCESS_KEY=__REPLACE_ME__
+STORAGE_REGION=us-east-1
+
+# ---------------------------------------------------------------------------
+# Optional: observability
+# ---------------------------------------------------------------------------
+# SENTRY_DSN=https://...ingest.sentry.io/...
+# OTEL_EXPORTER_OTLP_ENDPOINT=https://otel.example.org
+
+# ---------------------------------------------------------------------------
+# Optional: native push (APNs / FCM). Without these, in-app reminders still
+# work but won't fire when the app is fully closed.
+# ---------------------------------------------------------------------------
+# APNS_KEY_ID=
+# APNS_TEAM_ID=
+# APNS_BUNDLE_ID=
+# APNS_PRIVATE_KEY=
+# FCM_SERVICE_ACCOUNT=

--- a/infra/docker/Caddyfile
+++ b/infra/docker/Caddyfile
@@ -1,0 +1,24 @@
+# Kinhale — Caddy reverse proxy for self-hosted production.
+# This file is mounted read-only into the kinhale_caddy_prod container.
+#
+# Customise the hostnames to match KINHALE_HOSTNAME and KINHALE_WEB_HOSTNAME
+# in your .env.prod, then restart the caddy service:
+#   docker compose -f infra/docker/docker-compose.prod.yml restart caddy
+#
+# Caddy negotiates Let's Encrypt certificates automatically. The host needs
+# inbound 80 + 443 reachable from the public internet.
+
+{$KINHALE_HOSTNAME} {
+    encode zstd gzip
+    @websocket {
+        header Connection *Upgrade*
+        header Upgrade websocket
+    }
+    reverse_proxy @websocket api:3002
+    reverse_proxy api:3002
+}
+
+{$KINHALE_WEB_HOSTNAME} {
+    encode zstd gzip
+    reverse_proxy web:3000
+}

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -1,0 +1,150 @@
+# Production deployment for Kinhale (self-hosting profile, v1.0 preview).
+#
+# Usage:
+#   cp infra/docker/.env.prod.example infra/docker/.env.prod
+#   # edit infra/docker/.env.prod
+#   docker compose -f infra/docker/docker-compose.prod.yml --env-file infra/docker/.env.prod up -d
+#
+# See docs/user/SELF_HOSTING.md for the full guide.
+#
+# Scope of this file (v1.0 preview):
+# - Composes the same workspace images as the dev compose, but with
+#   NODE_ENV=production, no source bind mounts, no host port exposure for
+#   internal services, mandatory secrets (no defaults), and Caddy in front
+#   of the relay + web app for automatic Let's Encrypt TLS.
+# - Multi-stage hardened production Dockerfiles (apps/api/Dockerfile.prod,
+#   apps/web/Dockerfile.prod with Next standalone output) are tracked under
+#   ticket E14-S04 (CI/CD pipeline). For v1.0 preview self-hosters, the
+#   existing apps/api/Dockerfile and apps/web/Dockerfile work but produce
+#   larger images than the eventual prod build.
+#
+# Notes:
+# - All passwords / secrets MUST come from the env file. Variables marked
+#   `:?` will fail startup loudly if missing — desired behaviour for prod.
+# - Postgres and Redis are NOT exposed to the host. Only Caddy publishes
+#   80/443.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: kinhale_postgres_prod
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: kinhale
+      POSTGRES_USER: kinhale
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U kinhale -d kinhale']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: kinhale_redis_prod
+    restart: unless-stopped
+    command: redis-server --requirepass ${REDIS_PASSWORD:?REDIS_PASSWORD is required}
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', '--pass', '${REDIS_PASSWORD}', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  minio:
+    # Optional bundled S3-compatible blob storage.
+    # Comment this service out if you use AWS S3 / Cloudflare R2 / Backblaze B2
+    # and update STORAGE_ENDPOINT in .env.prod accordingly.
+    image: minio/minio:latest
+    container_name: kinhale_minio_prod
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${STORAGE_ACCESS_KEY_ID:?STORAGE_ACCESS_KEY_ID is required}
+      MINIO_ROOT_PASSWORD: ${STORAGE_SECRET_ACCESS_KEY:?STORAGE_SECRET_ACCESS_KEY is required}
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ['CMD', 'mc', 'ready', 'local']
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  api:
+    build:
+      context: ../..
+      dockerfile: apps/api/Dockerfile
+    container_name: kinhale_api_prod
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+      PORT: 3002
+      DATABASE_URL: postgresql://kinhale:${POSTGRES_PASSWORD}@postgres:5432/kinhale
+      REDIS_URL: redis://:${REDIS_PASSWORD}@redis:6379
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required, >= 32 random bytes}
+      JWT_ACCESS_TTL: ${JWT_ACCESS_TTL:-15m}
+      JWT_REFRESH_TTL: ${JWT_REFRESH_TTL:-14d}
+      SMTP_HOST: ${SMTP_HOST:?SMTP_HOST is required}
+      SMTP_PORT: ${SMTP_PORT:-587}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASS: ${SMTP_PASS:-}
+      SMTP_SECURE: ${SMTP_SECURE:-false}
+      MAIL_FROM: ${MAIL_FROM:?MAIL_FROM is required}
+      WEB_URL: ${KINHALE_WEB_URL:?KINHALE_WEB_URL is required}
+      STORAGE_ENDPOINT: ${STORAGE_ENDPOINT:-http://minio:9000}
+      STORAGE_BUCKET: ${STORAGE_BUCKET:?STORAGE_BUCKET is required}
+      STORAGE_ACCESS_KEY_ID: ${STORAGE_ACCESS_KEY_ID}
+      STORAGE_SECRET_ACCESS_KEY: ${STORAGE_SECRET_ACCESS_KEY}
+      STORAGE_REGION: ${STORAGE_REGION:-us-east-1}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+
+  web:
+    build:
+      context: ../..
+      dockerfile: apps/web/Dockerfile
+    container_name: kinhale_web_prod
+    restart: unless-stopped
+    depends_on:
+      - api
+    environment:
+      NODE_ENV: production
+      NEXT_PUBLIC_API_URL: https://${KINHALE_HOSTNAME:?KINHALE_HOSTNAME is required}
+
+  caddy:
+    image: caddy:2-alpine
+    container_name: kinhale_caddy_prod
+    restart: unless-stopped
+    depends_on:
+      - api
+      - web
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+    environment:
+      KINHALE_HOSTNAME: ${KINHALE_HOSTNAME}
+      KINHALE_WEB_HOSTNAME: ${KINHALE_WEB_HOSTNAME:-${KINHALE_HOSTNAME}}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+volumes:
+  postgres_data:
+  redis_data:
+  minio_data:
+  caddy_data:
+  caddy_config:
+
+networks:
+  default:
+    name: kinhale_prod


### PR DESCRIPTION
## Contexte

Couvre les stories **E14-S01** (dépôt public AGPL v3) et **E14-S02** (guide self-hosting Docker Compose). Matérialise le projet comme vrai open source — prérequis go-live public.

## Contenu

### Fichiers racine
- **LICENSE** — texte AGPL v3 verbatim (661 lignes)
- **README.md** (EN) + **README.fr.md** (FR) — pitch + promesse zero-knowledge + statut preview v1.0 + quickstart dev + quickstart self-hosting + disclaimer non-DM (RM27)
- **CONTRIBUTING.md** — Gitflow, conventions commit, workflow PR avec revue assistée \`kz-review\` + \`kz-securite\`, fallback signature SSH si GPG indispo, tests obligatoires, ADR process
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 + paragraphe spécial données pédiatriques
- **SECURITY.md** — responsible disclosure, scope in/out, délais réalistes (5j ouvrés acceptation, 30/60/best-effort selon sévérité), hall of fame, contacts \`security@\` + \`community@\`

### Self-hosting
- **\`docs/user/SELF_HOSTING.md\`** — guide pas-à-pas : prérequis, variables d'env exhaustives, JWT secret, SMTP (Postmark), TLS Caddy, healthcheck, backups, mise à jour, disclaimer responsabilité opérateur
- **\`infra/docker/docker-compose.prod.yml\`** — stack prod avec pattern \`\${VAR:?}\` (fail-loud sur secret manquant)
- **\`infra/docker/.env.prod.example\`** — placeholders uniquement
- **\`infra/docker/Caddyfile\`** — terminaison TLS Let's Encrypt automatique

### Gitignore + repo hygiene
- \`.agents/\`, \`.claude/\`, \`.env*\`, \`*.pem\`, \`*.key\`, \`*.p8\` (APNs), \`secrets/\`, \`private/\` bloqués
- **27 tests** \`apps/api/src/__tests__/repo-hygiene.test.ts\` vérifient en CI :
  - Présence des fichiers racine obligatoires
  - Patterns \`.gitignore\` critiques
  - **AGPL v3 §13 « Remote Network Interaction »** présent dans LICENSE

### Gitflow
\`docs/contributing/GITFLOW.md\` — branches, branch protection, signatures, fallback SSH

## Corrections appliquées dans le commit

- **M1 kz-review (MAJEUR)** : variable \`SMTP_PASS\` unifiée entre \`apps/api/src/env.ts\` et \`infra/docker\` (.env.prod.example + docker-compose.prod.yml + SELF_HOSTING.md). Bug réel : la doc utilisait \`SMTP_PASSWORD\` alors que l'API lit \`SMTP_PASS\` — magic-link login aurait échoué silencieusement chez tout self-hosteur.
- **m2 kz-review** : \`support@kinhale.health\` → \`community@kinhale.health\` pour cohérence canonique (security@ + community@ uniquement).

## Tests

- **API : 312/312 verts** (+27 sur repo-hygiene)
- \`pnpm format:check\` / \`lint:root\` / \`lint\` / \`typecheck\` : tous verts

## Revues assistées

- **kz-review** — APPROVED après correction du majeur SMTP_PASS et d'un mineur. 3 mineurs restants → issues de suivi (variables env réservées pour E14-S04, Caddyfile WebSocket matcher redondant Caddy v2, ambiguïté \"admin\" caregiver vs operator dans SELF_HOSTING). Rapport : [\`kz-review-KIN-089.md\`](../.agents/current-run/kz-review-KIN-089.md)
- **kz-conformite** — **REPORTÉ avant merge humain** (l'agent automatique a atteint sa limite quota avant de produire le rapport). Issue de suivi #XXX — bloquant merge. À valider avant merge : AGPL §13 conforme, README disclaimer RM27 cohérent, CODE_OF_CONDUCT Covenant officiel, SECURITY délais réalistes, SELF_HOSTING disclaimer opérateur.
- **kz-securite** — non requis (documentation pure, gitignore + tests CI vérifient l'absence de secrets).

## Suivi

Issues à créer :
- **kz-conformite** repassage avant merge (bloquant)
- 4 stories E14 restantes : E14-S03 OpenAPI, E14-S04 CI/CD, E14-S05 migrations versionnées, E14-S06 instance prod ca-central-1
- 3 mineurs kz-review en suivi

Refs: KIN-089
Closes: E14-S01, E14-S02