### PR TITLE
ci(pipeline): durcissement CI + build images Docker vers ghcr.io (KIN-090)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,56 @@
+# Build context exclusions — applies to every `docker build .` from the repo
+# root. Keep aligned with `.gitignore` plus a few CI artefacts.
+
+# Node / pnpm
+**/node_modules
+.pnpm-store
+.npmrc.local
+
+# Builds
+**/dist
+**/build
+**/.next
+**/.turbo
+**/.expo
+**/coverage
+**/playwright-report
+**/test-results
+**/tsconfig.tsbuildinfo
+
+# Logs / OS
+**/*.log
+.DS_Store
+
+# Git / CI
+.git
+.github
+.gitignore
+.gitattributes
+
+# Editor / local
+.vscode
+.idea
+.env
+.env.*
+**/.env
+**/.env.*
+!.env.example
+!**/.env.example
+
+# Docs / heavy assets that shouldn't ship in images
+docs
+**/*.md
+!README.md
+!apps/api/README.md
+!apps/web/README.md
+
+# Tests we don't ship in runtime images
+**/__tests__
+**/*.test.ts
+**/*.test.tsx
+**/playwright.config.ts
+**/jest.config.ts
+**/vitest.config.ts
+
+# Agents / runs
+.agents

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,56 @@
+# Composite GitHub Action shared by every CI workflow.
+#
+# Purpose: install pnpm + Node 20, restore the pnpm store and Turborepo
+# remote-effect cache (`~/.turbo`), and run `pnpm install --frozen-lockfile`.
+# Centralising this keeps Node + pnpm versions consistent across workflows
+# and makes upgrades a one-line change.
+#
+# Tracking: KIN-090 / E14-S04.
+
+name: Setup Kinhale toolchain
+description: pnpm + Node 20 + caches + monorepo install
+
+runs:
+  using: composite
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10.33.0
+
+    - name: Setup Node 20
+      uses: actions/setup-node@v4
+      with:
+        node-version-file: .nvmrc
+        cache: pnpm
+
+    - name: Resolve pnpm store path
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+    - name: Cache pnpm store
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          pnpm-store-${{ runner.os }}-
+
+    - name: Cache Turborepo
+      uses: actions/cache@v4
+      with:
+        path: .turbo
+        key: turbo-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
+        restore-keys: |
+          turbo-${{ runner.os }}-${{ github.ref_name }}-
+          turbo-${{ runner.os }}-
+
+    - name: Install dependencies
+      shell: bash
+      env:
+        NPM_CONFIG_FETCH_RETRIES: '5'
+        NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: '15000'
+        NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: '120000'
+        NPM_CONFIG_NETWORK_CONCURRENCY: '16'
+      run: pnpm install --frozen-lockfile --prefer-offline

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,149 @@
+# Build & push Docker images — Kinhale API + Web.
+#
+# Triggers
+#   - push to `develop`             → tags: `develop`, `<short-sha>`
+#   - push to a tag matching `v*`   → tags: `<tag>`, `<short-sha>`, `latest`
+#   - manual `workflow_dispatch`    → tags: `<short-sha>` (smoke test)
+#
+# Images are pushed to `ghcr.io/<owner>/kinhale-api` and
+# `ghcr.io/<owner>/kinhale-web`. Multi-arch (amd64 + arm64) is built so the
+# same artefacts can run on Apple Silicon laptops, Graviton EC2, and the
+# default x86_64 self-hosting target.
+#
+# Each image is then scanned by Trivy; results are uploaded as SARIF to
+# GitHub's code scanning tab so high/critical findings are reviewable.
+#
+# IMPORTANT — scope KIN-090
+#   This workflow ONLY builds and publishes images. Real deployment to
+#   staging / prod is out of scope and tracked by KIN-091 (depends on
+#   E14-S06: Kamez Conseils ca-central-1 infra + secrets).
+#
+# Security
+#   - `permissions:` is scoped per-job (least privilege).
+#   - `pull_request_target` is intentionally NOT used (no privileged build of
+#     fork PR code → no supply-chain pwn vector).
+#   - All third-party actions are pinned to a major SemVer release; the
+#     security audit (kz-securite-KIN-090.md) lists the rationale.
+
+name: Build Docker images
+
+on:
+  push:
+    branches: [develop]
+    tags: ['v*']
+  workflow_dispatch:
+
+# Default: deny everything. Each job adds only what it needs.
+permissions: {}
+
+concurrency:
+  group: build-images-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_OWNER: ${{ github.repository_owner }}
+  PLATFORMS: linux/amd64,linux/arm64
+
+jobs:
+  build:
+    name: Build · ${{ matrix.app }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+      packages: write
+      # Allow uploading the Trivy SARIF.
+      security-events: write
+      # Required for OIDC-based image signing (cosign keyless) — used in a
+      # follow-up step but reserved here so we don't have to bump perms later.
+      id-token: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: api
+            image: kinhale-api
+            dockerfile: apps/api/Dockerfile.prod
+          - app: web
+            image: kinhale-web
+            dockerfile: apps/web/Dockerfile.prod
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image tags + labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha,format=short
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=Kinhale ${{ matrix.app }}
+            org.opencontainers.image.description=Kinhale ${{ matrix.app }} — local-first E2EE asthma tracker for caregivers
+            org.opencontainers.image.licenses=AGPL-3.0-only
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.vendor=Kamez Conseils
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=${{ matrix.app }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.app }}
+
+      - name: Trivy vulnerability scan (image)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          # Scan the first tag — all share the same digest.
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
+          format: sarif
+          output: trivy-${{ matrix.app }}.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+
+      - name: Upload Trivy SARIF to GitHub Security
+        if: ${{ !cancelled() }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-${{ matrix.app }}.sarif
+          category: trivy-${{ matrix.app }}
+
+      - name: Trivy vulnerability scan (table — for logs)
+        if: ${{ !cancelled() }}
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/${{ matrix.image }}@${{ steps.build.outputs.digest }}
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,23 @@
+# Continuous integration — Kinhale monorepo.
+#
+# Runs on pull requests targeting `main` / `develop` / `release/**` and on
+# pushes to `develop` / `main`. Jobs are split so contributors get fast
+# feedback per category (format, lint, typecheck, test, build) and so a
+# failure in one stays scoped.
+#
+# All jobs share the same setup composite (see `.github/actions/setup`) which
+# caches the pnpm store and the Turborepo remote-effect cache (`~/.turbo`).
+# Heavy packages are tested twice: once on Ubuntu glibc, once on Alpine musl
+# (mirrors the production runtime — Docker images are based on
+# `node:20-alpine`).
+#
+# Coverage from `vitest --coverage` is uploaded as artefacts (and to Codecov
+# when a token is configured) so reviewers can inspect the diff coverage.
+#
+# Tracking: KIN-090 / E14-S04. Permissions are minimal per workflow as a
+# defence-in-depth measure against supply-chain attacks (KIN-090 security
+# review).
+
 name: CI
 
 on:
@@ -6,76 +26,143 @@ on:
   push:
     branches: [main, develop]
 
+# Default to no privileges; individual jobs grant only what they need.
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PNPM_VERSION: '10.33.0'
+  # Disable Turbo's anonymous telemetry in CI.
+  TURBO_TELEMETRY_DISABLED: '1'
+  DO_NOT_TRACK: '1'
+
 jobs:
-  lint-typecheck-test:
-    name: Lint · Typecheck · Test
+  # --------------------------------------------------------------------------
+  # Format check — fastest job, fail the PR before doing anything heavier.
+  # --------------------------------------------------------------------------
+  format-check:
+    name: Format · prettier
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Format check
+        run: pnpm format:check
+
+  # --------------------------------------------------------------------------
+  # Lint root + workspaces in parallel.
+  # --------------------------------------------------------------------------
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Lint root config
+        run: pnpm lint:root
+      - name: Lint workspaces (turbo)
+        run: pnpm lint
+
+  # --------------------------------------------------------------------------
+  # Typecheck — depends only on workspace package compilation, not on lint.
+  # --------------------------------------------------------------------------
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Typecheck
+        run: pnpm typecheck
+
+  # --------------------------------------------------------------------------
+  # Tests with coverage — vitest emits coverage/ folders, jest emits its own
+  # under `apps/web/coverage`. We upload them as artefacts and (when secret
+  # available) push to Codecov.
+  # --------------------------------------------------------------------------
+  test:
+    name: Test · coverage
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.0
-
-      - name: Setup Node 20
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-
-      - name: Get pnpm store directory
-        id: pnpm-store
-        shell: bash
-        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache pnpm store
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.pnpm-store.outputs.path }}
-          key: pnpm-store-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            pnpm-store-${{ runner.os }}-
-
-      - name: Install dependencies
-        timeout-minutes: 8
-        run: pnpm install --frozen-lockfile --prefer-offline
-        env:
-          NPM_CONFIG_FETCH_RETRIES: '5'
-          NPM_CONFIG_FETCH_RETRY_MINTIMEOUT: '15000'
-          NPM_CONFIG_FETCH_RETRY_MAXTIMEOUT: '120000'
-          NPM_CONFIG_NETWORK_CONCURRENCY: '16'
-
-      - name: Format check
-        run: pnpm format:check
-
-      - name: Lint (root)
-        run: pnpm lint:root
-
-      - name: Lint (workspaces)
-        run: pnpm lint
-
-      - name: Typecheck
-        run: pnpm typecheck
-
+      - name: Setup
+        uses: ./.github/actions/setup
       - name: Test
         run: pnpm test
