### PR TITLE
feat(api,ui): journal d'activité du foyer (90 derniers événements) — KIN-093

### DIFF
--- a/apps/api/src/__tests__/idor/route-scope-table.ts
+++ b/apps/api/src/__tests__/idor/route-scope-table.ts
@@ -54,6 +54,8 @@ export const ROUTE_SCOPE_TABLE: Record<string, RouteScope> = {
   'POST /audit/report-generated': 'self_scoped',
   'POST /audit/report-shared': 'self_scoped',
   'POST /audit/privacy-export': 'self_scoped',
+  // KIN-093 / E9-S09 — lecture du journal d'audit du compte courant.
+  'GET /me/audit-events': 'self_scoped',
 
   // --- Relais WS + catchup (household-scoped) ---------------------------
   // WebSocket upgrade — skippé par le test REST (auth WS dédiée).

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,7 +17,7 @@ import invitationsRoute from './routes/invitations.js';
 import notificationsRoute from './routes/notifications.js';
 import notificationPreferencesRoute from './routes/notification-preferences.js';
 import quietHoursRoute from './routes/quiet-hours.js';
-import auditRoute from './routes/audit.js';
+import auditRoute, { auditEventsListRoute } from './routes/audit.js';
 import privacyRoute from './routes/privacy.js';
 import accountDeletionRoute from './routes/account-deletion.js';
 
@@ -88,6 +88,9 @@ export function buildApp(env: Env, overrides: BuildAppOverrides = {}): FastifyIn
   void app.register(notificationPreferencesRoute);
   void app.register(quietHoursRoute);
   void app.register(auditRoute, { prefix: '/audit' });
+  // KIN-093 / E9-S09 — endpoint `GET /me/audit-events` enregistré sans
+  // préfixe (pattern privacy/notification-preferences/quiet-hours).
+  void app.register(auditEventsListRoute);
   void app.register(privacyRoute);
   void app.register(accountDeletionRoute);
 

--- a/apps/api/src/routes/__tests__/audit.test.ts
+++ b/apps/api/src/routes/__tests__/audit.test.ts
@@ -614,3 +614,397 @@ describe('POST /audit/privacy-export', () => {
     await app.close();
   });
 });
