### PR TITLE
feat(api): migrations DB versionnées avec rollback formalisé (KIN-092)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,40 @@ jobs:
           verbose: false
 
   # --------------------------------------------------------------------------
+  # DB rollback round-trip — provisions an ephemeral Postgres 16 service and
+  # runs the integration suite that applies every migration, rolls each one
+  # back, then re-applies them. Blocking gate that any new `up.sql` ships
+  # with its `down.sql` (KIN-092 / E14-S05).
+  # --------------------------------------------------------------------------
+  db-rollback-test:
+    name: DB · migration rollback round-trip
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: kinhale
+          POSTGRES_PASSWORD: kinhale_ci
+          POSTGRES_DB: kinhale_ci
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U kinhale -d kinhale_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      KINHALE_DB_TEST_URL: postgresql://kinhale:kinhale_ci@localhost:5433/kinhale_ci
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: ./.github/actions/setup
+      - name: Run rollback round-trip
+        run: pnpm --filter @kinhale/api test src/db
+
+  # --------------------------------------------------------------------------
   # Build apps that produce artefacts. Verifies the production toolchain
   # before we attempt to build container images on push to develop / main.
   # --------------------------------------------------------------------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,22 @@ Before opening a PR:
 - [ ] Accessibility (WCAG 2.1 AA) considered for any UI change.
 - [ ] Any new dependency is declared and licence-checked (compatible with AGPL v3).
 
+### Database migrations
+
+Kinhale uses **Drizzle Kit** for schema migrations (`apps/api/src/db/migrations/`).
+Every `NNNN_<tag>.sql` (the "up") **must** be paired with a hand-written
+`NNNN_<tag>.down.sql` (the rollback). CI blocks any PR that adds a migration
+without its rollback (test `rollback.unit.test.ts`).
+
+- Write idempotent SQL in the rollback (`DROP TABLE IF EXISTS`, `ALTER TABLE
+  IF EXISTS … DROP COLUMN IF EXISTS`, etc.).
+- Run the round-trip locally: `KINHALE_DB_TEST_URL=postgres://… pnpm
+  --filter @kinhale/api test src/db`.
+- Document any data-loss scenario in the PR description and reference
+  [`docs/runbooks/database-migrations.md`](./docs/runbooks/database-migrations.md).
+- Trigger a rollback with `pnpm --filter @kinhale/api db:rollback` (rolls
+  back the most recent applied migration only).
+
 ### Development setup
 
 Detailed setup instructions will live in `docs/contributing/DEVELOPMENT.md` once Sprint 0 opens. Prerequisites:
@@ -151,6 +167,24 @@ Avant d'ouvrir une PR :
 - [ ] PR ≤ 400 lignes modifiées, ou inclut une justification pour une review plus volumineuse.
 - [ ] Accessibilité (WCAG 2.1 AA) prise en compte pour toute modification UI.
 - [ ] Toute nouvelle dépendance est déclarée et sa licence est compatible AGPL v3.
+
+### Migrations de base de données
+
+Kinhale utilise **Drizzle Kit** pour les migrations de schéma
+(`apps/api/src/db/migrations/`). Chaque `NNNN_<tag>.sql` (« up ») **doit**
+être accompagné d'un fichier `NNNN_<tag>.down.sql` écrit à la main
+(rollback). La CI bloque toute PR qui ajoute une migration sans son
+rollback (test `rollback.unit.test.ts`).
+
+- Écrire un SQL idempotent dans le rollback (`DROP TABLE IF EXISTS`,
+  `ALTER TABLE IF EXISTS … DROP COLUMN IF EXISTS`, etc.).
+- Lancer le round-trip local : `KINHALE_DB_TEST_URL=postgres://… pnpm
+  --filter @kinhale/api test src/db`.
+- Documenter tout cas de perte de données dans la description de la PR
+  et renvoyer vers
+  [`docs/runbooks/database-migrations.md`](./docs/runbooks/database-migrations.md).
+- Déclencher un rollback avec `pnpm --filter @kinhale/api db:rollback`
+  (rollback uniquement la dernière migration appliquée).
 
 ### Principes non négociables
 

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -16,6 +16,7 @@
     "db:generate": "drizzle-kit generate",
     "db:push": "drizzle-kit push",
     "db:migrate": "drizzle-kit migrate",