+      - name: Aggregate coverage
+        if: ${{ !cancelled() }}
+        run: |
+          mkdir -p coverage-artifacts
+          shopt -s globstar nullglob
+          for f in packages/**/coverage/lcov.info apps/**/coverage/lcov.info; do
+            pkg=$(echo "$f" | awk -F'/' '{print $2}')
+            cp "$f" "coverage-artifacts/${pkg}.lcov.info" || true
+          done
+          ls -la coverage-artifacts || true
+      - name: Upload coverage artefacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ github.run_id }}
+          path: coverage-artifacts/
+          retention-days: 14
+          if-no-files-found: warn
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() && env.CODECOV_TOKEN != '' }}
+        uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage-artifacts
+          fail_ci_if_error: false
+          verbose: false
 
-  docker-alpine-verify:
-    name: Docker · node:20-alpine (musl)
+  # --------------------------------------------------------------------------
+  # Build apps that produce artefacts. Verifies the production toolchain
+  # before we attempt to build container images on push to develop / main.
+  # --------------------------------------------------------------------------
+  build:
+    name: Build (web + api)
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: lint-typecheck-test
+    timeout-minutes: 20
+    needs: [typecheck]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Build (turbo)
+        run: pnpm build
 
+  # --------------------------------------------------------------------------
+  # Alpine musl smoke-test — runs lint/typecheck/test inside `node:20-alpine`
+  # so we surface musl-only regressions (libc differences, native modules)
+  # before they reach Docker images.
+  # --------------------------------------------------------------------------
+  docker-alpine-verify:
+    name: Docker · node:20-alpine (musl)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [lint, typecheck, test]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Cache pnpm store (Alpine)
         uses: actions/cache@v4
         with:
@@ -83,20 +170,22 @@ jobs:
           key: pnpm-store-alpine-${{ hashFiles('pnpm-lock.yaml') }}
           restore-keys: |
             pnpm-store-alpine-
-
       - name: Verify scaffold on Alpine (musl libc)
-        timeout-minutes: 8
+        timeout-minutes: 12
+        env:
+          PNPM_VERSION: ${{ env.PNPM_VERSION }}
         run: |
           mkdir -p "${RUNNER_TEMP}/pnpm-store"
           docker run --rm \
             -v "${RUNNER_TEMP}/pnpm-store:/root/.local/share/pnpm/store" \
             -v "$GITHUB_WORKSPACE:/ws:ro" \
+            -e PNPM_VERSION="$PNPM_VERSION" \
             node:20-alpine sh -c '
               set -eu
               cp -r /ws /tmp/work
               cd /tmp/work
               corepack enable
-              corepack prepare pnpm@10.33.0 --activate
+              corepack prepare pnpm@"$PNPM_VERSION" --activate
               pnpm install --frozen-lockfile --prefer-offline
               pnpm format:check
               pnpm lint:root

--- a/.github/workflows/e2e-web.yml
+++ b/.github/workflows/e2e-web.yml
@@ -1,3 +1,11 @@
+# End-to-end web tests — Playwright (Chromium + WebKit).
+#
+# Triggered on PRs that touch the web app or shared packages, and on push to
+# `develop` / `main`. Reuses the shared setup composite so Node / pnpm /
+# cache strategy stays consistent with the main CI workflow.
+#
+# Tracking: KIN-090 / E14-S04.
+
 name: E2E Web (Playwright)
 
 on:
@@ -9,38 +17,44 @@ on:
       - 'packages/sync/**'
       - 'packages/crypto/**'
       - '.github/workflows/e2e-web.yml'
+      - '.github/actions/setup/**'
   push:
     branches:
       - develop
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-web-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   playwright:
-    timeout-minutes: 15
+    name: Playwright (chromium + webkit)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.0
-      - name: Setup Node 20
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: .nvmrc
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup
+        uses: ./.github/actions/setup
+
       - name: Install Playwright browsers
         run: pnpm --filter @kinhale/web exec playwright install --with-deps chromium webkit
+
       - name: Run Playwright tests
         run: pnpm e2e:web
         env:
           NEXT_PUBLIC_API_URL: http://localhost:3002
+
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
+          name: playwright-report-${{ github.run_id }}
           path: apps/web/playwright-report/
           retention-days: 7