+
+/**
+ * Tests de la route `GET /me/audit-events` (KIN-093, E9-S09).
+ *
+ * Vérifie :
+ * - rejet 401 sans JWT,
+ * - filtrage strict par `account_id = sub` (pas d'IDOR cross-tenant),
+ * - tri antéchronologique + limite par défaut 90,
+ * - pagination via `?limit=` (1..90 borné),
+ * - filtrage `event_data` whitelist (anti-fuite),
+ * - rate-limit 60/h/device,
+ * - aucune fuite de champ inattendu (les champs hors whitelist sont écartés),
+ * - couverture de tous les types d'événements documentés.
+ */
+describe('GET /me/audit-events (KIN-093 / E9-S09)', () => {
+  /**
+   * Mock DB pour la lecture audit. Capture le `accountId` passé au filtre
+   * `eq(auditEvents.accountId, X)` via une closure et expose les rows
+   * fixtures à retourner.
+   */
+  function makeMockSelectDb(rows: Array<Record<string, unknown>>) {
+    // Capture le filtre WHERE pour vérifier qu'il porte bien sur le `sub`
+    // du JWT et pas sur une valeur forgée. Drizzle expose un objet
+    // circulaire — on capture juste le drapeau qu'un appel a eu lieu et
+    // on garde une trace de la dernière `accountId` filtrée via une mutation
+    // partagée (le mock se contente de retourner les rows fournis).
+    let lastLimit: number | undefined = undefined;
+    const select = vi.fn().mockImplementation((_projection: Record<string, unknown>) => {
+      const fromObj = {
+        where: (_whereClause: unknown) => {
+          const orderObj = {
+            limit: (n: number) => {
+              lastLimit = n;
+              return Promise.resolve(rows);
+            },
+          };
+          return {
+            orderBy: (_o: unknown) => orderObj,
+          };
+        },
+      };
+      return { from: (_table: unknown) => fromObj };
+    });
+
+    const insertValues = vi.fn().mockResolvedValue(undefined);
+    const insert = vi.fn().mockReturnValue({ values: insertValues });
+
+    return {
+      select,
+      insert,
+      get _lastLimit() {
+        return lastLimit;
+      },
+    } as unknown as DrizzleDb & { _lastLimit: number | undefined };
+  }
+
+  function buildAppWithRows(rows: Array<Record<string, unknown>>) {
+    const db = makeMockSelectDb(rows);
+    const app = buildApp(testEnv(), { db, redis: makeMockRedis() });
+    return { db, app };
+  }
+
+  const NOW = 1_700_500_000_000;
+
+  it('retourne 401 sans JWT', async () => {
+    const { app } = buildAppWithRows([]);
+    await app.ready();
+    const res = await app.inject({ method: 'GET', url: '/me/audit-events' });
+    expect(res.statusCode).toBe(401);
+    await app.close();
+  });
+
+  it('retourne 200 et un tableau vide si aucun événement', async () => {
+    const { app } = buildAppWithRows([]);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/audit-events',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Record<string, unknown>;
+    expect(body['events']).toEqual([]);
+    await app.close();
+  });
+
+  it('retourne les événements avec uniquement les champs whitelistés (anti-fuite)', async () => {
+    const fixtureRows = [
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        eventType: 'report_generated',
+        eventData: {
+          reportHash: 'a'.repeat(64),
+          rangeStartMs: NOW - 1000,
+          rangeEndMs: NOW,
+          generatedAtMs: NOW,
+          // Champ inattendu — DOIT être filtré côté lecture (deuxième barrière).
+          childName: 'Léa',
+        },
+        createdAt: new Date(NOW),
+      },
+    ];
+    const { app } = buildAppWithRows(fixtureRows);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/audit-events',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { events: Array<Record<string, unknown>> };
+    expect(body.events).toHaveLength(1);
+    const event = body.events[0]!;
+    expect(event['eventType']).toBe('report_generated');
+    expect(event['eventData']).toEqual({
+      reportHash: 'a'.repeat(64),
+      rangeStartMs: NOW - 1000,
+      rangeEndMs: NOW,
+      generatedAtMs: NOW,
+    });
+    // Le champ exfiltrant doit être absent de la réponse.
+    expect(JSON.stringify(event)).not.toContain('Léa');
+    expect(JSON.stringify(event)).not.toContain('childName');
+    await app.close();
+  });
+
+  it("ne renvoie JAMAIS l'accountId dans la réponse (anti-IDOR)", async () => {
+    const fixtureRows = [
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        eventType: 'privacy_export',
+        eventData: { archiveHash: 'b'.repeat(64), generatedAtMs: NOW },
+        createdAt: new Date(NOW),
+      },
+    ];
+    const { app } = buildAppWithRows(fixtureRows);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/audit-events',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    const text = res.body;
+    expect(text).not.toContain(ACCOUNT_ID);
+    expect(text).not.toContain('accountId');
+    await app.close();
+  });
+
+  it("couvre tous les types d'événement documentés (KIN-083 → KIN-086)", async () => {
+    const fixtureRows = [
+      {
+        id: '00000000-0000-0000-0000-000000000001',
+        eventType: 'report_generated',
+        eventData: {
+          reportHash: 'a'.repeat(64),
+          rangeStartMs: NOW - 1000,
+          rangeEndMs: NOW,
+          generatedAtMs: NOW,
+        },
+        createdAt: new Date(NOW),
+      },
+      {
+        id: '00000000-0000-0000-0000-000000000002',
+        eventType: 'report_shared',
+        eventData: { reportHash: 'a'.repeat(64), shareMethod: 'download', sharedAtMs: NOW },
+        createdAt: new Date(NOW + 1),
+      },
+      {
+        id: '00000000-0000-0000-0000-000000000003',
+        eventType: 'privacy_export',
+        eventData: { archiveHash: 'b'.repeat(64), generatedAtMs: NOW },
+        createdAt: new Date(NOW + 2),
+      },
+      {
+        id: '00000000-0000-0000-0000-000000000004',
+        eventType: 'account_deletion_requested',
+        eventData: { scheduledAtMs: NOW + 7 * 24 * 3600 * 1000, requestedAtMs: NOW },
+        createdAt: new Date(NOW + 3),
+      },
+      {
+        id: '00000000-0000-0000-0000-000000000005',
+        eventType: 'account_deletion_cancelled',
+        eventData: { cancelledAtMs: NOW + 60_000 },
+        createdAt: new Date(NOW + 4),
+      },
+      {
+        id: '00000000-0000-0000-0000-000000000006',
+        eventType: 'account_deleted',
+        eventData: { pseudoId: 'c'.repeat(64), deletedAtMs: NOW + 7 * 24 * 3600 * 1000 },
+        createdAt: new Date(NOW + 5),
+      },
+    ];
+    const { app } = buildAppWithRows(fixtureRows);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/audit-events',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { events: Array<Record<string, unknown>> };
+    expect(body.events).toHaveLength(6);
+    const types = body.events.map((e) => e['eventType']);
+    expect(types).toEqual([
+      'report_generated',
+      'report_shared',
+      'privacy_export',
+      'account_deletion_requested',
+      'account_deletion_cancelled',
+      'account_deleted',
+    ]);
+    // Chaque événement doit conserver ses champs whitelistés.
+    expect(body.events[0]!['eventData']).toMatchObject({ reportHash: 'a'.repeat(64) });
+    expect(body.events[1]!['eventData']).toMatchObject({ shareMethod: 'download' });
+    expect(body.events[2]!['eventData']).toMatchObject({ archiveHash: 'b'.repeat(64) });
+    expect(body.events[3]!['eventData']).toMatchObject({ requestedAtMs: NOW });
+    expect(body.events[4]!['eventData']).toMatchObject({ cancelledAtMs: NOW + 60_000 });
+    expect(body.events[5]!['eventData']).toMatchObject({ pseudoId: 'c'.repeat(64) });
+    await app.close();
+  });
+
+  it('renvoie {} (event_data vide) pour un type inconnu (fail-closed)', async () => {
+    const fixtureRows = [
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        eventType: 'unknown_future_type',
+        eventData: { secretField: 'should-not-leak', anotherSecret: 42 },
+        createdAt: new Date(NOW),
+      },
+    ];
+    const { app } = buildAppWithRows(fixtureRows);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/audit-events',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { events: Array<Record<string, unknown>> };
+    expect(body.events[0]!['eventData']).toEqual({});
+    expect(res.body).not.toContain('should-not-leak');
+    expect(res.body).not.toContain('secretField');
+    await app.close();
+  });
+
+  it('utilise par défaut limit=90 (cf. AUDIT_LIST_DEFAULT_LIMIT)', async () => {
+    const { db, app } = buildAppWithRows([]);
+    await app.ready();
+    await app.inject({
+      method: 'GET',
+      url: '/me/audit-events',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    expect(db._lastLimit).toBe(90);
+    await app.close();
+  });
+
+  it('accepte ?limit=10 (1..90 borné)', async () => {
+    const { db, app } = buildAppWithRows([]);
+    await app.ready();
+    await app.inject({
+      method: 'GET',
+      url: '/me/audit-events?limit=10',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    expect(db._lastLimit).toBe(10);
+    await app.close();
+  });
+
+  it('rejette ?limit=0 ou ?limit>90 ou non numérique', async () => {
+    const { app } = buildAppWithRows([]);
+    await app.ready();
+    const token = signAccess(app);
+    const res0 = await app.inject({
+      method: 'GET',
+      url: '/me/audit-events?limit=0',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res0.statusCode).toBe(400);
+    const resTooBig = await app.inject({
+      method: 'GET',
+      url: '/me/audit-events?limit=91',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(resTooBig.statusCode).toBe(400);
+    const resNonInt = await app.inject({
+      method: 'GET',
+      url: '/me/audit-events?limit=abc',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(resNonInt.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('rejette un querystring contenant un champ inconnu (.strict() anti-fuite)', async () => {
+    const { app } = buildAppWithRows([]);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/audit-events?limit=10&accountId=other',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    // .strict() fait échouer le parse — le filtre WHERE ne sera donc jamais
+    // construit avec la valeur du query, c'est la défense en profondeur attendue.
+    expect(res.statusCode).toBe(400);
+    await app.close();
+  });
+
+  it('applique un rate-limit (429 après 60/h par device)', async () => {
+    const { app } = buildAppWithRows([]);
+    await app.ready();
+    const token = signAccess(app);
+    let lastStatus = 0;
+    for (let i = 0; i < 61; i++) {
+      const res = await app.inject({
+        method: 'GET',
+        url: '/me/audit-events',
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      lastStatus = res.statusCode;
+    }
+    expect(lastStatus).toBe(429);
+    await app.close();
+  });
+
+  it('retourne createdAtMs en epoch ms (pas en Date sérialisée)', async () => {
+    const fixtureRows = [
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        eventType: 'privacy_export',
+        eventData: { archiveHash: 'a'.repeat(64), generatedAtMs: NOW },
+        createdAt: new Date(NOW),
+      },
+    ];
+    const { app } = buildAppWithRows(fixtureRows);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/audit-events',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    const body = res.json() as { events: Array<Record<string, unknown>> };
+    expect(body.events[0]!['createdAtMs']).toBe(NOW);
+    expect(typeof body.events[0]!['createdAtMs']).toBe('number');
+    await app.close();
+  });
+
+  it('aucune fuite de motif santé dans la réponse (sentinelle anti-régression)', async () => {
+    // Si un futur dev faisait un JOIN accidentel ou élargissait la projection,
+    // ce test attraperait la fuite.
+    const fixtureRows = [
+      {
+        id: '11111111-1111-1111-1111-111111111111',
+        eventType: 'report_generated',
+        eventData: {
+          reportHash: 'a'.repeat(64),
+          rangeStartMs: NOW - 1000,
+          rangeEndMs: NOW,
+          generatedAtMs: NOW,
+          // Champs interdits qui pourraient venir d'une régression —
+          // doivent être éliminés par la whitelist.
+          firstName: 'Léa',
+          birthYear: 2020,
+          pumpName: 'Ventolin',
+          symptomCode: 'wheezing',
+          freeFormTag: 'après sport',
+        },
+        createdAt: new Date(NOW),
+      },
+    ];
+    const { app } = buildAppWithRows(fixtureRows);
+    await app.ready();
+    const res = await app.inject({
+      method: 'GET',
+      url: '/me/audit-events',
+      headers: { Authorization: `Bearer ${signAccess(app)}` },
+    });
+    const text = res.body;
+    const forbidden = [
+      'Léa',
+      'firstName',
+      'birthYear',
+      'Ventolin',
+      'pumpName',
+      'wheezing',
+      'freeFormTag',
+      'après sport',
+    ];
+    for (const w of forbidden) {
+      expect(text).not.toContain(w);
+    }
+    await app.close();
+  });
+});

--- a/apps/api/src/routes/audit.ts
+++ b/apps/api/src/routes/audit.ts
@@ -1,5 +1,6 @@
 import type { FastifyPluginAsync } from 'fastify';
 import { z } from 'zod';
+import { eq, desc } from 'drizzle-orm';
 import { auditEvents } from '../db/schema.js';
 import type { SessionJwtPayload } from '../plugins/jwt.js';
 
@@ -39,10 +40,32 @@ const AUDIT_REPORT_SHARED_WINDOW_SECONDS = 3600;
 const AUDIT_PRIVACY_EXPORT_MAX_PER_HOUR = 5;
 const AUDIT_PRIVACY_EXPORT_WINDOW_SECONDS = 3600;
 
+/**
+ * Quota de lecture du journal d'audit (KIN-093, E9-S09).
+ *
+ * 60/h/device — cohérent avec les autres routes self-scoped authentifiées
+ * (notification-preferences, quiet-hours). La lecture est rare (l'écran est
+ * consulté ponctuellement), un quota plus haut ouvrirait une fenêtre
+ * d'exfiltration répétée pour un device compromis.
+ */
+const AUDIT_LIST_MAX_PER_HOUR = 60;
+const AUDIT_LIST_WINDOW_SECONDS = 3600;
+
+/**
+ * Borne supérieure du nombre d'événements retournés par `GET /me/audit-events`.
+ *
+ * 90 derniers événements (cf. E9-S09 — « 90 derniers évts »). Suffisant pour
+ * couvrir plusieurs mois d'activité d'un foyer normal sans exposer un trail
+ * volumineux d'un coup.
+ */
+const AUDIT_LIST_DEFAULT_LIMIT = 90;
+const AUDIT_LIST_MAX_LIMIT = 90;
+
 const rateLimitKey = (deviceId: string): string => `rl:audit-report-generated:${deviceId}`;
 const rateLimitSharedKey = (deviceId: string): string => `rl:audit-report-shared:${deviceId}`;
 const rateLimitPrivacyExportKey = (deviceId: string): string =>
   `rl:audit-privacy-export:${deviceId}`;
+const rateLimitListKey = (deviceId: string): string => `rl:audit-list:${deviceId}`;
 
 /**
  * Borne supérieure de timestamp acceptée (année 3000). Protège contre des
@@ -147,6 +170,106 @@ const PrivacyExportBody = z
   .strict();
 
 type PrivacyExportData = z.infer<typeof PrivacyExportBody>;
+
+/**
+ * Schéma Zod du querystring `GET /me/audit-events` (KIN-093, E9-S09).
+ *
+ * Pagination v1 minimaliste : un simple `limit` borné par
+ * {@link AUDIT_LIST_MAX_LIMIT}. La spec parle de pagination cursor-based
+ * « optionnelle pour le futur » — en v1.0 on retourne juste les N plus
+ * récents, ordre antéchronologique. Si > 90 events s'avèrent nécessaires
+ * un jour, ajouter un curseur `before` (timestamp d'un event observé) sans
+ * changer le format actuel.
+ */
+const ListEventsQuery = z
+  .object({
+    limit: z.coerce
+      .number()
+      .int()
+      .min(1)
+      .max(AUDIT_LIST_MAX_LIMIT)
+      .default(AUDIT_LIST_DEFAULT_LIMIT),
+  })
+  .strict();
+
+/**
+ * Whitelists **explicites** des champs `event_data` retournés au client par
+ * type d'événement (KIN-093, défense en profondeur anti-fuite).
+ *
+ * Motivation : la table `audit_events` accepte n'importe quel JSONB. Les
+ * routes d'écriture (`POST /audit/*`) protègent à l'entrée via Zod `.strict()`,
+ * mais un dev pourrait :
+ * - écrire un nouvel événement sans schéma strict côté insert,
+ * - faire un JOIN par accident qui ramènerait une colonne d'une autre table,
+ * - patcher une ligne existante avec des champs supplémentaires.
+ *
+ * La sortie est donc filtrée par une **deuxième barrière** : seul les champs
+ * documentés ici remontent au client. Tout champ inconnu est silencieusement
+ * écarté (pas d'erreur — l'API reste tolérante aux données legacy).
+ *
+ * Aligné sur les schémas Zod d'écriture déclarés plus haut. Si un nouveau
+ * type est introduit, il faut y ajouter son entrée ; sinon ses event_data
+ * sortiront vides (`{}`), ce qui est le comportement le plus sûr par défaut.
+ *
+ * **Aucune donnée santé** ici par construction — uniquement hashes opaques
+ * et timestamps.
+ */
+type AuditEventDataPlain = Readonly<Record<string, unknown>>;
+
+const AUDIT_EVENT_DATA_WHITELIST: Readonly<Record<string, ReadonlyArray<string>>> = {
+  report_generated: ['reportHash', 'rangeStartMs', 'rangeEndMs', 'generatedAtMs'],
+  report_shared: ['reportHash', 'shareMethod', 'sharedAtMs'],
+  privacy_export: ['archiveHash', 'generatedAtMs'],
+  // E9-S03 / KIN-086 — payloads écrits par account-deletion.ts.
+  account_deletion_requested: ['scheduledAtMs', 'requestedAtMs'],
+  account_deletion_cancelled: ['cancelledAtMs'],
+  // Worker `account-purge` — l'événement est inséré avec `account_id = NULL`
+  // (FK ON DELETE SET NULL) et un `pseudoId` pour corrélation post-purge.
+  // Ce type ne devrait jamais apparaître dans `GET /me/audit-events` (le
+  // compte est purgé), mais on déclare la whitelist par sécurité.
+  account_deleted: ['pseudoId', 'deletedAtMs'],
+};
+
+/**
+ * Filtre une valeur `event_data` brute en ne gardant que les clés autorisées
+ * pour le type donné. Tout type inconnu retourne `{}` (fail-closed).
+ */
+function pickWhitelistedEventData(eventType: string, raw: unknown): AuditEventDataPlain {
+  const allowed = AUDIT_EVENT_DATA_WHITELIST[eventType];
+  if (allowed === undefined) {
+    return {};
+  }
+  if (raw === null || typeof raw !== 'object') {
+    return {};
+  }
+  const out: Record<string, unknown> = {};
+  const obj = raw as Record<string, unknown>;
+  for (const key of allowed) {
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      out[key] = obj[key];
+    }
+  }
+  return out;
+}
+
+/**
+ * Format de réponse `GET /me/audit-events`.
+ *
+ * **Aucune fuite de scope** : `accountId` est *volontairement* absent —
+ * le client connaît son propre `sub` via le JWT, pas besoin de lui répéter,
+ * et son absence évite qu'un futur dev introduise une régression IDOR
+ * (l'attaquant n'a aucun champ à comparer pour deviner un id étranger).
+ */
+interface AuditEventListItem {
+  readonly id: string;
+  readonly eventType: string;
+  readonly eventData: AuditEventDataPlain;
+  readonly createdAtMs: number;
+}
+
+interface AuditEventListResponse {
+  readonly events: ReadonlyArray<AuditEventListItem>;
+}
 
 const auditRoute: FastifyPluginAsync = async (app) => {
   /**
@@ -303,4 +426,85 @@ const auditRoute: FastifyPluginAsync = async (app) => {
   });
 };
 
+/**
+ * Plugin séparé pour `GET /me/audit-events` (KIN-093, E9-S09).
+ *
+ * Hébergé dans le même fichier que `auditRoute` pour cohérence du module
+ * audit, mais enregistré **sans préfixe** côté `app.ts` afin d'exposer la
+ * route à `/me/audit-events` (pattern aligné sur `notification-preferences`,
+ * `quiet-hours`, `privacy`).
+ *
+ * **Sécurité (KIN-093)** :
+ * - Authentification JWT obligatoire (`preHandler: [app.authenticate]`).
+ * - Filtre `WHERE account_id = sub` strict — aucune fuite cross-tenant
+ *   possible (un JWT du compte B ne récupère JAMAIS les events de A).
+ * - Rate-limit Redis 60/h/device (cohérent self-scoped).
+ * - Réponse strictement scopée à la table `audit_events` — aucun JOIN.
+ * - `event_data` est filtré par `pickWhitelistedEventData` : seuls les
+ *   champs documentés par type sont remontés au client. Tout champ
+ *   inattendu est écarté silencieusement (fail-closed).
+ * - L'`accountId` n'apparaît PAS dans la réponse (le client le connaît
+ *   déjà via le JWT — réémettre ne fait que créer une cible IDOR).
+ *
+ * Refs: KIN-093, E9-S09, RM11.
+ */
+const auditEventsListRoute: FastifyPluginAsync = async (app) => {
+  app.get<{ Querystring: z.infer<typeof ListEventsQuery> }>(
+    '/me/audit-events',
+    { preHandler: [app.authenticate] },
+    async (request, reply) => {
+      const parsedQuery = ListEventsQuery.safeParse(request.query);
+      if (!parsedQuery.success) {
+        return reply.status(400).send({ error: 'invalid_query' });
+      }
+      const { limit } = parsedQuery.data;
+
+      const { sub: accountId, deviceId } = request.user as SessionJwtPayload;
+
+      // Rate-limit Redis (pattern identique à audit.ts / privacy.ts).
+      const key = rateLimitListKey(deviceId);
+      const count = await app.redis.pub.incr(key);
+      if (count === 1) {
+        await app.redis.pub.expire(key, AUDIT_LIST_WINDOW_SECONDS);
+      }
+      if (count > AUDIT_LIST_MAX_PER_HOUR) {
+        app.log.warn(
+          { event: 'audit.list.rate_limited', deviceId },
+          'Rate-limit atteint sur GET /me/audit-events',
+        );
+        return reply.status(429).send({ error: 'rate_limited' });
+      }
+
+      // Filtrage strict par `account_id = sub`. La projection ne sélectionne
+      // QUE les colonnes d'`audit_events` — aucun JOIN possible avec une
+      // autre table (cf. anti-fuite KIN-093). Si on ajoute un jour des FK
+      // à exposer (ex. invite émetteur), il faudra étendre la whitelist
+      // explicitement et mettre à jour les tests anti-fuite.
+      const rows = await app.db
+        .select({
+          id: auditEvents.id,
+          eventType: auditEvents.eventType,
+          eventData: auditEvents.eventData,
+          createdAt: auditEvents.createdAt,
+        })
+        .from(auditEvents)
+        .where(eq(auditEvents.accountId, accountId))
+        .orderBy(desc(auditEvents.createdAt))
+        .limit(limit);
+
+      const response: AuditEventListResponse = {
+        events: rows.map((r) => ({
+          id: r.id,
+          eventType: r.eventType,
+          eventData: pickWhitelistedEventData(r.eventType, r.eventData),
+          createdAtMs: r.createdAt.getTime(),
+        })),
+      };
+
+      return reply.status(200).send(response);
+    },
+  );
+};
+
+export { auditEventsListRoute };
 export default auditRoute;

--- a/apps/mobile/app/settings/__tests__/activity.test.tsx
+++ b/apps/mobile/app/settings/__tests__/activity.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react-native';
+import SettingsActivityScreen from '../activity';
+import { renderWithProviders } from '../../../src/test-utils/render';
+import { listMyAuditEvents } from '../../../src/lib/audit-events/client';
+
+jest.mock('../../../src/lib/audit-events/client', () => ({
+  listMyAuditEvents: jest.fn(),
+}));
+
+const mockList = listMyAuditEvents as jest.MockedFunction<typeof listMyAuditEvents>;
+
+const SAMPLE_EVENTS = [
+  {
+    id: '11111111-1111-1111-1111-111111111111',
+    eventType: 'report_generated',
+    eventData: {
+      reportHash: 'a'.repeat(64),
+      rangeStartMs: 1_700_000_000_000,
+      rangeEndMs: 1_700_500_000_000,
+      generatedAtMs: 1_700_500_000_000,
+    },
+    createdAtMs: 1_700_500_000_000,
+  },
+  {
+    id: '22222222-2222-2222-2222-222222222222',
+    eventType: 'privacy_export',
+    eventData: { archiveHash: 'b'.repeat(64), generatedAtMs: 1_700_510_000_000 },
+    createdAtMs: 1_700_510_000_000,
+  },
+  {
+    id: '33333333-3333-3333-3333-333333333333',
+    eventType: 'unknown_future_type',
+    eventData: {},
+    createdAtMs: 1_700_520_000_000,
+  },
+];
+
+describe('SettingsActivityScreen (mobile, KIN-093)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockList.mockResolvedValue(SAMPLE_EVENTS);
+  });
+
+  it('affiche le titre et le sous-titre i18n', async () => {
+    renderWithProviders(<SettingsActivityScreen />);
+    await waitFor(() => {
+      expect(screen.getByRole('header')).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/activité du foyer|household activity/i)).toBeTruthy();
+    });
+  });
+
+  it('charge la liste et affiche les libellés traduits', async () => {
+    renderWithProviders(<SettingsActivityScreen />);
+    await waitFor(() => {
+      expect(mockList).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/rapport médecin généré|medical report generated/i)).toBeTruthy();
+    });
+    expect(
+      screen.getByText(/export de portabilité téléchargé|portability export downloaded/i),
+    ).toBeTruthy();
+  });
+
+  it('affiche un libellé fallback pour un type inconnu (forward-compat)', async () => {
+    renderWithProviders(<SettingsActivityScreen />);
+    await waitFor(() => {
+      expect(screen.getByText(/autre événement|other event/i)).toBeTruthy();
+    });
+  });
+
+  it("affiche l'état vide quand aucun événement n'est retourné", async () => {
+    mockList.mockResolvedValue([]);
+    renderWithProviders(<SettingsActivityScreen />);
+    await waitFor(() => {
+      expect(screen.getByText(/aucune activité|no activity recorded/i)).toBeTruthy();
+    });
+  });
+
+  it('affiche un message i18n quand le chargement échoue', async () => {
+    mockList.mockRejectedValue(new Error('Network down'));
+    renderWithProviders(<SettingsActivityScreen />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/impossible de charger l'historique|could not load activity/i),
+      ).toBeTruthy();
+    });
+  });
+
+  it('aucune fuite santé dans le rendu (zero-knowledge)', async () => {
+    renderWithProviders(<SettingsActivityScreen />);
+    await waitFor(() => {
+      expect(mockList).toHaveBeenCalled();
+    });
+    const forbidden = ['Léa', 'Ventolin', 'wheezing', 'freeFormTag', 'firstName'];
+    for (const w of forbidden) {
+      expect(screen.queryByText(new RegExp(w, 'i'))).toBeNull();
+    }
+  });
+});

--- a/apps/mobile/app/settings/activity.tsx
+++ b/apps/mobile/app/settings/activity.tsx
@@ -1,0 +1,114 @@
+import React, { type JSX } from 'react';
+import { useTranslation } from 'react-i18next';
+import { YStack, XStack, H1, H2, Text, Card } from 'tamagui';
+import { listMyAuditEvents, type AuditEventListItem } from '../../src/lib/audit-events/client';
+
+/**
+ * Écran « Paramètres → Activité du foyer » mobile — KIN-093, E9-S09.
+ *
+ * Symétrique de `apps/web/src/app/settings/activity/page.tsx` :
+ * - liste les 90 derniers événements d'audit du compte courant,
+ * - aucune donnée santé (zero-knowledge),
+ * - libellés i18n FR/EN, formatage date/heure selon locale.
+ *
+ * Refs: KIN-093, E9-S09, RM11.
+ */
+
+const KNOWN_EVENT_TYPES = new Set([
+  'report_generated',
+  'report_shared',
+  'privacy_export',
+  'account_deletion_requested',
+  'account_deletion_cancelled',
+  'account_deleted',
+]);
+
+function formatDateTime(ms: number, locale: 'fr' | 'en'): string {
+  const formatter = new Intl.DateTimeFormat(locale === 'fr' ? 'fr-CA' : 'en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  return formatter.format(new Date(ms));
+}
+
+export default function SettingsActivityScreen(): JSX.Element {
+  const { t, i18n } = useTranslation('common');
+  const [events, setEvents] = React.useState<ReadonlyArray<AuditEventListItem>>([]);
+  const [loading, setLoading] = React.useState<boolean>(true);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    const refresh = async (): Promise<void> => {
+      try {
+        const data = await listMyAuditEvents();
+        if (!cancelled) {
+          setEvents(data);
+          setError(null);
+        }
+      } catch {
+        if (!cancelled) {
+          setError(t('audit.page.loadError'));
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+    void refresh();
+    return (): void => {
+      cancelled = true;
+    };
+  }, [t]);
+
+  const locale: 'fr' | 'en' = i18n.language?.toLowerCase().startsWith('en') ? 'en' : 'fr';
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1 accessibilityRole="header">{t('audit.page.title')}</H1>
+      <Text fontSize="$3" color="$color11">
+        {t('audit.page.subtitle')}
+      </Text>
+
+      {loading ? <Text accessibilityLiveRegion="polite">{t('common.loading')}</Text> : null}
+
+      {error !== null ? (
+        <Text color="$red10" accessibilityLiveRegion="polite">
+          {error}
+        </Text>
+      ) : null}
+
+      {!loading && error === null && events.length === 0 ? (
+        <Card padded bordered>
+          <Text>{t('audit.page.empty')}</Text>
+        </Card>
+      ) : null}
+
+      {events.length > 0 ? (
+        <YStack gap="$2">
+          <H2>{t('audit.page.listHeading')}</H2>
+          {events.map((event) => (
+            <Card key={event.id} padded bordered>
+              <XStack justifyContent="space-between" alignItems="center" gap="$3" flexWrap="wrap">
+                <YStack flex={1} gap="$1">
+                  <Text fontWeight="600">
+                    {KNOWN_EVENT_TYPES.has(event.eventType)
+                      ? t(`audit.event.${event.eventType}`)
+                      : t('audit.event.other')}
+                  </Text>
+                  <Text fontSize="$2" color="$color11">
+                    {formatDateTime(event.createdAtMs, locale)}
+                  </Text>
+                </YStack>
+              </XStack>
+            </Card>
+          ))}
+        </YStack>
+      ) : null}
+    </YStack>
+  );
+}

--- a/apps/mobile/src/lib/audit-events/client.ts
+++ b/apps/mobile/src/lib/audit-events/client.ts
@@ -1,0 +1,53 @@
+/**
+ * Client mobile `GET /me/audit-events` (KIN-093, E9-S09).
+ *
+ * Symétrique de `apps/web/src/lib/audit-events/client.ts` — l'app mobile
+ * utilise le même contrat HTTP. Le store auth mobile fournit le JWT.
+ *
+ * Refs: KIN-093, E9-S09, RM11.
+ */
+
+import { ApiError } from '../api-client';
+import { useAuthStore } from '../../stores/auth-store';
+
+const API_BASE = process.env['EXPO_PUBLIC_API_URL'] ?? 'http://localhost:3001';
+
+export type AuditEventType =
+  | 'report_generated'
+  | 'report_shared'
+  | 'privacy_export'
+  | 'account_deletion_requested'
+  | 'account_deletion_cancelled'
+  | 'account_deleted';
+
+export interface AuditEventListItem {
+  readonly id: string;
+  readonly eventType: string;
+  readonly eventData: Readonly<Record<string, unknown>>;
+  readonly createdAtMs: number;
+}
+
+interface AuditEventListResponse {
+  readonly events: ReadonlyArray<AuditEventListItem>;
+}
+
+export async function listMyAuditEvents(): Promise<ReadonlyArray<AuditEventListItem>> {
+  const token = useAuthStore.getState().accessToken;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token !== null) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`${API_BASE}/me/audit-events`, {
+    method: 'GET',
+    headers,
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    throw new ApiError(
+      res.status,
+      typeof body['error'] === 'string' ? body['error'] : 'list_failed',
+    );
+  }
+  const data = (await res.json()) as AuditEventListResponse;
+  return data.events;
+}

--- a/apps/web/src/app/settings/activity/__tests__/page.test.tsx
+++ b/apps/web/src/app/settings/activity/__tests__/page.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { screen, waitFor } from '@testing-library/react';
+import SettingsActivityPage from '../page';
+import { renderWithProviders } from '../../../../test-utils/render';
+
+const mockReplace = jest.fn();
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+}));
+
+let mockAccessToken: string | null = 'tok-valid';
+jest.mock('../../../../stores/auth-store', () => ({
+  useAuthStore: Object.assign(
+    jest.fn((selector: (s: { accessToken: string | null }) => unknown) =>
+      selector({ accessToken: mockAccessToken }),
+    ),
+    {
+      getState: () => ({ accessToken: mockAccessToken }),
+    },
+  ),
+}));
+
+const mockListEvents = jest.fn();
+jest.mock('../../../../lib/audit-events/client', () => ({
+  listMyAuditEvents: (...args: unknown[]) => mockListEvents(...args),
+}));
+
+const SAMPLE_EVENTS = [
+  {
+    id: '11111111-1111-1111-1111-111111111111',
+    eventType: 'report_generated',
+    eventData: {
+      reportHash: 'a'.repeat(64),
+      rangeStartMs: 1_700_000_000_000,
+      rangeEndMs: 1_700_500_000_000,
+      generatedAtMs: 1_700_500_000_000,
+    },
+    createdAtMs: 1_700_500_000_000,
+  },
+  {
+    id: '22222222-2222-2222-2222-222222222222',
+    eventType: 'privacy_export',
+    eventData: { archiveHash: 'b'.repeat(64), generatedAtMs: 1_700_510_000_000 },
+    createdAtMs: 1_700_510_000_000,
+  },
+  {
+    id: '33333333-3333-3333-3333-333333333333',
+    eventType: 'unknown_future_type',
+    eventData: {},
+    createdAtMs: 1_700_520_000_000,
+  },
+];
+
+describe('SettingsActivityPage (web, KIN-093)', () => {
+  jest.setTimeout(15000);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAccessToken = 'tok-valid';
+    mockListEvents.mockResolvedValue(SAMPLE_EVENTS);
+  });
+
+  it('affiche le titre et le sous-titre i18n FR', async () => {
+    renderWithProviders(<SettingsActivityPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/activité du foyer|household activity/i)).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/90 derniers événements|90 most recent events/i)).toBeTruthy();
+    });
+  });
+
+  it('redirige vers /auth sans token', async () => {
+    mockAccessToken = null;
+    renderWithProviders(<SettingsActivityPage />);
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/auth');
+    });
+  });
+
+  it('affiche les libellés i18n traduits pour chaque type connu', async () => {
+    renderWithProviders(<SettingsActivityPage />);
+    await waitFor(() => {
+      expect(mockListEvents).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(screen.getByText(/rapport médecin généré|medical report generated/i)).toBeTruthy();
+    });
+    expect(
+      screen.getByText(/export de portabilité téléchargé|portability export downloaded/i),
+    ).toBeTruthy();
+  });
+
+  it('affiche un libellé fallback pour un type inconnu (forward-compat)', async () => {
+    renderWithProviders(<SettingsActivityPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/autre événement|other event/i)).toBeTruthy();
+    });
+  });
+
+  it('ne fait JAMAIS apparaître de mot santé (anti-régression zero-knowledge)', async () => {
+    renderWithProviders(<SettingsActivityPage />);
+    await waitFor(() => {
+      expect(mockListEvents).toHaveBeenCalled();
+    });
+    // L'UI ne rend que le label i18n + la date. Si quelqu'un un jour
+    // décidait d'afficher un champ exotique, ce test attraperait la
+    // régression.
+    const forbidden = ['Léa', 'Ventolin', 'wheezing', 'freeFormTag', 'firstName'];
+    for (const w of forbidden) {
+      expect(screen.queryByText(new RegExp(w, 'i'))).toBeNull();
+    }
+  });
+
+  it("affiche l'état vide quand aucun événement n'est retourné", async () => {
+    mockListEvents.mockResolvedValue([]);
+    renderWithProviders(<SettingsActivityPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/aucune activité|no activity recorded/i)).toBeTruthy();
+    });
+  });
+
+  it('affiche un message i18n quand le chargement échoue', async () => {
+    mockListEvents.mockRejectedValue(new Error('Network down'));
+    renderWithProviders(<SettingsActivityPage />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/impossible de charger l'historique|could not load activity/i),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/src/app/settings/activity/page.tsx
+++ b/apps/web/src/app/settings/activity/page.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { YStack, XStack, H1, H2, Text, Card } from 'tamagui';
+import { listMyAuditEvents, type AuditEventListItem } from '../../../lib/audit-events/client';
+import { useRequireAuth } from '../../../lib/useRequireAuth';
+
+/**
+ * Écran « Paramètres → Activité du foyer » — KIN-093, E9-S09.
+ *
+ * Affiche les 90 derniers événements d'audit du compte courant :
+ * - génération / partage de rapport médecin (KIN-083, KIN-084),
+ * - export RGPD/Loi 25 (KIN-085),
+ * - cycle de suppression de compte (KIN-086).
+ *
+ * **Zero-knowledge** : aucune donnée santé n'est jamais affichée — la table
+ * `audit_events` côté serveur ne stocke que des hashes opaques, des
+ * timestamps et des enums. La whitelist `event_data` est appliquée à
+ * deux niveaux (serveur + UI fallback : libellé "autre" pour un type futur).
+ *
+ * Refs: KIN-093, E9-S09, RM11.
+ */
+
+const QUERY_KEY = ['audit-events', 'me'] as const;
+
+const KNOWN_EVENT_TYPES = new Set([
+  'report_generated',
+  'report_shared',
+  'privacy_export',
+  'account_deletion_requested',
+  'account_deletion_cancelled',
+  'account_deleted',
+]);
+
+/**
+ * Liste de paires fixes [clé i18n datetime, locale i18next]. La détection de
+ * locale s'aligne sur le pattern de `apps/web/src/app/settings/privacy/page.tsx`
+ * qui lit `home.title` (équivalent visible aussi côté mobile). Pas
+ * d'`Intl.DateTimeFormat` calé sur navigator.language pour rester strictement
+ * cohérent avec la locale i18next sélectionnée.
+ */
+function formatDateTime(ms: number, locale: 'fr' | 'en'): string {
+  // ICU full Intl avec locale forcée (Node 20 / navigateurs modernes ont
+  // toutes les locales). Format : date courte + heure courte.
+  const formatter = new Intl.DateTimeFormat(locale === 'fr' ? 'fr-CA' : 'en-CA', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+  return formatter.format(new Date(ms));
+}
+
+export default function SettingsActivityPage(): React.JSX.Element | null {
+  const { t, i18n } = useTranslation('common');
+  const authenticated = useRequireAuth();
+
+  const { data, error, isLoading } = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: listMyAuditEvents,
+    enabled: authenticated,
+  });
+
+  if (!authenticated) return null;
+
+  // Détecte la locale i18n active (FR par défaut, EN sinon). i18n.language
+  // peut être `fr-FR`, `en-US`, etc. — on garde uniquement la base.
+  const locale: 'fr' | 'en' = i18n.language?.toLowerCase().startsWith('en') ? 'en' : 'fr';
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1>{t('audit.page.title')}</H1>
+      <Text fontSize="$3" color="$color11">
+        {t('audit.page.subtitle')}
+      </Text>
+
+      {isLoading ? <Text accessibilityLiveRegion="polite">{t('common.loading')}</Text> : null}
+
+      {error !== null && error !== undefined ? (
+        <Text color="$red10" accessibilityLiveRegion="polite">
+          {t('audit.page.loadError')}
+        </Text>
+      ) : null}
+
+      {!isLoading && data !== undefined && data.length === 0 ? (
+        <Card padded bordered>
+          <Text>{t('audit.page.empty')}</Text>
+        </Card>
+      ) : null}
+
+      {data !== undefined && data.length > 0 ? (
+        <YStack gap="$2">
+          <H2>{t('audit.page.listHeading')}</H2>
+          {data.map((event: AuditEventListItem) => (
+            <Card key={event.id} padded bordered>
+              <XStack justifyContent="space-between" alignItems="center" gap="$3" flexWrap="wrap">
+                <YStack flex={1} gap="$1">
+                  <Text fontWeight="600">
+                    {KNOWN_EVENT_TYPES.has(event.eventType)
+                      ? t(`audit.event.${event.eventType}`)
+                      : t('audit.event.other')}
+                  </Text>
+                  <Text fontSize="$2" color="$color11">
+                    {formatDateTime(event.createdAtMs, locale)}
+                  </Text>
+                </YStack>
+              </XStack>
+            </Card>
+          ))}
+        </YStack>
+      ) : null}
+    </YStack>
+  );
+}

--- a/apps/web/src/lib/audit-events/client.ts
+++ b/apps/web/src/lib/audit-events/client.ts
@@ -1,0 +1,74 @@
+/**
+ * Client web `GET /me/audit-events` (KIN-093, E9-S09).
+ *
+ * Encapsule l'appel au relais qui retourne les 90 derniers événements
+ * d'audit du compte courant — section « Activité du foyer ».
+ *
+ * **Zero-knowledge** : la réponse ne contient AUCUNE donnée santé. Le
+ * filtrage `event_data` whitelist est appliqué côté serveur, défense en
+ * profondeur.
+ *
+ * Refs: KIN-093, E9-S09, RM11.
+ */
+
+import { ApiError } from '../api-client';
+import { useAuthStore } from '../../stores/auth-store';
+
+const API_BASE = process.env['NEXT_PUBLIC_API_URL'] ?? 'http://localhost:3001';
+
+/**
+ * Types d'événement reconnus par l'UI. La liste est aligne sur les writes
+ * existants (KIN-083 `report_generated`, KIN-084 `report_shared`,
+ * KIN-085 `privacy_export`, KIN-086 `account_deletion_*`).
+ *
+ * Un type inconnu côté UI est traité comme « autre » (libellé i18n
+ * fallback) — l'app ne casse jamais sur un type futur.
+ */
+export type AuditEventType =
+  | 'report_generated'
+  | 'report_shared'
+  | 'privacy_export'
+  | 'account_deletion_requested'
+  | 'account_deletion_cancelled'
+  | 'account_deleted';
+
+export interface AuditEventListItem {
+  readonly id: string;
+  readonly eventType: string;
+  readonly eventData: Readonly<Record<string, unknown>>;
+  readonly createdAtMs: number;
+}
+
+interface AuditEventListResponse {
+  readonly events: ReadonlyArray<AuditEventListItem>;
+}
+
+/**
+ * Liste les 90 derniers événements d'audit du compte courant.
+ *
+ * Le serveur applique :
+ * - filtrage strict `WHERE account_id = sub` (anti-IDOR),
+ * - whitelist `event_data` par type,
+ * - tri antéchronologique,
+ * - rate-limit 60/h/device.
+ */
+export async function listMyAuditEvents(): Promise<ReadonlyArray<AuditEventListItem>> {
+  const token = useAuthStore.getState().accessToken;
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (token !== null) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  const res = await fetch(`${API_BASE}/me/audit-events`, {
+    method: 'GET',
+    headers,
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    throw new ApiError(
+      res.status,
+      typeof body['error'] === 'string' ? body['error'] : 'list_failed',
+    );
+  }
+  const data = (await res.json()) as AuditEventListResponse;
+  return data.events;
+}

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -367,6 +367,24 @@
     "contactLabel": "Privacy officer",
     "contactValue": "privacy@kinhale.health"
   },
+  "audit": {
+    "page": {
+      "title": "Household activity",
+      "subtitle": "The 90 most recent events about your account. No health data is ever sent to the server — only opaque hashes and timestamps are stored.",
+      "listHeading": "Recent events",
+      "empty": "No activity recorded yet.",
+      "loadError": "Could not load activity history."
+    },
+    "event": {
+      "report_generated": "Medical report generated",
+      "report_shared": "Medical report shared",
+      "privacy_export": "Portability export downloaded",
+      "account_deletion_requested": "Account deletion requested",
+      "account_deletion_cancelled": "Account deletion cancelled",
+      "account_deleted": "Account deleted",
+      "other": "Other event"
+    }
+  },
   "privacyExport": {
     "title": "Export my data",
     "description": "Exercise your right to data portability (GDPR art. 20 / Quebec Law 25 art. 30). The ZIP archive is generated entirely on your device — the Kinhale server never sees your health data.",

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -367,6 +367,24 @@
     "contactLabel": "Contact RPRP",
     "contactValue": "privacy@kinhale.health"
   },
+  "audit": {
+    "page": {
+      "title": "Activité du foyer",
+      "subtitle": "Les 90 derniers événements concernant votre compte. Aucune donnée santé n'est jamais transmise au serveur — seuls des hashes opaques et des horodatages sont conservés.",
+      "listHeading": "Événements récents",
+      "empty": "Aucune activité enregistrée pour le moment.",
+      "loadError": "Impossible de charger l'historique d'activité."
+    },
+    "event": {
+      "report_generated": "Rapport médecin généré",
+      "report_shared": "Rapport médecin partagé",
+      "privacy_export": "Export de portabilité téléchargé",
+      "account_deletion_requested": "Demande de suppression de compte",
+      "account_deletion_cancelled": "Suppression de compte annulée",
+      "account_deleted": "Compte supprimé",
+      "other": "Autre événement"
+    }
+  },
   "privacyExport": {
     "title": "Exporter mes données",
     "description": "Exercez votre droit à la portabilité (RGPD art. 20 / Loi 25 art. 30). L'archive ZIP est générée intégralement sur votre appareil — le serveur Kinhale ne voit jamais vos données santé.",


### PR DESCRIPTION
## Summary

KIN-093 / E9-S09 — Section **« Activité du foyer »** dans Settings (web + mobile) qui liste les 90 derniers événements d'audit du compte courant. Permet à l'Admin de voir qui/quoi/quand sans aucune exposition de donnée santé (zero-knowledge strict).

- Backend : `GET /me/audit-events` — self-scoped JWT, filtre `WHERE account_id = sub`, whitelist `event_data`, rate-limit 60/h, ajout dans `ROUTE_SCOPE_TABLE` (anti-IDOR auto-couvert).
- Frontend : page web (TanStack Query) + écran mobile (useState/useEffect) symétriques, état vide/loading/error.
- i18n FR + EN complets pour les 6 types existants + fallback `audit.event.other`.

## Acceptance criteria E9-S09

- [x] `GET /me/audit-events` retourne les 90 derniers événements de l'aidant authentifié, scope strict par `sub` JWT.
- [x] Pagination optionnelle (`?limit=` 1..90, défaut 90, ordre antéchronologique).
- [x] Section « Activité du foyer » ajoutée à Settings web + mobile.
- [x] Liste : date/heure formatée selon locale FR-CA / EN-CA, type traduit i18n (`audit.event.<type>`), description courte.
- [x] **Aucune donnée santé** affichée — whitelist `event_data` par type côté serveur + UI fallback côté client.
- [x] i18n FR + EN pour `report_generated`, `report_shared`, `privacy_export`, `account_deletion_requested`, `account_deletion_cancelled`, `account_deleted`.
- [x] Test anti-IDOR : `'GET /me/audit-events': 'self_scoped'` ajouté dans `ROUTE_SCOPE_TABLE`. 45 tests anti-IDOR existants passent y compris pour la nouvelle route.

## Sécurité (zero-knowledge / RM11)

- Authentification JWT obligatoire (`preHandler: [app.authenticate]`).
- Filtre `WHERE account_id = sub` strict — aucun cross-tenant.
- **Aucun JOIN** : projection limitée aux 4 colonnes d'`audit_events`.
- **Whitelist `event_data` par type** (`pickWhitelistedEventData`) avec fail-closed sur type inconnu — défense en profondeur contre tout dev qui ajouterait un champ santé par accident.
- L'`accountId` n'apparaît **pas** dans la réponse (le client le connaît via JWT — éviter une cible IDOR superflue).
- Rate-limit Redis 60/h/device (key `rl:audit-list:<deviceId>`).
- Validation querystring Zod `.strict()` (rejet de tout param inattendu, y compris une tentative `accountId=other`).

## Tests

**Backend (`audit.test.ts`)** — 13 nouveaux tests :
- 401 sans JWT, 200 vide, anti-fuite whitelist, anti-fuite accountId, 6 types couverts, type inconnu fail-closed, limit par défaut/custom, validation bornes, querystring strict, rate-limit 429, format `createdAtMs`, sentinelle santé (`Léa`, `Ventolin`, `wheezing`, `firstName`, `freeFormTag`).

**Anti-IDOR (`anti-idor.test.ts`)** — 45 tests existants couvrent automatiquement la nouvelle route via `ROUTE_SCOPE_TABLE`.

**Web (`page.test.tsx`)** — 7 tests : titre/sous-titre i18n, redirect non-auth, libellés traduits, fallback type inconnu, anti-fuite, état vide, état erreur.

**Mobile (`activity.test.tsx`)** — 6 tests symétriques.

## Vérifications locales

- `pnpm format:check` — vert
- `pnpm lint:root` — vert
- `pnpm lint` — vert (9 packages)
- `pnpm typecheck` — vert (9 packages)
- `pnpm test` — vert (api: 336 / web: 148 / mobile: 97)

## Revues automatisées

- **kz-review** : approuvé sans bloquant. Suggestions mineures (test format date, harmonisation détection locale, déduplication `KNOWN_EVENT_TYPES`) → issues de suivi.
- **kz-securite** : 0 critique / 0 élevé / 0 modéré, 3 findings info (pas de comparaison constant-time pertinente, log info sur `event_data` mal-typé, quota par device vs accountId).

Rapports complets dans `.agents/current-run/kz-review-KIN-093.md` et `.agents/current-run/kz-securite-KIN-093.md` (non commitées — `.agents/` gitignored).

## Test plan

- [ ] Web : se connecter, naviguer vers `/settings/activity`, vérifier liste + état vide.
- [ ] Mobile : Settings → Activité, vérifier liste + format date locale.
- [ ] Générer un rapport médecin puis recharger la page — l'événement `Rapport médecin généré` apparaît.
- [ ] Vérifier en base : `select event_data from audit_events where account_id = $sub` ne contient aucun champ santé (cohérence zero-knowledge).

Refs: KIN-093
Closes: E9-S09

🤖 Generated with [Claude Code](https://claude.com/claude-code)