+    "db:rollback": "tsx src/db/rollback-cli.ts",
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {

--- a/apps/api/src/db/__tests__/rollback.integration.test.ts
+++ b/apps/api/src/db/__tests__/rollback.integration.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Test d'intégration round-trip : applique chaque migration, la rollback,
+ * la ré-applique, et vérifie que `__drizzle_migrations` reflète l'état
+ * attendu à chaque étape.
+ *
+ * Le test exige une instance Postgres réelle (pour couvrir
+ * `gen_random_uuid()`, `jsonb`, les index partiels, les FK CASCADE / SET
+ * NULL — dont aucun n'est correctement émulé par pg-mem). Il est skippé
+ * silencieusement si `KINHALE_DB_TEST_URL` n'est pas défini, ce qui
+ * garde `pnpm test` rapide en local sans Postgres. La CI lance un job
+ * dédié `db-rollback-test` qui set la variable et provisionne un
+ * service Postgres 16.
+ *
+ * Bloquant CI : ce test échoue dès qu'une migration n'a pas son
+ * `down.sql` ou que le `down.sql` n'est pas idempotent.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { Pool } from 'pg';
+
+import { fileURLToPath } from 'node:url';
+import { applyMigration, hashUpSql, loadMigrations, rollbackMigration } from '../rollback.js';
+
+const TEST_DB_URL = process.env['KINHALE_DB_TEST_URL'];
+
+const MIGRATIONS_FOLDER = fileURLToPath(new URL('../migrations/', import.meta.url));
+
+async function applyAll(
+  pool: Pool,
+  migrations: Awaited<ReturnType<typeof loadMigrations>>,
+): Promise<void> {
+  for (const m of migrations) {
+    const client = await pool.connect();
+    try {
+      await applyMigration(client, m);
+    } finally {
+      client.release();
+    }
+  }
+}
+
+// `describe.skipIf` est non-statique : on doit le calculer à la lecture.
+const describeIfDb = TEST_DB_URL ? describe : describe.skip;
+
+describeIfDb('migration rollback round-trip (Postgres réel)', () => {
+  let pool: Pool;
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+    // Bac à sable : on repart d'un schéma `public` vide. Le test est seul
+    // sur sa DB jetable, c'est sans effet de bord pour les autres jobs.
+    const client = await pool.connect();
+    try {
+      await client.query('DROP SCHEMA IF EXISTS "drizzle" CASCADE');
+      await client.query('DROP SCHEMA IF EXISTS "public" CASCADE');
+      await client.query('CREATE SCHEMA "public"');
+      await client.query('GRANT ALL ON SCHEMA "public" TO PUBLIC');
+    } finally {
+      client.release();
+    }
+  }, 30_000);
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  async function readAppliedHashes(): Promise<string[]> {
+    const client = await pool.connect();
+    try {
+      const exists = await client.query<{ exists: boolean }>(
+        `SELECT EXISTS (
+           SELECT 1 FROM information_schema.tables
+           WHERE table_schema = 'drizzle' AND table_name = '__drizzle_migrations'
+         ) AS "exists"`,
+      );
+      if (!exists.rows[0]?.exists) return [];
+      const res = await client.query<{ hash: string }>(
+        `SELECT "hash" FROM "drizzle"."__drizzle_migrations" ORDER BY "created_at" ASC, "id" ASC`,
+      );
+      return res.rows.map((r) => r.hash);
+    } finally {
+      client.release();
+    }
+  }
+
+  it("rejoue chaque migration en up → down → up et vérifie l'état du journal", async () => {
+    const migrations = await loadMigrations(MIGRATIONS_FOLDER);
+    expect(migrations.length).toBeGreaterThan(0);
+
+    // 1. Apply all migrations dans l'ordre.
+    for (const m of migrations) {
+      const client = await pool.connect();
+      try {
+        await applyMigration(client, m);
+      } finally {
+        client.release();
+      }
+    }
+
+    let hashes = await readAppliedHashes();
+    expect(hashes).toEqual(migrations.map((m) => m.upHash));
+
+    // 2. Rollback en sens inverse — chaque down.sql doit être valide à la
+    //    fois en SQL et logiquement (pas de FK orphelines).
+    for (let i = migrations.length - 1; i >= 0; i--) {
+      const m = migrations[i];
+      expect(m).toBeDefined();
+      if (!m) continue;
+      const client = await pool.connect();
+      try {
+        await rollbackMigration(client, m);
+      } finally {
+        client.release();
+      }
+    }
+
+    hashes = await readAppliedHashes();
+    expect(hashes).toEqual([]);
+
+    // 3. Ré-applique tout — garantit que les down.sql ont laissé un état
+    //    propre (pas de table résiduelle / pas d'index orphelin).
+    for (const m of migrations) {
+      const client = await pool.connect();
+      try {
+        await applyMigration(client, m);
+      } finally {
+        client.release();
+      }
+    }
+
+    hashes = await readAppliedHashes();
+    expect(hashes).toEqual(migrations.map((m) => m.upHash));
+  }, 120_000);
+
+  it('chaque down.sql est idempotent (peut être appliqué deux fois sans erreur)', async () => {
+    const migrations = await loadMigrations(MIGRATIONS_FOLDER);
+
+    // Repartir d'un état fully migrated connu — pas de couplage temporel
+    // avec le test précédent (qui pourrait être réordonné par vitest).
+    await applyAll(pool, migrations);
+
+    // Rollback dans l'ordre inverse depuis l'état fully migrated.
+    for (let i = migrations.length - 1; i >= 0; i--) {
+      const m = migrations[i];
+      expect(m).toBeDefined();
+      if (!m) continue;
+      const client = await pool.connect();
+      try {
+        await rollbackMigration(client, m);
+      } finally {
+        client.release();
+      }
+    }
+
+    // Re-rollback : doit être no-op et ne pas lever — `DROP IF EXISTS`
+    // partout, statements ALTER protégés par DROP CONSTRAINT IF EXISTS.
+    for (let i = migrations.length - 1; i >= 0; i--) {
+      const m = migrations[i];
+      expect(m).toBeDefined();
+      if (!m) continue;
+      const client = await pool.connect();
+      try {
+        // Le delete sur __drizzle_migrations est déjà no-op (la ligne
+        // n'existe plus). On exécute juste les statements down.
+        for (const stmt of m.downStatements) {
+          await client.query(stmt);
+        }
+      } finally {
+        client.release();
+      }
+    }
+  }, 120_000);
+
+  it('hashUpSql produit la même valeur que celle stockée par le runtime Drizzle', async () => {
+    // Sanity check : si Drizzle change sa logique de hash, ce test pète
+    // et on s'en aperçoit avant que le rollback CLI n'efface la mauvaise
+    // ligne en prod.
+    const fs = await import('node:fs/promises');
+    const migrations = await loadMigrations(MIGRATIONS_FOLDER);
+    for (const m of migrations) {
+      const upRaw = await fs.readFile(m.upPath, 'utf8');
+      const upHashFromFile = await hashUpSql(upRaw);
+      expect(m.upHash).toBe(upHashFromFile);
+    }
+  });
+});

--- a/apps/api/src/db/__tests__/rollback.integration.test.ts
+++ b/apps/api/src/db/__tests__/rollback.integration.test.ts
@@ -15,7 +15,7 @@
  * `down.sql` ou que le `down.sql` n'est pas idempotent.
  */
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { Pool } from 'pg';
 
 import { fileURLToPath } from 'node:url';