+          if-no-files-found: warn

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,166 @@
+# Security scans — Kinhale.
+#
+# Schedule
+#   - 03:17 UTC daily (off-peak, avoids the top-of-the-hour spike)
+#   - Push to `main` (post-release sanity)
+#   - Manual `workflow_dispatch`
+#
+# What runs
+#   1. `pnpm audit`            — npm audit DB, severity ≥ high.
+#   2. Trivy filesystem scan   — repo source + lockfile vulns, SARIF upload.
+#   3. Trivy image scan        — pulls the published `develop` images and
+#                                 re-scans (catches new CVEs without rebuild).
+#   4. Snyk scan               — only when `SNYK_TOKEN` secret is configured;
+#                                 skipped with a notice otherwise.
+#
+# Tracking: KIN-090 / E14-S04. Findings go to the GitHub Security tab
+# (Code scanning alerts) plus a workflow failure on critical results from
+# `pnpm audit`.
+
+name: Security scan
+
+on:
+  schedule:
+    - cron: '17 3 * * *'
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: security-scan-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  pnpm-audit:
+    name: pnpm audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Audit dependencies (high+)
+        # `pnpm audit --audit-level high` exits non-zero if any HIGH or
+        # CRITICAL is found. We do not block on moderate (too noisy in early
+        # development).
+        run: pnpm audit --audit-level high
+
+  trivy-fs:
+    name: Trivy · filesystem
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-fs.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+      - name: Upload SARIF
+        if: ${{ !cancelled() }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+  trivy-images:
+    name: Trivy · published images
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [kinhale-api, kinhale-web]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Log in to GHCR (read)
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve target image
+        id: target
+        run: |
+          set -e
+          # On scheduled runs scan the develop tag; on push to main scan the
+          # most recent vX.Y.Z tag (or fall back to develop if missing).
+          if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${GITHUB_REF_NAME}" = "main" ]; then
+            tag="latest"
+          else
+            tag="develop"
+          fi
+          echo "ref=ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${tag}" >> "$GITHUB_OUTPUT"
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ steps.target.outputs.ref }}
+          format: sarif
+          output: trivy-${{ matrix.image }}.sarif
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '0'
+      - name: Upload SARIF
+        if: ${{ !cancelled() }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-${{ matrix.image }}.sarif
+          category: trivy-${{ matrix.image }}
+
+  snyk:
+    name: Snyk · dependencies (optional)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Skip if SNYK_TOKEN missing
+        id: gate
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          if [ -z "${SNYK_TOKEN:-}" ]; then
+            echo "::notice::SNYK_TOKEN not configured — skipping Snyk scan."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Setup
+        if: ${{ steps.gate.outputs.skip != 'true' }}
+        uses: ./.github/actions/setup
+      - name: Snyk test (high+)
+        if: ${{ steps.gate.outputs.skip != 'true' }}
+        uses: snyk/actions/node@cdb760004ba9ea4d525f2e043745dfe85bb9077e # v0.4.0
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          args: --severity-threshold=high --all-projects --sarif-file-output=snyk.sarif
+        continue-on-error: true
+      - name: Upload Snyk SARIF
+        if: ${{ steps.gate.outputs.skip != 'true' && !cancelled() }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk.sarif
+          category: snyk

--- a/.github/workflows/workflows-lint.yml
+++ b/.github/workflows/workflows-lint.yml
@@ -1,0 +1,32 @@
+# Meta-workflow: lint the repo's GitHub Actions definitions.
+#
+# Runs `actionlint` (community tool, single static binary) on every PR that
+# touches `.github/`. Catches obvious YAML/Action mistakes (typos in `uses`,
+# wrong runner names, malformed expressions) before we waste a real CI run.
+#
+# Tracking: KIN-090 / E14-S04.
+
+name: Workflows lint
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/workflows-lint.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run actionlint
+        run: |
+          set -e
+          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.7/scripts/download-actionlint.bash) 1.7.7
+          ./actionlint -color

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,7 +2,12 @@
 
 > _Un journal de suivi des pompes d'asthme pour enfant, chiffré de bout en bout et local d'abord — pensé par des aidants, pour les aidants._
 
+[![CI](https://github.com/kamez-conseils/kinhale/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/kamez-conseils/kinhale/actions/workflows/ci.yml)
+[![E2E Web](https://github.com/kamez-conseils/kinhale/actions/workflows/e2e-web.yml/badge.svg?branch=develop)](https://github.com/kamez-conseils/kinhale/actions/workflows/e2e-web.yml)
+[![Scan sécurité](https://github.com/kamez-conseils/kinhale/actions/workflows/security-scan.yml/badge.svg)](https://github.com/kamez-conseils/kinhale/actions/workflows/security-scan.yml)
+[![Couverture](https://codecov.io/gh/kamez-conseils/kinhale/branch/develop/graph/badge.svg)](https://codecov.io/gh/kamez-conseils/kinhale)
 [![Licence : AGPL v3](https://img.shields.io/badge/Licence-AGPL_v3-blue.svg)](./LICENSE)
+[![Version](https://img.shields.io/github/v/tag/kamez-conseils/kinhale?label=version&sort=semver)](https://github.com/kamez-conseils/kinhale/releases)
 [![Statut](https://img.shields.io/badge/statut-aperçu_v1.0-orange.svg)]()
 [![EN](https://img.shields.io/badge/lang-english-blue.svg)](./README.md)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 > _A local-first, end-to-end encrypted asthma inhaler tracker for kids — built for caregivers, by caregivers._
 
+[![CI](https://github.com/kamez-conseils/kinhale/actions/workflows/ci.yml/badge.svg?branch=develop)](https://github.com/kamez-conseils/kinhale/actions/workflows/ci.yml)
+[![E2E Web](https://github.com/kamez-conseils/kinhale/actions/workflows/e2e-web.yml/badge.svg?branch=develop)](https://github.com/kamez-conseils/kinhale/actions/workflows/e2e-web.yml)
+[![Security scan](https://github.com/kamez-conseils/kinhale/actions/workflows/security-scan.yml/badge.svg)](https://github.com/kamez-conseils/kinhale/actions/workflows/security-scan.yml)
+[![Coverage](https://codecov.io/gh/kamez-conseils/kinhale/branch/develop/graph/badge.svg)](https://codecov.io/gh/kamez-conseils/kinhale)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](./LICENSE)
+[![Version](https://img.shields.io/github/v/tag/kamez-conseils/kinhale?label=version&sort=semver)](https://github.com/kamez-conseils/kinhale/releases)
 [![Status](https://img.shields.io/badge/status-v1.0--preview-orange.svg)]()
 [![FR](https://img.shields.io/badge/lang-français-blue.svg)](./README.fr.md)
 

--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -1,0 +1,82 @@
+# syntax=docker/dockerfile:1.7
+#
+# Production image for Kinhale API (Fastify 5).
+#
+# Multi-stage build:
+#   1. `deps`    : install full pnpm workspace (workspace packages export `.ts`
+#                   directly via NodeNext, so we keep TypeScript at runtime
+#                   through `tsx`).
+#   2. `runtime` : minimal Node 20 LTS Alpine, non-root, no shell utilities
+#                   beyond what `tsx` needs. Healthcheck + read-only friendly.
+#
+# Built and pushed by `.github/workflows/build-images.yml` to
+# `ghcr.io/kamez-conseils/kinhale-api`.
+#
+# Tracking: KIN-090 / E14-S04. Real deployment is KIN-091 / E14-S06.
+
+ARG NODE_IMAGE=node:20.19-alpine
+
+# ---- Stage 1: deps ---------------------------------------------------------
+FROM ${NODE_IMAGE} AS deps
+WORKDIR /app
+
+# Toolchain for native module builds (e.g. better-sqlite, libpq optional deps).
+RUN apk add --no-cache libc6-compat python3 make g++ \
+ && corepack enable \
+ && corepack prepare pnpm@10.33.0 --activate
+
+# Manifests first to maximise Docker layer caching.
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/crypto/package.json ./packages/crypto/
+COPY packages/domain/package.json ./packages/domain/
+COPY packages/eslint-config/package.json ./packages/eslint-config/
+COPY packages/tsconfig/package.json ./packages/tsconfig/
+COPY packages/test-utils/package.json ./packages/test-utils/
+
+# Install full deps (tsx is in devDependencies but required at runtime).
+RUN --mount=type=cache,id=pnpm-store-api,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --prefer-offline
+
+# Copy workspace sources needed at runtime.
+COPY apps/api ./apps/api
+COPY packages/crypto ./packages/crypto
+COPY packages/domain ./packages/domain
+COPY packages/tsconfig ./packages/tsconfig
+
+# Sanity: typecheck the API once during build (fail fast on broken images).
+RUN pnpm --filter @kinhale/api typecheck
+
+# ---- Stage 2: runtime ------------------------------------------------------
+FROM ${NODE_IMAGE} AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    PORT=3002 \
+    DISABLE_PURGE_WORKER=0 \
+    NPM_CONFIG_UPDATE_NOTIFIER=false
+
+RUN apk add --no-cache tini libc6-compat \
+ && addgroup -S kinhale -g 1001 \
+ && adduser -S kinhale -G kinhale -u 1001
+
+# Copy installed workspace from `deps`. We keep dev deps because workspace
+# packages export `.ts` directly and the API runs through `tsx`.
+COPY --from=deps --chown=kinhale:kinhale /app /app
+
+USER kinhale
+
+EXPOSE 3002
+
+# Minimal HTTP healthcheck against the public liveness endpoint.
+# Falls back gracefully if the route is missing — the relay always answers
+# 200 on `/health` (see `apps/api/src/app.ts`).
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:'+ (process.env.PORT||3002) +'/health', r => process.exit(r.statusCode===200?0:1)).on('error', () => process.exit(1))"
+
+WORKDIR /app/apps/api
+
+ENTRYPOINT ["/sbin/tini", "--"]
+# Invoke the local `tsx` binary directly — avoids reaching for `pnpm exec`
+# (which would re-trigger corepack to re-download pnpm on every cold start).
+CMD ["./node_modules/.bin/tsx", "src/index.ts"]

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -1,0 +1,100 @@
+# syntax=docker/dockerfile:1.7
+#
+# Production image for Kinhale Web (Next.js 15, standalone output).
+#
+# Multi-stage build:
+#   1. `deps`    : install pnpm workspace dependencies (cache-friendly).
+#   2. `builder` : run `next build` with `output: 'standalone'` enabled in
+#                   `next.config.ts` — emits `.next/standalone/` and
+#                   `.next/static/` ready for a minimal runtime image.
+#   3. `runtime` : copy only the standalone server + static assets + public/
+#                   into a slim Alpine image, run as non-root.
+#
+# Built and pushed by `.github/workflows/build-images.yml` to
+# `ghcr.io/kamez-conseils/kinhale-web`.
+#
+# Tracking: KIN-090 / E14-S04. Real deployment is KIN-091 / E14-S06.
+
+ARG NODE_IMAGE=node:20.19-alpine
+
+# ---- Stage 1: deps ---------------------------------------------------------
+FROM ${NODE_IMAGE} AS deps
+WORKDIR /app
+
+RUN apk add --no-cache libc6-compat python3 make g++ \
+ && corepack enable \
+ && corepack prepare pnpm@10.33.0 --activate
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY apps/web/package.json ./apps/web/
+COPY packages/crypto/package.json ./packages/crypto/
+COPY packages/sync/package.json ./packages/sync/
+COPY packages/domain/package.json ./packages/domain/
+COPY packages/i18n/package.json ./packages/i18n/
+COPY packages/reports/package.json ./packages/reports/
+COPY packages/eslint-config/package.json ./packages/eslint-config/
+COPY packages/tsconfig/package.json ./packages/tsconfig/
+COPY packages/test-utils/package.json ./packages/test-utils/
+
+RUN --mount=type=cache,id=pnpm-store-web,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --prefer-offline
+
+# ---- Stage 2: builder ------------------------------------------------------
+FROM ${NODE_IMAGE} AS builder
+WORKDIR /app
+
+RUN corepack enable \
+ && corepack prepare pnpm@10.33.0 --activate
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1
+
+# Reuse installed deps from previous stage.
+COPY --from=deps /app /app
+
+# Sources of the web app + workspace packages it transpiles.
+COPY apps/web ./apps/web
+COPY packages/crypto ./packages/crypto
+COPY packages/sync ./packages/sync
+COPY packages/domain ./packages/domain
+COPY packages/i18n ./packages/i18n
+COPY packages/reports ./packages/reports
+COPY packages/tsconfig ./packages/tsconfig
+
+# Ensure `public/` exists even when no static asset is shipped (tamagui only
+# writes `public/tamagui.css` when extraction runs). The runtime stage copies
+# this directory unconditionally.
+RUN mkdir -p ./apps/web/public \
+ && pnpm --filter @kinhale/web build
+
+# ---- Stage 3: runtime ------------------------------------------------------
+FROM ${NODE_IMAGE} AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0 \
+    NEXT_TELEMETRY_DISABLED=1
+
+RUN apk add --no-cache tini \
+ && addgroup -S kinhale -g 1001 \
+ && adduser -S kinhale -G kinhale -u 1001
+
+# Standalone tracer copies a minimal node_modules subset and a `server.js`.
+# `outputFileTracingRoot` is set to the monorepo root so the standalone
+# directory contains `apps/web/server.js` and shared `node_modules`.
+COPY --from=builder --chown=kinhale:kinhale /app/apps/web/.next/standalone ./
+COPY --from=builder --chown=kinhale:kinhale /app/apps/web/.next/static ./apps/web/.next/static
+# `public/` is created by the builder stage even when empty (tamagui emits
+# `tamagui.css` there at build time — see `next.config.ts`).
+COPY --from=builder --chown=kinhale:kinhale /app/apps/web/public ./apps/web/public
+
+USER kinhale
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:'+ (process.env.PORT||3000) +'/', r => process.exit(r.statusCode<500?0:1)).on('error', () => process.exit(1))"
+
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,15 @@
+import path from 'node:path';
 import type { NextConfig } from 'next';
 import { withTamagui } from '@tamagui/next-plugin';
 
 const nextConfig: NextConfig = {
+  // Build autonome : copie node_modules + serveur Node minimal dans
+  // `.next/standalone`, exploité par `apps/web/Dockerfile.prod` pour produire
+  // une image runtime ~150 Mo au lieu de ~1.2 Go (full workspace install).
+  // En monorepo pnpm, la racine du workspace doit être indiquée pour que le
+  // tracer Next inclue les fichiers de `packages/*` dans `.next/standalone`.
+  output: 'standalone',
+  outputFileTracingRoot: path.resolve(__dirname, '../..'),
   transpilePackages: [
     'react-native-web',
     'tamagui',

--- a/apps/web/src/app/reports/page.tsx
+++ b/apps/web/src/app/reports/page.tsx
@@ -10,7 +10,6 @@ import {
   buildReportStrings,
   generateMedicalCsv,
   generateMedicalReport,
-  MS_PER_DAY,
   presetRange,
   validateDateRange,
   type DateRange,
@@ -445,5 +444,3 @@ function buildLookup(
   }
   return (doseId: string) => map.get(doseId) ?? null;
 }
-
-export { MS_PER_DAY };

--- a/docs/contributing/CI_CD.md
+++ b/docs/contributing/CI_CD.md
@@ -1,0 +1,168 @@
+# CI/CD — guide de référence
+
+> Pipeline GitHub Actions du monorepo Kinhale.
+> Ticket de référence : **KIN-090 (E14-S04)**.
+> Le déploiement réel staging/prod est suivi séparément par **KIN-091**
+> (dépend de E14-S06, infra `ca-central-1`).
+
+## Vue d'ensemble
+
+| Workflow                            | Déclencheurs                       | Objectif                                                                                  |
+| ----------------------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------- |
+| `.github/workflows/ci.yml`          | PR vers `main`/`develop`/`release/**`, push `develop`/`main` | format-check, lint, typecheck, test (+ coverage), build, smoke Alpine (musl) |
+| `.github/workflows/e2e-web.yml`     | PR touchant le web, push `develop`/`main`         | Playwright (chromium + webkit) sur l'app Next.js                          |
+| `.github/workflows/build-images.yml`| Push `develop`, tag `v*`, manuel                   | Build + push images Docker `kinhale-api` / `kinhale-web` vers ghcr.io + scan Trivy |
+| `.github/workflows/security-scan.yml`| Daily 03:17 UTC, push `main`, manuel             | `pnpm audit` + Trivy filesystem + Trivy images publiées + Snyk (optionnel) |
+| `.github/workflows/workflows-lint.yml`| PR touchant `.github/`                          | actionlint sur les workflows eux-mêmes                                    |
+
+Le pipeline est **gating** :
+
+- Les jobs `format-check`, `lint`, `typecheck`, `test`, `build` du workflow CI doivent être verts pour merger sur `develop`.
+- Le job `playwright` doit être vert sur les PRs touchant le web.
+- La règle de protection de branche correspondante est documentée dans `docs/contributing/GITFLOW.md` (à compléter côté repo settings — aujourd'hui géré par les mainteneurs).
+
+## Composite action partagée
+
+`.github/actions/setup` centralise :
+
+- Installation de **pnpm 10.33.0**
+- Installation de **Node 20** (via `.nvmrc`)
+- Cache du store pnpm
+- Cache Turborepo (`.turbo/`)
+- `pnpm install --frozen-lockfile --prefer-offline`
+
+Tout nouveau workflow qui dépend des dépendances doit l'utiliser :
+
+```yaml
+- name: Setup
+  uses: ./.github/actions/setup
+```
+
+## Reproduire le CI en local
+
+Avant tout `git push`, lancer la même séquence que la CI :
+
+```bash
+pnpm format:check
+pnpm lint:root
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build      # uniquement si tu touches `apps/api` ou `apps/web`
+```
+
+Pour les e2e web :
+
+```bash
+pnpm --filter @kinhale/web exec playwright install chromium webkit
+pnpm e2e:web
+```
+
+Pour reproduire le smoke Alpine :
+
+```bash
+docker run --rm -v "$PWD:/ws:ro" node:20-alpine sh -c '
+  cp -r /ws /tmp/work && cd /tmp/work
+  corepack enable && corepack prepare pnpm@10.33.0 --activate
+  pnpm install --frozen-lockfile --prefer-offline
+  pnpm format:check && pnpm lint:root && pnpm typecheck && pnpm lint && pnpm test
+'
+```
+
+## Builds Docker prod
+
+Deux Dockerfiles `*.prod` multi-stage produisent des images runtime minimales :
+
+- `apps/api/Dockerfile.prod` — image Fastify 5, runtime `tsx` + `tini`, utilisateur non-root `kinhale` (uid 1001), healthcheck HTTP `/health`.
+- `apps/web/Dockerfile.prod` — exploite le mode `output: 'standalone'` de Next.js 15, copie `.next/standalone` + `.next/static` + `public/`, utilisateur non-root, healthcheck HTTP `/`.
+
+Build local :
+
+```bash
+docker build -f apps/api/Dockerfile.prod -t kinhale-api:local .
+docker build -f apps/web/Dockerfile.prod -t kinhale-web:local .
+```
+
+Smoke local :
+
+```bash
+docker run --rm -p 3002:3002 \
+  -e DATABASE_URL=postgres://kinhale:dev@host.docker.internal:5432/kinhale \
+  -e REDIS_URL=redis://host.docker.internal:6379 \
+  -e JWT_SECRET=devsecretdevsecretdevsecretdevse \
+  -e SMTP_HOST=smtp.example.com -e MAIL_FROM=dev@example.com \
+  -e WEB_URL=http://localhost:3000 -e STORAGE_BUCKET=kinhale-dev \
+  -e STORAGE_ACCESS_KEY_ID=dev -e STORAGE_SECRET_ACCESS_KEY=dev \
+  kinhale-api:local
+```
+
+## Tags d'image
+
+Les tags sont calculés par `docker/metadata-action@v5` :
+
+| Événement                | Tags poussés                                   |
+| ------------------------ | ---------------------------------------------- |
+| Push `develop`           | `develop`, `sha-<short>`                       |
+| Tag `vX.Y.Z`             | `vX.Y.Z`, `sha-<short>`, `latest`              |
+| `workflow_dispatch`      | `sha-<short>` uniquement                       |
+
+Architectures : **linux/amd64 + linux/arm64** (Apple Silicon, Graviton).
+
+## Coverage
+
+Chaque package critique (`packages/crypto`, `packages/sync`, `packages/domain`, `apps/api`)
+émet un `coverage/lcov.info`. Le job `test` agrège ces fichiers dans
+`coverage-artifacts/<package>.lcov.info` et :
+
+1. les publie comme artefact `coverage-<run-id>` (rétention 14 jours)
+2. les pousse vers Codecov si `CODECOV_TOKEN` est configuré
+
+> Le repo étant public, Codecov accepte des uploads sans token, mais on
+> garde la branche conditionnelle pour ne pas casser les forks.
+
+## Comment debug un échec CI
+
+1. **Lire le job rouge en premier.** GitHub liste les jobs par ordre de
+   déclenchement, l'erreur racine est souvent le premier job rouge.
+2. **Re-run failed jobs only** : bouton _Re-run failed jobs_ après avoir
+   inspecté les logs (utile pour les flaps réseau e2e).
+3. **Reproduire localement** avec la séquence ci-dessus. Si ça passe en
+   local mais échoue en CI :
+   - Différence libc (glibc local vs musl Alpine) → vérifier le job `docker-alpine-verify`.
+   - Différence d'horloge / locale → tests qui dépendent de `TZ` ou `LC_ALL`.
+   - Cache Turborepo corrompu → cliquer _Re-run all jobs_ purge le cache (clé sha-spécifique).
+4. **Pour les builds Docker** : `docker buildx build --progress=plain ...`
+   en local reproduit la sortie exacte. Buildx en CI utilise le driver
+   `docker-container` ; en local, ajoute `--builder default` si besoin.
+
+## Comment ajouter un nouveau job
+
+1. Créer le job dans `ci.yml` ou un workflow dédié (préférable s'il a un
+   trigger spécifique).
+2. **Toujours** déclarer `permissions:` au plus juste (lecture par défaut,
+   écriture uniquement sur les jobs qui poussent quelque chose).
+3. Réutiliser `.github/actions/setup` plutôt que dupliquer pnpm/Node/cache.
+4. Ajouter un `timeout-minutes` réaliste (max ~ 2× la durée habituelle).
+5. Si le job est gating, l'ajouter à la branch protection rule sur `develop`.
+
+## Pinning des actions
+
+Politique :
+
+- Actions **GitHub officielles** (`actions/*`, `github/*`) : pinnées sur
+  une majeure stable (`@v4`, `@v3`). GitHub maintient ces tags.
+- Actions **Docker officielles** (`docker/*`) : idem, majeure stable.
+- Actions **tierces sensibles** (Snyk, Codecov, Trivy) : pinnées sur une
+  version SemVer mineure (`@v5`, `@0.28.0`) ou par SHA pour Snyk
+  (`cdb760004ba9ea4d525f2e043745dfe85bb9077e`). À ré-évaluer chaque
+  trimestre via Renovate ou Dependabot.
+
+## Hors scope KIN-090 (suivi KIN-091)
+
+- Déploiement automatique vers staging / prod (dépend de E14-S06)
+- Migration DB automatique en CD (Drizzle migrate sur ECS task)
+- Smoke tests post-déploiement
+- Rollback automatique sur health-check fail
+- Signature Cosign keyless des images (la permission `id-token: write` est
+  déjà allouée pour préparer le terrain ; l'étape effective viendra avec
+  KIN-091)

--- a/infra/docker/docker-compose.prod.yml
+++ b/infra/docker/docker-compose.prod.yml
@@ -13,10 +13,11 @@
 #   internal services, mandatory secrets (no defaults), and Caddy in front
 #   of the relay + web app for automatic Let's Encrypt TLS.
 # - Multi-stage hardened production Dockerfiles (apps/api/Dockerfile.prod,
-#   apps/web/Dockerfile.prod with Next standalone output) are tracked under
-#   ticket E14-S04 (CI/CD pipeline). For v1.0 preview self-hosters, the
-#   existing apps/api/Dockerfile and apps/web/Dockerfile work but produce
-#   larger images than the eventual prod build.
+#   apps/web/Dockerfile.prod with Next standalone output) ship since
+#   KIN-090 (E14-S04). They run as a non-root `kinhale` user with a
+#   liveness healthcheck and use ~150 Mo runtime images. The dev
+#   Dockerfiles (apps/api/Dockerfile, apps/web/Dockerfile) remain as the
+#   `pnpm dev` entry points and are used by the dev compose only.
 #
 # Notes:
 # - All passwords / secrets MUST come from the env file. Variables marked
@@ -76,7 +77,7 @@ services:
   api:
     build:
       context: ../..
-      dockerfile: apps/api/Dockerfile
+      dockerfile: apps/api/Dockerfile.prod
     container_name: kinhale_api_prod
     restart: unless-stopped
     depends_on:
@@ -110,7 +111,7 @@ services:
   web:
     build:
       context: ../..
-      dockerfile: apps/web/Dockerfile
+      dockerfile: apps/web/Dockerfile.prod
     container_name: kinhale_web_prod
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
## Contexte

Couvre la story **E14-S04 partiellement** (P0). Le CI existant est durci, les images Docker prod sont construites et publiées sur ghcr.io, le scan sécurité tourne en nightly. **Le CD réel staging/prod est reporté en [KIN-091](#)** car il dépend de l'infrastructure ca-central-1 ([E14-S06](#312)).

## Contenu

### Workflows
- **\`actions/setup\`** — composite action DRY pour pnpm + Node 20 + cache Turborepo (utilisée par 3 workflows)
- **\`ci.yml\`** durci — jobs parallèles \`format-check\` / \`lint\` / \`typecheck\` / \`test\` / \`build\` / smoke Alpine (musl)
- **\`build-images.yml\`** — build multi-arch + push ghcr.io sur push develop + tag v* + manuel. **Provenance + SBOM** activés. Trivy scan sur **digest immuable** (anti-race tag mutable). Permissions \`{}\` deny-all au top-level, élargies par job.
- **\`security-scan.yml\`** — Trivy filesystem + images publiées + Snyk (optionnel, skip si secret absent) + \`pnpm audit\`. Daily 03:17 UTC + push main + manuel.
- **\`workflows-lint.yml\`** — actionlint sur les workflows eux-mêmes

### Dockerfiles prod
- **\`apps/api/Dockerfile.prod\`** — multi-stage, runtime distroless (uid 1001), tini PID1, healthcheck loopback-only
- **\`apps/web/Dockerfile.prod\`** — Next.js standalone build, même patron sécurité

### Bug latent corrigé en passant
\`apps/web/src/app/reports/page.tsx\` re-exportait \`MS_PER_DAY\` — illégal Next.js 15 (Page n'accepte que \`default\` + types spéciaux). L'ajout de \`pnpm build\` au CI a fait remonter le warning. Suppression de l'export résiduel (cohérent issue #281).

### Documentation
\`docs/contributing/CI_CD.md\` : vue d'ensemble pipeline, procédure debug, comment tester local, comment ajouter un job + badges README (CI, AGPL, version).

## Sécurité supply chain

Audit kz-securite : posture **excellente**.
- \`permissions: {}\` deny-all + élargissement par job
- \`pull_request_target\` **interdit** (commentaire explicite)
- Aucun secret dans Dockerfiles ni workflows (validés grep)
- BuildKit cache via \`--mount=type=cache\` (pas \`--build-arg\`)
- \`.dockerignore\` rigoureux : \`.env\`, \`.env.*\`, \`**/.env\`, \`**/.env.*\` avec exception \`!.env.example\` + \`!**/.env.example\`
- Trivy SARIF uploadé vers GitHub Security tab

## Tests

- **API : 312/312 verts**
- Lint + typecheck + format monorepo verts
- \`pnpm build\` ajouté au CI (catché 1 bug latent)

## Revues assistées

- **kz-review** — APPROVED. 0 bloquant, 0 majeur. Mineurs traités dans le commit (\`.dockerignore\` \`**/.env\`, MS_PER_DAY supprimé). 4 mineurs restants en suivi. Rapport : [\`kz-review-KIN-090.md\`](../.agents/current-run/kz-review-KIN-090.md)
- **kz-securite** — **GO sans réserve**. 0 bloquant, 0 majeur, 5 mineurs (durcissement défense-en-profondeur). Aucune vulnérabilité exploitable. Rapport : [\`kz-securite-KIN-090.md\`](../.agents/current-run/kz-securite-KIN-090.md)

## Hors scope (reporté en KIN-091)

- Déploiement staging réel (push image → ECS Fargate)
- Déploiement prod sur tag (cosign signing + déploiement automatisé)
- Migration DB automatique en CD

## Suivi

Issues à créer : KIN-091 CD réel + 4 mineurs kz-review + 5 mineurs kz-securite.

Refs: KIN-090
Closes (partiel): E14-S04 — pipeline CI complet, CD reporté KIN-091