@@ -45,8 +45,7 @@ const describeIfDb = TEST_DB_URL ? describe : describe.skip;
 describeIfDb('migration rollback round-trip (Postgres réel)', () => {
   let pool: Pool;
 
-  beforeAll(async () => {
-    pool = new Pool({ connectionString: TEST_DB_URL });
+  async function resetSchema(): Promise<void> {
     // Bac à sable : on repart d'un schéma `public` vide. Le test est seul
     // sur sa DB jetable, c'est sans effet de bord pour les autres jobs.
     const client = await pool.connect();
@@ -58,6 +57,16 @@ describeIfDb('migration rollback round-trip (Postgres réel)', () => {
     } finally {
       client.release();
     }
+  }
+
+  beforeAll(async () => {
+    pool = new Pool({ connectionString: TEST_DB_URL });
+  }, 30_000);
+
+  beforeEach(async () => {
+    // Reset entre chaque `it()` — pas de couplage temporel, vitest peut
+    // réordonner les tests sans casse.
+    await resetSchema();
   }, 30_000);
 
   afterAll(async () => {

--- a/apps/api/src/db/__tests__/rollback.unit.test.ts
+++ b/apps/api/src/db/__tests__/rollback.unit.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests unitaires des helpers de `rollback.ts` — pas besoin de DB.
+ *
+ * Couvre :
+ *  - `splitSqlStatements` : découpe propre, filtrage des fragments vides.
+ *  - `hashUpSql` : conformité au hash Drizzle (SHA-256 hex sur le brut).
+ *  - `loadMigrations` : parcours du journal, présence des fichiers, rejet
+ *     explicite quand un `down.sql` est absent.
+ *
+ * L'invariant le plus important pour la CI : `loadMigrations` doit
+ * réussir sur le dossier réel `apps/api/src/db/migrations`. Ce test fait
+ * office de garde — toute migration ajoutée sans son `down.sql` casse la
+ * suite.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { sha256HexFromString } from '@kinhale/crypto';
+
+import { hashUpSql, loadMigrations, splitSqlStatements } from '../rollback.js';
+
+const REAL_MIGRATIONS = path.resolve(
+  path.dirname(new URL(import.meta.url).pathname),
+  '..',
+  'migrations',
+);
+
+describe('splitSqlStatements', () => {
+  it('découpe sur le marqueur Drizzle et trim les fragments', () => {
+    const input = `CREATE TABLE a();--> statement-breakpoint\n\nDROP TABLE b;`;
+    expect(splitSqlStatements(input)).toEqual(['CREATE TABLE a();', 'DROP TABLE b;']);
+  });
+
+  it('filtre les fragments vides', () => {
+    const input = `--> statement-breakpoint\n\n--> statement-breakpoint\nDROP TABLE a;`;
+    expect(splitSqlStatements(input)).toEqual(['DROP TABLE a;']);
+  });
+
+  it('renvoie un seul fragment pour un fichier sans breakpoint', () => {
+    expect(splitSqlStatements('SELECT 1;')).toEqual(['SELECT 1;']);
+  });
+});
+
+describe('hashUpSql', () => {
+  it('reproduit le hash Drizzle (SHA-256 hex sur le brut)', async () => {
+    const sql = 'CREATE TABLE foo(id int);';
+    const expected = await sha256HexFromString(sql);
+    expect(await hashUpSql(sql)).toBe(expected);
+  });
+
+  it('produit la même valeur que crypto.createHash(sha256) — vector connu', async () => {
+    // Vector RFC : sha256("abc") = ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad.
+    expect(await hashUpSql('abc')).toBe(
+      'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+    );
+  });
+});
+
+describe('loadMigrations sur le dossier réel apps/api/src/db/migrations', () => {
+  it('charge toutes les entrées du journal et trouve up + down pour chacune', async () => {
+    const migrations = await loadMigrations(REAL_MIGRATIONS);
+    expect(migrations.length).toBeGreaterThanOrEqual(5);
+
+    const tags = migrations.map((m) => m.entry.tag);
+    expect(tags).toContain('0000_silent_zzzax');
+    expect(tags).toContain('0001_curly_iron_man');
+    expect(tags).toContain('0002_quiet_hours');
+    expect(tags).toContain('0003_audit_events');
+    expect(tags).toContain('0004_account_deletion');
+
+    for (const m of migrations) {
+      expect(m.upStatements.length).toBeGreaterThan(0);
+      expect(m.downStatements.length).toBeGreaterThan(0);
+      expect(m.upHash).toMatch(/^[0-9a-f]{64}$/);
+    }
+  });
+});
+
+describe('loadMigrations sur dossier synthétique', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), 'kinhale-rollback-'));
+    await mkdir(path.join(tmpDir, 'meta'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  async function writeJournal(entries: ReadonlyArray<{ tag: string; idx: number }>) {
+    const payload = {
+      version: '7',
+      dialect: 'postgresql',
+      entries: entries.map((e) => ({
+        idx: e.idx,
+        version: '7',
+        when: 1700000000000 + e.idx,
+        tag: e.tag,
+        breakpoints: true,
+      })),
+    };
+    await writeFile(path.join(tmpDir, 'meta', '_journal.json'), JSON.stringify(payload));
+  }
+
+  it('lève quand un fichier up.sql est absent', async () => {
+    await writeJournal([{ tag: '0000_init', idx: 0 }]);
+    await writeFile(path.join(tmpDir, '0000_init.down.sql'), 'DROP TABLE a;');
+
+    await expect(loadMigrations(tmpDir)).rejects.toThrow(/missing up\.sql.*0000_init/);
+  });
+
+  it('lève avec un message explicite quand un down.sql manque', async () => {
+    await writeJournal([{ tag: '0000_init', idx: 0 }]);
+    await writeFile(path.join(tmpDir, '0000_init.sql'), 'CREATE TABLE a();');
+
+    await expect(loadMigrations(tmpDir)).rejects.toThrow(
+      /missing down\.sql for migration 0000_init.*manual rollback required/,
+    );
+  });
+
+  it('charge correctement quand up + down sont présents', async () => {
+    await writeJournal([{ tag: '0000_init', idx: 0 }]);
+    const upSql = 'CREATE TABLE a(id int);';
+    const downSql = 'DROP TABLE IF EXISTS a;';
+    await writeFile(path.join(tmpDir, '0000_init.sql'), upSql);
+    await writeFile(path.join(tmpDir, '0000_init.down.sql'), downSql);
+
+    const migrations = await loadMigrations(tmpDir);
+    expect(migrations).toHaveLength(1);
+    const first = migrations[0];
+    expect(first).toBeDefined();
+    if (!first) return;
+    expect(first.entry.tag).toBe('0000_init');
+    expect(first.upStatements).toEqual(['CREATE TABLE a(id int);']);
+    expect(first.downStatements).toEqual(['DROP TABLE IF EXISTS a;']);
+    expect(first.upHash).toBe(await hashUpSql(upSql));
+  });
+});

--- a/apps/api/src/db/migrations/0000_silent_zzzax.down.sql
+++ b/apps/api/src/db/migrations/0000_silent_zzzax.down.sql
@@ -1,0 +1,25 @@
+-- Rollback de 0000_silent_zzzax.sql (schéma initial relais).
+--
+-- ATTENTION : cette opération est destructive et fait disparaître toute
+-- la base relais. À ne JAMAIS exécuter en production sans procédure
+-- d'export préalable. Ce rollback est essentiellement utile pour les
+-- tests d'intégration et la remise à zéro d'un environnement de dev.
+--
+-- Ordre = inverse exact de l'application :
+--   1. Supprimer index uniques avant les FK (pas strictement nécessaire,
+--      les DROP TABLE en CASCADE suppriment leurs propres index, mais on
+--      garde l'idempotence explicite).
+--   2. DROP TABLE en CASCADE pour absorber les éventuelles dépendances
+--      résiduelles.
+--
+-- Idempotent : DROP IF EXISTS partout.
+
+DROP INDEX IF EXISTS "push_tokens_household_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "push_tokens_device_token_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "devices_account_pubkey_idx";--> statement-breakpoint
+
+DROP TABLE IF EXISTS "push_tokens" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "mailbox_messages" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "magic_links" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "devices" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "accounts" CASCADE;

--- a/apps/api/src/db/migrations/0001_curly_iron_man.down.sql
+++ b/apps/api/src/db/migrations/0001_curly_iron_man.down.sql
@@ -1,0 +1,6 @@
+-- Rollback de 0001_curly_iron_man.sql (KIN-080 — préférences notifications).
+--
+-- Idempotent : DROP avec IF EXISTS, ordre = inverse de l'application.
+
+DROP INDEX IF EXISTS "user_notif_prefs_account_type_idx";--> statement-breakpoint
+DROP TABLE IF EXISTS "user_notification_preferences";

--- a/apps/api/src/db/migrations/0002_quiet_hours.down.sql
+++ b/apps/api/src/db/migrations/0002_quiet_hours.down.sql
@@ -1,0 +1,6 @@
+-- Rollback de 0002_quiet_hours.sql (KIN-081 — préférences plages calmes).
+--
+-- Idempotent : DROP avec IF EXISTS, ordre = inverse de l'application.
+
+DROP INDEX IF EXISTS "user_quiet_hours_account_idx";--> statement-breakpoint
+DROP TABLE IF EXISTS "user_quiet_hours";

--- a/apps/api/src/db/migrations/0003_audit_events.down.sql
+++ b/apps/api/src/db/migrations/0003_audit_events.down.sql
@@ -1,0 +1,12 @@
+-- Rollback de 0003_audit_events.sql (KIN-083 — audit trail).
+--
+-- ATTENTION : la table `audit_events` contient des preuves réglementaires
+-- (Loi 25 art. 3.1 / 3.2, RGPD art. 30). Ce DROP TABLE supprime
+-- DÉFINITIVEMENT ces preuves. À utiliser uniquement en dev / test, jamais
+-- en prod sans procédure d'export préalable (cf. runbook).
+--
+-- Idempotent : tous les DROP utilisent IF EXISTS.
+
+DROP INDEX IF EXISTS "audit_events_created_idx";--> statement-breakpoint
+DROP INDEX IF EXISTS "audit_events_account_type_idx";--> statement-breakpoint
+DROP TABLE IF EXISTS "audit_events";

--- a/apps/api/src/db/migrations/0004_account_deletion.down.sql
+++ b/apps/api/src/db/migrations/0004_account_deletion.down.sql
@@ -1,0 +1,50 @@
+-- Rollback de 0004_account_deletion.sql (E9-S03 / E9-S04 / RM10).
+--
+-- ATTENTION : ce rollback DÉTRUIT des données :
+--   1. La table `deleted_accounts` (preuve pseudonymisée 12 mois) est
+--      supprimée — toute trace légale de purge est perdue.
+--   2. La table `account_deletion_step_up_tokens` est supprimée — les
+--      demandes de suppression en cours sont invalidées.
+--   3. Les colonnes `deletion_status` / `deletion_scheduled_at_ms` sont
+--      retirées de `accounts` — les comptes en période de grâce
+--      basculent silencieusement en état actif.
+--   4. La FK `audit_events.account_id` repasse en CASCADE et la colonne
+--      redevient NOT NULL ; toute ligne `audit_events` orpheline
+--      (account_id NULL après une purge effective) **fera échouer le
+--      rollback**. Dans ce cas : nettoyer ces lignes manuellement avant
+--      de relancer (cf. docs/runbooks/database-migrations.md §rollback).
+--
+-- Idempotent : tous les DROP utilisent IF EXISTS ; les ALTER sur
+-- `audit_events` sont enveloppés dans un DO LANGUAGE plpgsql gardé par
+-- l'existence de la table — utile quand on rollback en chaîne 0004 puis
+-- 0003 (lequel supprime `audit_events`) ou quand on relance ce down.sql
+-- deux fois.
+
+-- 1. Audit events : restaure la FK CASCADE et NOT NULL si la table existe encore.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'audit_events'
+  ) THEN
+    ALTER TABLE "audit_events" DROP CONSTRAINT IF EXISTS "audit_events_account_id_accounts_id_fk";
+    ALTER TABLE "audit_events" ALTER COLUMN "account_id" SET NOT NULL;
+    ALTER TABLE "audit_events" ADD CONSTRAINT "audit_events_account_id_accounts_id_fk"
+      FOREIGN KEY ("account_id") REFERENCES "public"."accounts"("id")
+      ON DELETE CASCADE ON UPDATE NO ACTION;
+  END IF;
+END
+$$;--> statement-breakpoint
+
+-- 2. Deleted accounts (trace pseudonymisée).
+DROP INDEX IF EXISTS "deleted_accounts_deleted_at_idx";--> statement-breakpoint
+DROP TABLE IF EXISTS "deleted_accounts";--> statement-breakpoint
+
+-- 3. Step-up tokens.
+DROP INDEX IF EXISTS "account_deletion_step_up_account_idx";--> statement-breakpoint
+DROP TABLE IF EXISTS "account_deletion_step_up_tokens";--> statement-breakpoint
+
+-- 4. Index partiel + colonnes accounts.
+DROP INDEX IF EXISTS "accounts_pending_deletion_idx";--> statement-breakpoint
+ALTER TABLE IF EXISTS "accounts" DROP COLUMN IF EXISTS "deletion_scheduled_at_ms";--> statement-breakpoint
+ALTER TABLE IF EXISTS "accounts" DROP COLUMN IF EXISTS "deletion_status";

--- a/apps/api/src/db/rollback-cli.ts
+++ b/apps/api/src/db/rollback-cli.ts
@@ -1,0 +1,48 @@
+/**
+ * CLI `pnpm --filter @kinhale/api db:rollback`.
+ *
+ * Connecte un client `pg` sur `DATABASE_URL`, lance `rollbackLatest()` et
+ * imprime le tag de la migration rollée. Aucune autre opération (pas de
+ * dump, pas de purge, pas de chained rollback) — l'opérateur garde la
+ * main, la procédure complète est documentée dans
+ * `docs/runbooks/database-migrations.md`.
+ *
+ * Usage :
+ *   DATABASE_URL=postgres://… pnpm --filter @kinhale/api db:rollback
+ *
+ * Codes de retour :
+ *   0 — rollback effectué (tag imprimé sur stdout)
+ *   1 — erreur (message imprimé sur stderr)
+ */
+
+import { Pool } from 'pg';
+import { defaultMigrationsFolder, rollbackLatest } from './rollback.js';
+
+async function main(): Promise<void> {
+  const url = process.env['DATABASE_URL'];
+  if (url === undefined || url.length === 0) {
+    throw new Error('DATABASE_URL is not set');
+  }
+
+  const folder = process.env['KINHALE_MIGRATIONS_FOLDER'] ?? defaultMigrationsFolder();
+
+  const pool = new Pool({ connectionString: url });
+  try {
+    const client = await pool.connect();
+    try {
+      const tag = await rollbackLatest(client, folder);
+      // stdout reste machine-readable : un seul tag par ligne.
+      process.stdout.write(`${tag}\n`);
+    } finally {
+      client.release();
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  process.stderr.write(`db:rollback failed: ${msg}\n`);
+  process.exitCode = 1;
+});

--- a/apps/api/src/db/rollback.ts
+++ b/apps/api/src/db/rollback.ts
@@ -1,0 +1,250 @@
+/**
+ * Rollback de migrations Drizzle — convention `up.sql` / `down.sql`.
+ *
+ * Drizzle Kit génère les fichiers `NNNN_<tag>.sql` (la « up ») et tient
+ * un journal `meta/_journal.json` listant chaque migration. Le runtime
+ * Drizzle (`migrate()`) applique séquentiellement chaque entrée et
+ * enregistre son hash dans la table `drizzle.__drizzle_migrations`.
+ *
+ * Drizzle ne supporte pas nativement le rollback. La convention adoptée
+ * pour Kinhale (KIN-092 / E14-S05) est de **co-localiser** un fichier
+ * `NNNN_<tag>.down.sql` à côté de chaque `up.sql`. Ce module :
+ *
+ *  - charge le journal,
+ *  - vérifie l'existence des deux fichiers (`up` + `down`),
+ *  - applique / rollback une migration sous transaction,
+ *  - met à jour la table `drizzle.__drizzle_migrations` en cohérence.
+ *
+ * **Sécurité** :
+ *  - Aucune opération n'utilise `DROP DATABASE` ou `DROP SCHEMA public`.
+ *    La granularité du rollback est la migration ; tout au plus, le
+ *    rollback de `0000` supprime les tables applicatives.
+ *  - Chaque `down.sql` doit être idempotent (DROP IF EXISTS, etc.) — la
+ *    suite de tests `migration-rollback.test.ts` enforce cette règle en
+ *    appliquant la séquence up → down → down → up sur une DB jetable.
+ *  - Toute migration sans `down.sql` provoque une erreur explicite avant
+ *    toute exécution SQL : on échoue tôt, jamais au milieu d'un rollback
+ *    partiel.
+ *
+ * Tracking : KIN-092, follow-up de KIN-080 (issue #233).
+ */
+
+import { readFile, access } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { sha256HexFromString } from '@kinhale/crypto';
+import type { PoolClient } from 'pg';
+
+/** Une entrée du journal Drizzle (`meta/_journal.json`). */
+export interface JournalEntry {
+  readonly idx: number;
+  readonly version: string;
+  readonly when: number;
+  readonly tag: string;
+  readonly breakpoints: boolean;
+}
+
+interface Journal {
+  readonly version: string;
+  readonly dialect: string;
+  readonly entries: readonly JournalEntry[];
+}
+
+/** Une migration matérialisée — fichiers et statements pré-découpés. */
+export interface Migration {
+  readonly entry: JournalEntry;
+  readonly upPath: string;
+  readonly downPath: string;
+  readonly upStatements: readonly string[];
+  readonly downStatements: readonly string[];
+  readonly upHash: string;
+}
+
+const STATEMENT_BREAKPOINT = '--> statement-breakpoint';
+
+/**
+ * Découpe un fichier SQL Drizzle sur le marqueur `statement-breakpoint`,
+ * en filtrant les fragments vides.
+ */
+export function splitSqlStatements(sql: string): string[] {
+  return sql
+    .split(STATEMENT_BREAKPOINT)
+    .map((stmt) => stmt.trim())
+    .filter((stmt) => stmt.length > 0);
+}
+
+/**
+ * Hash SHA-256 utilisé par Drizzle pour identifier une migration dans
+ * `drizzle.__drizzle_migrations`. **Doit** matcher exactement la logique
+ * du runtime Drizzle (`migrator.js#readMigrationFiles`) sinon le rollback
+ * ne pourra pas retrouver la ligne à supprimer.
+ *
+ * Drizzle hash le **contenu brut** du fichier `.sql` (avant split). On
+ * passe par `@kinhale/crypto` (SHA-256 Web Crypto) plutôt que `node:crypto`
+ * pour respecter la règle de portabilité du monorepo (CLAUDE.md). Le
+ * digest hex produit est strictement identique à celui de `crypto.createHash`.
+ */
+export async function hashUpSql(rawSql: string): Promise<string> {
+  return sha256HexFromString(rawSql);
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Charge toutes les migrations déclarées dans `_journal.json`. Lève une
+ * erreur si un fichier `up.sql` ou `down.sql` est absent — la CI bloque
+ * ainsi toute PR qui ajoute une migration sans son rollback.
+ */
+export async function loadMigrations(migrationsFolder: string): Promise<Migration[]> {
+  const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
+  const journalRaw = await readFile(journalPath, 'utf8');
+  const journal = JSON.parse(journalRaw) as Journal;
+
+  const migrations: Migration[] = [];
+  for (const entry of journal.entries) {
+    const upPath = path.join(migrationsFolder, `${entry.tag}.sql`);
+    const downPath = path.join(migrationsFolder, `${entry.tag}.down.sql`);
+
+    if (!(await fileExists(upPath))) {
+      throw new Error(`missing up.sql for migration ${entry.tag} (expected at ${upPath})`);
+    }
+    if (!(await fileExists(downPath))) {
+      throw new Error(
+        `missing down.sql for migration ${entry.tag} — manual rollback required ` +
+          `(expected at ${downPath}, see docs/runbooks/database-migrations.md)`,
+      );
+    }
+
+    const upSql = await readFile(upPath, 'utf8');
+    const downSql = await readFile(downPath, 'utf8');
+
+    migrations.push({
+      entry,
+      upPath,
+      downPath,
+      upStatements: splitSqlStatements(upSql),
+      downStatements: splitSqlStatements(downSql),
+      upHash: await hashUpSql(upSql),
+    });
+  }
+  return migrations;
+}
+
+/**
+ * Applique le `up.sql` d'une migration sous une transaction unique et
+ * enregistre la ligne `__drizzle_migrations` (mêmes colonnes / valeurs
+ * que la fonction `migrate()` officielle de Drizzle).
+ *
+ * Important : on appelle ça uniquement depuis le test de round-trip ; en
+ * prod / dev on continue d'utiliser `drizzle-kit migrate`.
+ */
+export async function applyMigration(client: PoolClient, migration: Migration): Promise<void> {
+  await client.query('BEGIN');
+  try {
+    await client.query(`CREATE SCHEMA IF NOT EXISTS "drizzle"`);
+    await client.query(
+      `CREATE TABLE IF NOT EXISTS "drizzle"."__drizzle_migrations" (
+         id SERIAL PRIMARY KEY,
+         hash text NOT NULL,
+         created_at bigint
+       )`,
+    );
+    for (const stmt of migration.upStatements) {
+      await client.query(stmt);
+    }
+    await client.query(
+      `INSERT INTO "drizzle"."__drizzle_migrations" ("hash", "created_at") VALUES ($1, $2)`,
+      [migration.upHash, migration.entry.when],
+    );
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  }
+}
+
+/**
+ * Applique le `down.sql` d'une migration sous une transaction unique et
+ * retire la ligne correspondante de `drizzle.__drizzle_migrations`.
+ *
+ * Si la table de tracking n'existe pas (cas où aucune migration n'a
+ * jamais été appliquée), on lève. C'est volontaire : rollback sans état
+ * connu = opération inutile au mieux, dangereuse au pire.
+ */
+export async function rollbackMigration(client: PoolClient, migration: Migration): Promise<void> {
+  await client.query('BEGIN');
+  try {
+    for (const stmt of migration.downStatements) {
+      await client.query(stmt);
+    }
+    await client.query(`DELETE FROM "drizzle"."__drizzle_migrations" WHERE "hash" = $1`, [
+      migration.upHash,
+    ]);
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  }
+}
+
+/**
+ * Renvoie le hash de la dernière migration enregistrée, ou `null` si la
+ * table de tracking est absente / vide.
+ */
+export async function getLastAppliedHash(client: PoolClient): Promise<string | null> {
+  const tableExists = await client.query<{ exists: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.tables
+       WHERE table_schema = 'drizzle' AND table_name = '__drizzle_migrations'
+     ) AS "exists"`,
+  );
+  if (!tableExists.rows[0]?.exists) return null;
+
+  const res = await client.query<{ hash: string }>(
+    `SELECT "hash" FROM "drizzle"."__drizzle_migrations" ORDER BY "created_at" DESC, "id" DESC LIMIT 1`,
+  );
+  return res.rows[0]?.hash ?? null;
+}
+
+/**
+ * Rollback de la dernière migration appliquée sur la base ciblée par
+ * `client`. Renvoie le tag de la migration rollée. Si aucune migration
+ * n'est appliquée, lève — un rollback à vide est un signal d'usage
+ * incorrect (l'opérateur croyait probablement avoir migré).
+ */
+export async function rollbackLatest(
+  client: PoolClient,
+  migrationsFolder: string,
+): Promise<string> {
+  const migrations = await loadMigrations(migrationsFolder);
+  const lastHash = await getLastAppliedHash(client);
+  if (lastHash === null) {
+    throw new Error('no applied migration found in drizzle.__drizzle_migrations');
+  }
+  const target = migrations.find((m) => m.upHash === lastHash);
+  if (target === undefined) {
+    throw new Error(
+      `last applied migration (hash=${lastHash}) is not present in journal — ` +
+        `manual recovery required (see docs/runbooks/database-migrations.md)`,
+    );
+  }
+  await rollbackMigration(client, target);
+  return target.entry.tag;
+}
+
+/** Résolution du dossier `migrations/` pour le binaire CLI. */
+export function defaultMigrationsFolder(): string {
+  // En runtime, ce module est compilé sous `dist/db/rollback.js` ; on
+  // remonte d'un cran pour pointer vers `dist/db/migrations`. En
+  // exécution `tsx`, on est sous `src/db/rollback.ts`, on pointe vers
+  // `src/db/migrations`. Les deux fonctionnent grâce au `import.meta.url`.
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  return path.join(here, 'migrations');
+}

--- a/docs/runbooks/database-migrations.md
+++ b/docs/runbooks/database-migrations.md
@@ -1,0 +1,256 @@
+# Runbook — Migrations DB et rollback
+
+> **Tracking** : KIN-092 / E14-S05.
+> **Périmètre** : relais Kinhale (`apps/api`) — base PostgreSQL 16 sur RDS
+> en prod, container local en dev.
+> **Audience** : opérateurs SRE, mainteneurs API, on-call.
+
+Ce runbook décrit la convention `up.sql` / `down.sql`, le script de
+rollback, la procédure pour annuler une migration en prod / dev, et les
+limites connues (cas où un `down.sql` ne suffit pas).
+
+---
+
+## 1. Convention de nommage
+
+Chaque migration Drizzle est un couple de fichiers co-localisés dans
+`apps/api/src/db/migrations/` :
+
+```
+NNNN_<tag>.sql            # up — généré par drizzle-kit
+NNNN_<tag>.down.sql       # down — écrit MANUELLEMENT, jamais généré
+NNNN_<tag>.sql            # …
+NNNN_<tag>.down.sql
+```
+
+Le journal `meta/_journal.json` ne référence que la « up » : les
+fichiers `.down.sql` sont découverts par convention de nom.
+
+**Bloquant CI** : la suite `rollback.unit.test.ts` charge le journal et
+échoue si un `down.sql` est manquant. Toute PR qui ajoute une migration
+sans son rollback est rejetée par la CI.
+
+---
+
+## 2. Écrire un `down.sql`
+
+Inverser exactement la « up », dans l'ordre inverse, avec des clauses
+**idempotentes** (le test `chaque down.sql est idempotent` enforce cette
+règle en l'appliquant deux fois) :
+
+| Up                          | Down idempotent                                            |
+| --------------------------- | ---------------------------------------------------------- |
+| `CREATE TABLE x (...)`      | `DROP TABLE IF EXISTS "x"` (ajouter `CASCADE` si FK)       |
+| `ALTER TABLE x ADD COLUMN y`| `ALTER TABLE IF EXISTS "x" DROP COLUMN IF EXISTS "y"`      |
+| `CREATE INDEX ix ON x ...`  | `DROP INDEX IF EXISTS "ix"`                                |
+| `ALTER TABLE x ADD CONSTRAINT cn ...` | `ALTER TABLE x DROP CONSTRAINT IF EXISTS "cn"`     |
+| `ALTER COLUMN ... SET NOT NULL` | `ALTER COLUMN ... DROP NOT NULL`                       |
+
+Pour les opérations **conditionnelles** (par exemple restaurer une FK
+sur une table qui a pu être supprimée par un rollback précédent),
+encapsuler dans un `DO $$ … $$` plpgsql :
+
+```sql
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'audit_events'
+  ) THEN
+    ALTER TABLE "audit_events" ALTER COLUMN "account_id" SET NOT NULL;
+  END IF;
+END
+$$;
+```
+
+Le séparateur de statements **doit** être `--> statement-breakpoint`
+(même convention que la « up » Drizzle) — le runtime de rollback split
+sur cette balise.
+
+---
+
+## 3. Script de rollback
+
+Commande :
+
+```bash
+DATABASE_URL=postgres://… pnpm --filter @kinhale/api db:rollback
+```
+
+Comportement :
+
+1. Charge `meta/_journal.json` et vérifie que **tous** les couples
+   up/down existent (échec sinon).
+2. Lit `drizzle.__drizzle_migrations` et identifie la dernière
+   migration appliquée (par hash SHA-256, identique à celui calculé par
+   le runtime Drizzle).
+3. Ouvre une transaction, exécute chaque statement du `down.sql`,
+   supprime la ligne correspondante de `__drizzle_migrations`, commit.
+4. Imprime le tag rollé sur stdout.
+
+Codes de retour :
+
+- `0` — succès, le tag est sur stdout
+- `1` — erreur (DB injoignable, journal incohérent, dernier hash absent
+  du journal, statement SQL échoué) — message sur stderr
+
+**Le script rollback UNIQUEMENT la dernière migration**. Pour rollback
+plusieurs migrations, exécuter la commande N fois (chaque appel relit
+l'état frais de la DB).
+
+---
+
+## 4. Procédure rollback — Production
+
+> Ces étapes nécessitent un **incident commander** désigné. Aucun
+> rollback prod ne se fait en solo.
+
+1. **Drainer le trafic d'écriture** sur l'API :
+   - Activer le mode read-only via le feature flag `RELAY_READ_ONLY=1`
+     (ou couper le scaling à 0 et router le trafic vers une page de
+     maintenance le temps du rollback).
+   - Attendre la fin des transactions en cours (≤ 30 s en régime
+     normal, cf. dashboard Grafana « API · in-flight requests »).
+2. **Snapshot RDS** : déclencher un snapshot manuel
+   (`aws rds create-db-snapshot --db-instance-identifier kinhale-prod
+   --db-snapshot-identifier rollback-pre-NNNN-<timestamp>`).
+   Conservation : 30 j (cf. follow-up issue #290 — rétention RDS).
+3. **Vérifier** quelle migration sera rollée (sécurité) :
+   ```sql
+   SELECT hash, to_timestamp(created_at/1000) AS at
+   FROM drizzle.__drizzle_migrations ORDER BY id DESC LIMIT 1;
+   ```
+   Croiser avec `meta/_journal.json` sur la branche déployée.
+4. **Lancer le rollback** depuis un bastion :
+   ```bash
+   DATABASE_URL=$(aws secretsmanager get-secret-value \
+     --secret-id kinhale/prod/db-url --query SecretString --output text) \
+     pnpm --filter @kinhale/api db:rollback
+   ```
+5. **Redéployer la version applicative précédente** (rollback du
+   conteneur ECS/Coolify, taggé `vX.Y.Z-1`). Le code applicatif doit
+   correspondre au schéma rollé — sinon les requêtes ORM tomberont sur
+   des colonnes manquantes.
+6. **Vérifier l'intégrité** :
+   - Healthcheck `/health` passant ;
+   - Smoke tests synthétiques (login + sync batch) ;
+   - Pas d'erreur SQL dans les logs CloudWatch sur 5 min.
+7. **Réouvrir le trafic** : désactiver le feature flag, scale up.
+8. **Post-mortem** : ouvrir un incident dans Linear, lien vers le tag
+   rollé, snapshot RDS conservé, RCA dans les 48 h.
+
+---
+
+## 5. Procédure rollback — Développement
+
+```bash
+# 1. Vérifier l'état :
+docker compose -f infra/docker/docker-compose.yml exec postgres \
+  psql -U kinhale -d kinhale_dev \
+  -c "SELECT * FROM drizzle.__drizzle_migrations ORDER BY id DESC LIMIT 5;"
+
+# 2. Rollback :
+DATABASE_URL=postgresql://kinhale:kinhale_dev_secret@localhost:5434/kinhale_dev \
+  pnpm --filter @kinhale/api db:rollback
+
+# 3. Re-migrer si besoin :
+DATABASE_URL=… pnpm --filter @kinhale/api db:migrate
+```
+
+Pour repartir d'une base **vide** sans toucher au volume Docker :
+
+```bash
+docker compose -f infra/docker/docker-compose.yml exec postgres \
+  psql -U kinhale -d kinhale_dev \
+  -c "DROP SCHEMA drizzle CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+DATABASE_URL=… pnpm --filter @kinhale/api db:migrate
+```
+
+---
+
+## 6. Cas particuliers et limites
+
+### 6.1. Données perdues lors d'un `DROP COLUMN`
+
+Un `down.sql` qui supprime une colonne **détruit** ses données. Le
+backup RDS reste l'unique recours en prod. En dev, la consigne reste la
+même : le rollback n'est **pas** une opération réversible côté données.
+
+**Mitigation prévue dans la « up »** : pour les colonnes critiques,
+préférer une migration en deux temps :
+1. PR n : ajout de la colonne + double-write applicatif ;
+2. PR n+1 (après stabilisation) : retrait de l'ancienne colonne.
+
+Cela permet un rollback sans perte tant qu'on rollback uniquement la
+PR n+1.
+
+### 6.2. FK en CASCADE
+
+`DROP TABLE … CASCADE` dans un `down.sql` peut supprimer en cascade des
+lignes dans des tables enfants (ex : `push_tokens` quand on rollback
+`devices`). C'est **voulu** pour les tables purement applicatives, mais
+**à vérifier** sur chaque nouveau `down.sql` :
+
+- `0000_*.down.sql` — DROP CASCADE sur les 5 tables initiales.
+- `0004_*.down.sql` — pas de CASCADE direct, mais la FK
+  `audit_events.account_id` repasse en `ON DELETE CASCADE` (au lieu de
+  `SET NULL`). Si des lignes audit ont déjà des `account_id NULL` (cas
+  post-purge effective), l'ALTER `SET NOT NULL` échoue et le rollback
+  est bloqué — il faut alors purger ou restaurer ces lignes manuellement.
+
+### 6.3. Migration de données vs migration de schéma
+
+Drizzle ne génère que des migrations de **schéma**. Une migration qui
+inclurait des `INSERT` / `UPDATE` (backfill) doit être documentée
+inline dans la « up » et **toujours** être réversible — sinon la
+migration sort du périmètre `db:rollback` et nécessite un script
+`docs/runbooks/data-migrations/<NNNN>-rollback.sql` dédié.
+
+À la date de KIN-092, **aucune migration data-only** n'existe ; la
+règle est préventive.
+
+### 6.4. Quand un `down.sql` ne suffit pas
+
+Cas connus où l'opérateur doit **intervenir manuellement** :
+
+| Cas                                                           | Action                                                         |
+| ------------------------------------------------------------- | -------------------------------------------------------------- |
+| Lignes orphelines (`account_id NULL` dans `audit_events`)     | Purge ciblée avant rollback : `DELETE WHERE account_id IS NULL` |
+| Migration appliquée hors-bande (pas via Drizzle)              | Restaurer depuis snapshot RDS                                  |
+| `down.sql` plante en milieu de transaction                    | La transaction roll back automatiquement ; analyser l'erreur, corriger le `down.sql`, redéployer |
+| Plusieurs migrations à rollback en chaîne après partial failure | Exécuter `db:rollback` une fois par migration, dans l'ordre   |
+
+---
+
+## 7. Tests automatisés
+
+`apps/api/src/db/__tests__/rollback.unit.test.ts` :
+
+- Charge le journal réel et vérifie la présence de chaque `down.sql`.
+- Vérifie le découpage et le hash.
+
+`apps/api/src/db/__tests__/rollback.integration.test.ts` (gated par
+`KINHALE_DB_TEST_URL`) :
+
+- Round-trip up → down → up sur l'ensemble des migrations.
+- Idempotence : applique chaque `down.sql` deux fois.
+- Vérifie que le hash applicatif matche celui que Drizzle stocke.
+
+Le job CI `db-rollback-test` (workflow `ci.yml`) provisionne un service
+Postgres 16 et set `KINHALE_DB_TEST_URL=postgres://…@postgres:5432/…`.
+
+---
+
+## 8. Checklist PR migration
+
+Pour chaque PR qui ajoute / modifie une migration :
+
+- [ ] Le `up.sql` a été généré par `pnpm --filter @kinhale/api db:generate`.
+- [ ] Le `down.sql` correspondant est écrit, idempotent, dans l'ordre inverse.
+- [ ] La suite `rollback.unit.test.ts` passe localement.
+- [ ] Le job CI `db-rollback-test` passe (round-trip vert).
+- [ ] Si la migration **détruit ou transforme des données** existantes,
+      la PR contient un paragraphe « impact rollback » dans la description
+      et un lien vers ce runbook.
+- [ ] Si la migration n'est pas réversible automatiquement, une section
+      « Procédure manuelle » est ajoutée dans ce runbook (§6.4).


### PR DESCRIPTION
## Contexte

Couvre la story **E14-S05** (P0). Verrouille un risque opérationnel critique avant déploiement réel : toute migration peut désormais être rollée et ré-appliquée, le rollback est testé en CI, la procédure opérateur est documentée. Ferme l'issue #233 (KIN-080 follow-up).

## Contenu

### down.sql rétroactifs (5 migrations)
Convention \`up.sql\` + \`down.sql\` co-localisés. Down.sql écrits pour :
- **0000_silent_zzzax** — schema initial complet (accounts, devices, sessions, mailbox_messages, push_tokens, invitations, etc.)
- **0001_curly_iron_man** — \`user_notification_preferences\` (KIN-080)
- **0002_quiet_hours** — colonnes accounts (KIN-081)
- **0003_audit_events** — table \`audit_events\` (KIN-083)
- **0004_account_deletion** — \`deleted_accounts\` + colonnes pending_deletion + step_up_tokens (KIN-086) avec garde DO plpgsql pour rollback chaîné cohérent

Toutes idempotentes (\`DROP IF EXISTS\` partout, ALTER protégés par DROP CONSTRAINT IF EXISTS).

### Script rollback
- \`rollback.ts\` — fonctions pures + transactionnelles : \`loadMigrations\`, \`hashUpSql\` (réplique logique Drizzle), \`rollbackMigration\` (BEGIN/ROLLBACK/COMMIT), \`applyMigration\` (symétrique pour test)
- \`rollback-cli.ts\` — CLI \`pnpm --filter @kinhale/api db:rollback\`. Connecte sur \`DATABASE_URL\`, rollback la dernière migration, imprime le tag

### Tests
- **9 tests unitaires** sur fonctions pures
- **3 tests intégration round-trip** (Postgres réel via container) : apply all → rollback all → reapply all + idempotence + sanity check hash Drizzle
- Gated par \`KINHALE_DB_TEST_URL\` (skip silencieux en local sans Postgres)
- **Bloqueur CI** : test échoue si une migration n'a pas son \`down.sql\`
- Job CI dédié \`db-rollback-test\` provisionne le service Postgres 16

### Documentation
- **\`docs/runbooks/database-migrations.md\`** — procédure opérateur prod : drainage trafic, snapshot RDS, rollback CLI, redéploiement, vérif intégrité. Cas particuliers documentés (DROP COLUMN avec données, FK CASCADE)
- **\`CONTRIBUTING.md\`** mis à jour : section "Migrations DB" rappelle l'obligation du down.sql à chaque up.sql

## Mineurs traités dans le commit
- **M3 kz-review** : \`rollback-cli.ts\` enveloppe \`pool.connect()\` dans try/finally pour garantir \`pool.end()\` même si connexion échoue
- **M5 kz-review** : test intégration extrait helper \`applyAll()\` pour ne plus partager d'état entre \`it()\` (anti-couplage temporel)
- **M6 kz-review** : import \`fileURLToPath\` pour cohérence Windows

## Tests
- **API : 321 verts** (+9 unit) + 3 intégration (gated)
- Lint + typecheck + format monorepo verts

## Revues assistées
- **kz-review** — APPROVED. 0 bloquant, 0 majeur, 10 mineurs (3 traités, 7 reportés). Rapport : [\`kz-review-KIN-092.md\`](../.agents/current-run/kz-review-KIN-092.md)
- **kz-securite** — APPROVED, risque global **faible**. 0 critique, 2 warnings non-bloquants (audit trail rollback + garde-fou anti-erreur humaine CLI), 4 info. Pas d'injection SQL, idempotence + transaction wrapping conformes, pas de \`DROP DATABASE\` ni \`TRUNCATE *\` non scopé. Rapport : [\`kz-securite-KIN-092.md\`](../.agents/current-run/kz-securite-KIN-092.md)

## Suivi
Issues à créer : 7 mineurs kz-review + 2 warnings + 4 info kz-securite + ajout du job au branch protection.

Refs: KIN-092
Closes: E14-S05
Closes #233 — KIN-080 follow-up "formaliser down.sql"