### PR TITLE
feat(sync,ui): édition + void + résolution conflit RM6 (KIN-094)

### DIFF
--- a/apps/mobile/app/journal/__tests__/index.test.tsx
+++ b/apps/mobile/app/journal/__tests__/index.test.tsx
@@ -171,4 +171,75 @@ describe('JournalScreen', () => {
     renderWithProviders(<JournalScreen />);
     expect(screen.getByText(/toux/i)).toBeTruthy();
   });
+
+  it("affiche le badge 'À vérifier' pour une dose pending_review (E4-S05)", () => {
+    const { useDocStore } = jest.requireMock('../../../src/stores/doc-store') as {
+      useDocStore: jest.Mock;
+    };
+    const { projectDoses } = jest.requireMock('@kinhale/sync') as {
+      projectDoses: jest.Mock;
+    };
+    const doc = makeDocWithDose();
+    useDocStore.mockImplementation(
+      (selector: (s: { doc: KinhaleDoc | null; initDoc: jest.Mock }) => unknown) =>
+        selector({ doc, initDoc: jest.fn() }),
+    );
+    projectDoses.mockReturnValue([
+      {
+        eventId: 'evt-1',
+        doseId: 'dose-abc',
+        pumpId: 'pump-1',
+        childId: 'child-1',
+        caregiverId: 'dev-1',
+        administeredAtMs: Date.now() - 5 * 60_000,
+        doseType: 'rescue',
+        dosesAdministered: 1,
+        symptoms: [],
+        circumstances: [],
+        freeFormTag: null,
+        occurredAtMs: Date.now() - 5 * 60_000,
+        deviceId: 'dev-1',
+        status: 'pending_review',
+      },
+    ]);
+    renderWithProviders(<JournalScreen />);
+    expect(screen.getByText(/à vérifier|needs review/i)).toBeTruthy();
+  });
+
+  it("affiche le badge 'Annulée' et grise une dose voidée (E4-S07)", () => {
+    const { useDocStore } = jest.requireMock('../../../src/stores/doc-store') as {
+      useDocStore: jest.Mock;
+    };
+    const { projectDoses } = jest.requireMock('@kinhale/sync') as {
+      projectDoses: jest.Mock;
+    };
+    const doc = makeDocWithDose();
+    useDocStore.mockImplementation(
+      (selector: (s: { doc: KinhaleDoc | null; initDoc: jest.Mock }) => unknown) =>
+        selector({ doc, initDoc: jest.fn() }),
+    );
+    projectDoses.mockReturnValue([
+      {
+        eventId: 'evt-1',
+        doseId: 'dose-abc',
+        pumpId: 'pump-1',
+        childId: 'child-1',
+        caregiverId: 'dev-1',
+        administeredAtMs: 1_700_000_000_000,
+        doseType: 'maintenance',
+        dosesAdministered: 1,
+        symptoms: [],
+        circumstances: [],
+        freeFormTag: null,
+        occurredAtMs: 1_700_000_000_000,
+        deviceId: 'dev-1',
+        status: 'voided',
+        voidedReason: 'mauvaise pompe',
+        voidedByDeviceId: 'dev-1',
+        voidedAtMs: 1_700_000_500_000,
+      },
+    ]);
+    renderWithProviders(<JournalScreen />);
+    expect(screen.getByText(/annulée|cancelled/i)).toBeTruthy();
+  });
 });

--- a/apps/mobile/app/journal/edit/[doseId].tsx
+++ b/apps/mobile/app/journal/edit/[doseId].tsx
@@ -1,0 +1,250 @@
+import React, { useEffect, useMemo, useState, type JSX } from 'react';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { YStack, H1, Button, Text, XStack, Input } from 'tamagui';
+import {
+  projectCaregivers,
+  projectDoses,
+  VOIDED_REASON_MAX_LENGTH,
+  type DoseEditedPayload,
+  type ProjectedDose,
+} from '@kinhale/sync';
+import { canEditDose } from '@kinhale/domain/entities';
+import type { Role } from '@kinhale/domain/entities';
+import { useAuthStore } from '../../../src/stores/auth-store';
+import { useDocStore } from '../../../src/stores/doc-store';
+import { getOrCreateDevice, getGroupKey } from '../../../src/lib/device';
+import { useRelay } from '../../../src/hooks/use-relay';
+
+const SYMPTOMS = ['cough', 'wheezing', 'shortness_of_breath', 'chest_tightness'] as const;
+
+function deriveCurrentRole(
+  caregivers: ReadonlyArray<{ caregiverId: string; role: string }>,
+  deviceId: string | null,
+): Role {
+  if (deviceId === null) return 'contributor';
+  const me = caregivers.find((c) => c.caregiverId === deviceId);
+  if (me === undefined) return 'contributor';
+  if (me.role === 'admin' || me.role === 'restricted_contributor' || me.role === 'contributor') {
+    return me.role;
+  }
+  return 'contributor';
+}
+
+export default function EditDoseScreen(): JSX.Element {
+  const { t } = useTranslation('common');
+  const router = useRouter();
+  const params = useLocalSearchParams<{ doseId: string }>();
+  const doseId = typeof params.doseId === 'string' ? params.doseId : '';
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const deviceId = useAuthStore((s) => s.deviceId) ?? '';
+  const householdId = useAuthStore((s) => s.householdId) ?? '';
+  const doc = useDocStore((s) => s.doc);
+  const appendDoseEdit = useDocStore((s) => s.appendDoseEdit);
+
+  const [groupKey, setGroupKey] = useState<Uint8Array | null>(null);
+  const [dosesValue, setDosesValue] = useState('');
+  const [symptoms, setSymptoms] = useState<string[]>([]);
+  const [administeredAtMs, setAdministeredAtMs] = useState('');
+  const [reason, setReason] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const dose: ProjectedDose | null = useMemo(() => {
+    if (doc === null) return null;
+    return projectDoses(doc).find((d) => d.doseId === doseId) ?? null;
+  }, [doc, doseId]);
+
+  const currentRole = useMemo(
+    () => deriveCurrentRole(doc !== null ? projectCaregivers(doc) : [], deviceId),
+    [doc, deviceId],
+  );
+
+  useEffect(() => {
+    if (householdId !== '') {
+      getGroupKey(householdId)
+        .then(setGroupKey)
+        .catch(() => undefined);
+    }
+  }, [householdId]);
+
+  useEffect(() => {
+    if (dose !== null) {
+      setDosesValue(String(dose.dosesAdministered));
+      setSymptoms([...dose.symptoms]);
+      setAdministeredAtMs(String(dose.administeredAtMs));
+    }
+  }, [dose]);
+
+  const { sendChanges } = useRelay(accessToken, groupKey);
+
+  if (dose === null) {
+    return (
+      <YStack padding="$4" gap="$4">
+        <H1>{t('journal.dose.editModal.title')}</H1>
+        <Text color="$red10" accessibilityRole="alert">
+          {t('journal.dose.resolveModal.missingPair')}
+        </Text>
+        <Button onPress={() => router.replace('/journal')} accessible accessibilityRole="button">
+          {t('journal.dose.resolveModal.back')}
+        </Button>
+      </YStack>
+    );
+  }
+
+  const verdict = canEditDose({
+    dose: {
+      recordedByDeviceId: dose.deviceId,
+      administeredAtMs: dose.administeredAtMs,
+      status: dose.status,
+    },
+    currentDeviceId: deviceId,
+    currentRole,
+    nowMs: Date.now(),
+  });
+
+  if (!verdict.allowed) {
+    const refusalKey =
+      verdict.reason === 'voided'
+        ? 'journal.dose.editPermission.voided'
+        : verdict.reason === 'pending_review'
+          ? 'journal.dose.editPermission.pendingReview'
+          : verdict.reason === 'restricted_role'
+            ? 'journal.dose.editPermission.restrictedRole'
+            : 'journal.dose.editPermission.tooEarly';
+    return (
+      <YStack padding="$4" gap="$4">
+        <H1>{t('journal.dose.editModal.title')}</H1>
+        <Text accessibilityRole="alert" color="$orange11">
+          {t(refusalKey)}
+        </Text>
+        {verdict.reason === 'not_author_and_too_old' && (
+          <Text color="$color10">{t('journal.dose.editPermission.adminOnly')}</Text>
+        )}
+        <Button onPress={() => router.replace('/journal')} accessible accessibilityRole="button">
+          {t('journal.dose.resolveModal.back')}
+        </Button>
+      </YStack>
+    );
+  }
+
+  const requiresReason = verdict.requiresReason;
+
+  const handleSubmit = async (): Promise<void> => {
+    setError(null);
+    const dosesNumber = Number(dosesValue);
+    if (!Number.isFinite(dosesNumber) || dosesNumber < 0) {
+      setError(t('journal.dose.editModal.saveError'));
+      return;
+    }
+    const adminAtNumber = Number(administeredAtMs);
+    if (!Number.isFinite(adminAtNumber)) {
+      setError(t('journal.dose.editModal.saveError'));
+      return;
+    }
+    const trimmedReason = reason.trim();
+    if (requiresReason && trimmedReason.length === 0) {
+      setError(t('journal.dose.editModal.reasonRequired'));
+      return;
+    }
+    if (trimmedReason.length > VOIDED_REASON_MAX_LENGTH) {
+      setError(t('journal.dose.editModal.reasonTooLong'));
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const kp = await getOrCreateDevice();
+      const payload: DoseEditedPayload = {
+        doseId: dose.doseId,
+        patch: {
+          administeredAtMs: adminAtNumber,
+          dosesAdministered: dosesNumber,
+          symptoms,
+        },
+        editedByDeviceId: deviceId,
+        editedAtMs: Date.now(),
+        ...(trimmedReason.length > 0 ? { reason: trimmedReason } : {}),
+      };
+      const changes = await appendDoseEdit(payload, deviceId, kp.secretKey);
+      if (groupKey !== null) {
+        await sendChanges(changes, groupKey);
+      }
+      router.replace('/journal');
+    } catch {
+      setError(t('journal.dose.editModal.saveError'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1>{t('journal.dose.editModal.title')}</H1>
+
+      <Text fontWeight="600">{t('journal.dose.editModal.administeredAtLabel')}</Text>
+      <Input value={administeredAtMs} onChangeText={setAdministeredAtMs} keyboardType="numeric" />
+
+      <Text fontWeight="600">{t('journal.dose.editModal.dosesLabel')}</Text>
+      <Input value={dosesValue} onChangeText={setDosesValue} keyboardType="numeric" />
+
+      <Text fontWeight="600">{t('journal.dose.editModal.symptomsLabel')}</Text>
+      <XStack flexWrap="wrap" gap="$2">
+        {SYMPTOMS.map((s) => (
+          <Button
+            key={s}
+            size="$3"
+            onPress={() =>
+              setSymptoms((prev) => (prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]))
+            }
+            theme={symptoms.includes(s) ? 'active' : null}
+            accessible
+            accessibilityRole="button"
+          >
+            {t(`journal.symptom.${s}`)}
+          </Button>
+        ))}
+      </XStack>
+
+      {requiresReason && (
+        <>
+          <Text fontWeight="600">{t('journal.dose.editModal.reasonLabel')}</Text>
+          <Input
+            value={reason}
+            onChangeText={setReason}
+            placeholder={t('journal.dose.editModal.reasonPlaceholder')}
+            accessible
+            accessibilityLabel={t('journal.dose.editModal.reasonLabel')}
+          />
+        </>
+      )}
+
+      {error !== null && (
+        <Text accessibilityRole="alert" color="$red10">
+          {error}
+        </Text>
+      )}
+
+      <XStack gap="$2">
+        <Button
+          flex={1}
+          onPress={() => router.replace('/journal')}
+          theme="gray"
+          accessible
+          accessibilityRole="button"
+        >
+          {t('journal.dose.editModal.cancel')}
+        </Button>
+        <Button
+          flex={1}
+          onPress={() => void handleSubmit()}
+          disabled={loading}
+          accessible
+          accessibilityRole="button"
+        >
+          {loading ? t('journal.saving') : t('journal.dose.editModal.submit')}
+        </Button>
+      </XStack>
+    </YStack>
+  );
+}

--- a/apps/mobile/app/journal/index.tsx
+++ b/apps/mobile/app/journal/index.tsx
@@ -2,15 +2,31 @@ import React, { useEffect, type JSX } from 'react';
 import { useRouter } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { YStack, H1, Text, Button, XStack } from 'tamagui';
-import { projectDoses } from '@kinhale/sync';
+import { projectDoses, projectCaregivers, type ProjectedDose } from '@kinhale/sync';
+import { canEditDose } from '@kinhale/domain/entities';
+import type { Role } from '@kinhale/domain/entities';
 import { useAuthStore } from '../../src/stores/auth-store';
 import { useDocStore } from '../../src/stores/doc-store';
+
+function deriveCurrentRole(
+  caregivers: ReadonlyArray<{ caregiverId: string; role: string }>,
+  deviceId: string | null,
+): Role {
+  if (deviceId === null) return 'contributor';
+  const me = caregivers.find((c) => c.caregiverId === deviceId);
+  if (me === undefined) return 'contributor';
+  if (me.role === 'admin' || me.role === 'restricted_contributor' || me.role === 'contributor') {
+    return me.role;
+  }
+  return 'contributor';
+}
 
 export default function JournalScreen(): JSX.Element {
   const { t } = useTranslation('common');
   const router = useRouter();
   const accessToken = useAuthStore((s) => s.accessToken);
   const householdId = useAuthStore((s) => s.householdId);
+  const deviceId = useAuthStore((s) => s.deviceId);
   const doc = useDocStore((s) => s.doc);
   const initDoc = useDocStore((s) => s.initDoc);
 
@@ -25,48 +41,50 @@ export default function JournalScreen(): JSX.Element {
   }, [accessToken, householdId, initDoc, router]);
 
   const doses = doc !== null ? projectDoses(doc) : [];
+  const caregivers = doc !== null ? projectCaregivers(doc) : [];
+  const currentRole = deriveCurrentRole(caregivers, deviceId);
+  const nowMs = Date.now();
 
   return (
     <YStack padding="$4" gap="$4">
       <H1>{t('journal.title')}</H1>
       {doses.length === 0 && <Text color="$color10">{t('journal.empty')}</Text>}
-      {doses.map((dose) => (
-        <YStack
-          key={dose.eventId}
-          padding="$3"
-          borderWidth={1}
-          borderColor="$borderColor"
-          borderRadius="$3"
-          gap="$2"
-        >
-          <XStack justifyContent="space-between" alignItems="center">
-            <Text fontSize="$4" fontWeight="700">
-              {dose.doseType === 'rescue' ? t('journal.rescue') : t('journal.maintenance')}
-            </Text>
-            <Text fontSize="$2" color="$color9">
-              {new Date(dose.administeredAtMs).toLocaleString()}
-            </Text>
-          </XStack>
-
-          {dose.symptoms.length > 0 && (
-            <Text fontSize="$3" color="$color10">
-              {dose.symptoms.map((s) => t(`journal.symptom.${s}`)).join(' · ')}
-            </Text>
-          )}
-
-          {dose.circumstances.length > 0 && (
-            <Text fontSize="$3" color="$color10">
-              {dose.circumstances.map((c) => t(`journal.circumstance.${c}`)).join(' · ')}
-            </Text>
-          )}
-
-          {dose.freeFormTag !== null && (
-            <Text fontSize="$3" color="$color9" fontStyle="italic">
-              {dose.freeFormTag}
-            </Text>
-          )}
-        </YStack>
-      ))}
+      {doses.map((dose) => {
+        const isVoided = dose.status === 'voided';
+        const isPendingReview = dose.status === 'pending_review';
+        const editVerdict = canEditDose({
+          dose: {
+            recordedByDeviceId: dose.deviceId,
+            administeredAtMs: dose.administeredAtMs,
+            status: dose.status,
+          },
+          currentDeviceId: deviceId ?? '',
+          currentRole,
+          nowMs,
+        });
+        return (
+          <DoseCard
+            key={dose.eventId}
+            dose={dose}
+            isVoided={isVoided}
+            isPendingReview={isPendingReview}
+            canEdit={editVerdict.allowed}
+            t={t}
+            onEdit={() =>
+              router.push({ pathname: '/journal/edit/[doseId]', params: { doseId: dose.doseId } })
+            }
+            onVoid={() =>
+              router.push({ pathname: '/journal/void/[doseId]', params: { doseId: dose.doseId } })
+            }
+            onResolve={() =>
+              router.push({
+                pathname: '/journal/resolve/[doseId]',
+                params: { doseId: dose.doseId },
+              })
+            }
+          />
+        );
+      })}
       <Button
         onPress={() => router.push('/journal/add')}
         marginTop="$2"
@@ -75,6 +93,113 @@ export default function JournalScreen(): JSX.Element {
       >
         {t('journal.addDose')}
       </Button>
+    </YStack>
+  );
+}
+
+interface DoseCardProps {
+  readonly dose: ProjectedDose;
+  readonly isVoided: boolean;
+  readonly isPendingReview: boolean;
+  readonly canEdit: boolean;
+  readonly t: (key: string) => string;
+  readonly onEdit: () => void;
+  readonly onVoid: () => void;
+  readonly onResolve: () => void;
+}
+
+function DoseCard({
+  dose,
+  isVoided,
+  isPendingReview,
+  canEdit,
+  t,
+  onEdit,
+  onVoid,
+  onResolve,
+}: DoseCardProps): JSX.Element {
+  const labelKey = dose.doseType === 'rescue' ? 'journal.rescue' : 'journal.maintenance';
+  const reasonLabel =
+    isVoided && dose.voidedReason !== undefined && dose.voidedReason === 'duplicate_resolved'
+      ? t('journal.dose.voidedReason.duplicate_resolved')
+      : (dose.voidedReason ?? '');
+  return (
+    <YStack
+      padding="$3"
+      borderWidth={1}
+      borderColor={isPendingReview ? '$orange8' : '$borderColor'}
+      borderRadius="$3"
+      gap="$2"
+      opacity={isVoided ? 0.55 : 1}
+      backgroundColor={isPendingReview ? '$orange3' : '$background'}
+    >
+      <XStack justifyContent="space-between" alignItems="center">
+        <Text
+          fontSize="$4"
+          fontWeight="700"
+          textDecorationLine={isVoided ? 'line-through' : 'none'}
+        >
+          {t(labelKey)}
+        </Text>
+        <Text fontSize="$2" color="$color9">
+          {new Date(dose.administeredAtMs).toLocaleString()}
+        </Text>
+      </XStack>
+
+      {isVoided && (
+        <Text fontSize="$2" color="$color10" fontWeight="600">
+          {t('journal.dose.voidedBadge')}
+          {reasonLabel.length > 0 && ` · ${t('journal.dose.voidedReason.label')} : ${reasonLabel}`}
+        </Text>
+      )}
+
+      {isPendingReview && (
+        <Text fontSize="$2" color="$orange11" fontWeight="600">
+          {t('journal.dose.pendingReviewBadge')}
+        </Text>
+      )}
+
+      {dose.symptoms.length > 0 && (
+        <Text fontSize="$3" color="$color10">
+          {dose.symptoms.map((s) => t(`journal.symptom.${s}`)).join(' · ')}
+        </Text>
+      )}
+
+      {dose.circumstances.length > 0 && (
+        <Text fontSize="$3" color="$color10">
+          {dose.circumstances.map((c) => t(`journal.circumstance.${c}`)).join(' · ')}
+        </Text>
+      )}
+
+      {dose.freeFormTag !== null && (
+        <Text fontSize="$3" color="$color9" fontStyle="italic">
+          {dose.freeFormTag}
+        </Text>
+      )}
+
+      {!isVoided && (
+        <XStack gap="$2" flexWrap="wrap" marginTop="$2">
+          {canEdit && (
+            <Button size="$2" onPress={onEdit} accessible accessibilityRole="button">
+              {t('journal.dose.actions.edit')}
+            </Button>
+          )}
+          <Button size="$2" onPress={onVoid} theme="red" accessible accessibilityRole="button">
+            {t('journal.dose.actions.void')}
+          </Button>
+          {isPendingReview && (
+            <Button
+              size="$2"
+              onPress={onResolve}
+              theme="orange"
+              accessible
+              accessibilityRole="button"
+            >
+              {t('journal.dose.actions.resolve')}
+            </Button>
+          )}
+        </XStack>
+      )}
     </YStack>
   );
 }

--- a/apps/mobile/app/journal/resolve/[doseId].tsx
+++ b/apps/mobile/app/journal/resolve/[doseId].tsx
@@ -1,0 +1,195 @@
+import React, { useEffect, useMemo, useState, type JSX } from 'react';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { YStack, H1, Button, Text, XStack } from 'tamagui';
+import {
+  projectCaregivers,
+  projectDoses,
+  VOIDED_REASON_DUPLICATE_RESOLVED,
+  type DoseReviewFlaggedPayload,
+  type DoseVoidedPayload,
+  type ProjectedDose,
+} from '@kinhale/sync';
+import { useAuthStore } from '../../../src/stores/auth-store';
+import { useDocStore } from '../../../src/stores/doc-store';
+import { getOrCreateDevice, getGroupKey } from '../../../src/lib/device';
+import { useRelay } from '../../../src/hooks/use-relay';
+
+function findConflictPartner(
+  doc: { events: ReadonlyArray<{ type: string; payloadJson: string }> } | null,
+  doseId: string,
+): string | null {
+  if (doc === null) return null;
+  for (const event of doc.events) {
+    if (event.type !== 'DoseReviewFlagged') continue;
+    let payload: DoseReviewFlaggedPayload;
+    try {
+      payload = JSON.parse(event.payloadJson) as DoseReviewFlaggedPayload;
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(payload.doseIds) || payload.doseIds.length < 2) continue;
+    const [a, b] = payload.doseIds;
+    if (a === doseId && typeof b === 'string') return b;
+    if (b === doseId && typeof a === 'string') return a;
+  }
+  return null;
+}
+
+export default function ResolveConflictScreen(): JSX.Element {
+  const { t } = useTranslation('common');
+  const router = useRouter();
+  const params = useLocalSearchParams<{ doseId: string }>();
+  const doseId = typeof params.doseId === 'string' ? params.doseId : '';
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const deviceId = useAuthStore((s) => s.deviceId) ?? '';
+  const householdId = useAuthStore((s) => s.householdId) ?? '';
+  const doc = useDocStore((s) => s.doc);
+  const appendDoseVoid = useDocStore((s) => s.appendDoseVoid);
+
+  const [groupKey, setGroupKey] = useState<Uint8Array | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const doses = useMemo(() => (doc !== null ? projectDoses(doc) : []), [doc]);
+  const caregivers = useMemo(() => (doc !== null ? projectCaregivers(doc) : []), [doc]);
+  const dose = doses.find((d) => d.doseId === doseId) ?? null;
+  const partnerId = findConflictPartner(doc, doseId);
+  const partner = partnerId === null ? null : (doses.find((d) => d.doseId === partnerId) ?? null);
+
+  // Mapping caregiverId → displayName. Hypothèse v1.0 : caregiverId === deviceId.
+  const caregiverNameByCaregiverId = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of caregivers) m.set(c.caregiverId, c.displayName);
+    return m;
+  }, [caregivers]);
+  const resolveCaregiverName = (deviceId: string): string => {
+    const name = caregiverNameByCaregiverId.get(deviceId);
+    if (name !== undefined) return name;
+    return t('journal.dose.unknownCaregiver', { id: deviceId.slice(-4) });
+  };
+
+  useEffect(() => {
+    if (householdId !== '') {
+      getGroupKey(householdId)
+        .then(setGroupKey)
+        .catch(() => undefined);
+    }
+  }, [householdId]);
+
+  const { sendChanges } = useRelay(accessToken, groupKey);
+
+  if (dose === null || partner === null) {
+    return (
+      <YStack padding="$4" gap="$4">
+        <H1>{t('journal.dose.resolveModal.title')}</H1>
+        <Text color="$red10" accessibilityRole="alert">
+          {t('journal.dose.resolveModal.missingPair')}
+        </Text>
+        <Button onPress={() => router.replace('/journal')} accessible accessibilityRole="button">
+          {t('journal.dose.resolveModal.back')}
+        </Button>
+      </YStack>
+    );
+  }
+
+  const handleKeep = async (kept: ProjectedDose, voided: ProjectedDose): Promise<void> => {
+    setError(null);
+    setLoading(true);
+    try {
+      const kp = await getOrCreateDevice();
+      const payload: DoseVoidedPayload = {
+        doseId: voided.doseId,
+        voidedByDeviceId: deviceId,
+        voidedAtMs: Date.now(),
+        voidedReason: VOIDED_REASON_DUPLICATE_RESOLVED,
+      };
+      const changes = await appendDoseVoid(payload, deviceId, kp.secretKey);
+      if (groupKey !== null) {
+        await sendChanges(changes, groupKey);
+      }
+      void kept;
+      router.replace('/journal');
+    } catch {
+      setError(t('journal.dose.resolveModal.saveError'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1>{t('journal.dose.resolveModal.title')}</H1>
+      <Text color="$color10">{t('journal.dose.resolveModal.intro')}</Text>
+
+      <XStack gap="$3" flexWrap="wrap">
+        <DosePane
+          dose={dose}
+          caregiverName={resolveCaregiverName(dose.deviceId)}
+          t={t}
+          onKeep={() => void handleKeep(dose, partner)}
+          loading={loading}
+        />
+        <DosePane
+          dose={partner}
+          caregiverName={resolveCaregiverName(partner.deviceId)}
+          t={t}
+          onKeep={() => void handleKeep(partner, dose)}
+          loading={loading}
+        />
+      </XStack>
+
+      {error !== null && (
+        <Text accessibilityRole="alert" color="$red10">
+          {error}
+        </Text>
+      )}
+
+      <Button
+        onPress={() => router.replace('/journal')}
+        theme="gray"
+        accessible
+        accessibilityRole="button"
+      >
+        {t('journal.dose.resolveModal.back')}
+      </Button>
+    </YStack>
+  );
+}
+
+interface DosePaneProps {
+  readonly dose: ProjectedDose;
+  readonly caregiverName: string;
+  readonly t: (key: string) => string;
+  readonly onKeep: () => void;
+  readonly loading: boolean;
+}
+
+function DosePane({ dose, caregiverName, t, onKeep, loading }: DosePaneProps): JSX.Element {
+  const labelKey = dose.doseType === 'rescue' ? 'journal.rescue' : 'journal.maintenance';
+  return (
+    <YStack
+      flex={1}
+      minWidth={240}
+      padding="$3"
+      borderWidth={1}
+      borderColor="$borderColor"
+      borderRadius="$3"
+      gap="$2"
+    >
+      <Text fontSize="$4" fontWeight="700">
+        {t(labelKey)}
+      </Text>
+      <Text fontSize="$2" color="$color9">
+        {new Date(dose.administeredAtMs).toLocaleString()}
+      </Text>
+      <Text fontSize="$3">{`${t('journal.dose.editModal.dosesLabel')} : ${String(dose.dosesAdministered)}`}</Text>
+      <Text fontSize="$2" color="$color10">
+        {`${t('journal.dose.caregiverLabel')} : ${caregiverName}`}
+      </Text>
+      <Button onPress={onKeep} disabled={loading} accessible accessibilityRole="button">
+        {t('journal.dose.resolveModal.keepThis')}
+      </Button>
+    </YStack>
+  );
+}

--- a/apps/mobile/app/journal/void/[doseId].tsx
+++ b/apps/mobile/app/journal/void/[doseId].tsx
@@ -1,0 +1,137 @@
+import React, { useEffect, useMemo, useState, type JSX } from 'react';
+import { useLocalSearchParams, useRouter } from 'expo-router';
+import { useTranslation } from 'react-i18next';
+import { YStack, H1, Button, Text, XStack, Input } from 'tamagui';
+import {
+  projectDoses,
+  VOIDED_REASON_MAX_LENGTH,
+  type DoseVoidedPayload,
+  type ProjectedDose,
+} from '@kinhale/sync';
+import { useAuthStore } from '../../../src/stores/auth-store';
+import { useDocStore } from '../../../src/stores/doc-store';
+import { getOrCreateDevice, getGroupKey } from '../../../src/lib/device';
+import { useRelay } from '../../../src/hooks/use-relay';
+
+export default function VoidDoseScreen(): JSX.Element {
+  const { t } = useTranslation('common');
+  const router = useRouter();
+  const params = useLocalSearchParams<{ doseId: string }>();
+  const doseId = typeof params.doseId === 'string' ? params.doseId : '';
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const deviceId = useAuthStore((s) => s.deviceId) ?? '';
+  const householdId = useAuthStore((s) => s.householdId) ?? '';
+  const doc = useDocStore((s) => s.doc);
+  const appendDoseVoid = useDocStore((s) => s.appendDoseVoid);
+
+  const [groupKey, setGroupKey] = useState<Uint8Array | null>(null);
+  const [reason, setReason] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const dose: ProjectedDose | null = useMemo(() => {
+    if (doc === null) return null;
+    return projectDoses(doc).find((d) => d.doseId === doseId) ?? null;
+  }, [doc, doseId]);
+
+  useEffect(() => {
+    if (householdId !== '') {
+      getGroupKey(householdId)
+        .then(setGroupKey)
+        .catch(() => undefined);
+    }
+  }, [householdId]);
+
+  const { sendChanges } = useRelay(accessToken, groupKey);
+
+  if (dose === null || dose.status === 'voided') {
+    return (
+      <YStack padding="$4" gap="$4">
+        <H1>{t('journal.dose.voidModal.title')}</H1>
+        <Text color="$red10" accessibilityRole="alert">
+          {t('journal.dose.editPermission.voided')}
+        </Text>
+        <Button onPress={() => router.replace('/journal')} accessible accessibilityRole="button">
+          {t('journal.dose.resolveModal.back')}
+        </Button>
+      </YStack>
+    );
+  }
+
+  const handleSubmit = async (): Promise<void> => {
+    setError(null);
+    const trimmed = reason.trim();
+    if (trimmed.length === 0) {
+      setError(t('journal.dose.voidModal.reasonRequired'));
+      return;
+    }
+    if (trimmed.length > VOIDED_REASON_MAX_LENGTH) {
+      setError(t('journal.dose.voidModal.reasonTooLong'));
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const kp = await getOrCreateDevice();
+      const payload: DoseVoidedPayload = {
+        doseId: dose.doseId,
+        voidedByDeviceId: deviceId,
+        voidedAtMs: Date.now(),
+        voidedReason: trimmed,
+      };
+      const changes = await appendDoseVoid(payload, deviceId, kp.secretKey);
+      if (groupKey !== null) {
+        await sendChanges(changes, groupKey);
+      }
+      router.replace('/journal');
+    } catch {
+      setError(t('journal.dose.voidModal.saveError'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1>{t('journal.dose.voidModal.title')}</H1>
+      <Text color="$color10">{t('journal.dose.voidModal.warning')}</Text>
+
+      <Text fontWeight="600">{t('journal.dose.voidModal.reasonLabel')}</Text>
+      <Input
+        value={reason}
+        onChangeText={setReason}
+        placeholder={t('journal.dose.voidModal.reasonPlaceholder')}
+        accessible
+        accessibilityLabel={t('journal.dose.voidModal.reasonLabel')}
+      />
+
+      {error !== null && (
+        <Text accessibilityRole="alert" color="$red10">
+          {error}
+        </Text>
+      )}
+
+      <XStack gap="$2">
+        <Button
+          flex={1}
+          onPress={() => router.replace('/journal')}
+          theme="gray"
+          accessible
+          accessibilityRole="button"
+        >
+          {t('journal.dose.voidModal.cancel')}
+        </Button>
+        <Button
+          flex={1}
+          onPress={() => void handleSubmit()}
+          disabled={loading}
+          theme="red"
+          accessible
+          accessibilityRole="button"
+        >
+          {loading ? t('journal.saving') : t('journal.dose.voidModal.submit')}
+        </Button>
+      </XStack>
+    </YStack>
+  );
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,6 +14,7 @@
     "test": "jest --passWithNoTests"
   },
   "dependencies": {
+    "@kinhale/domain": "workspace:*",
     "@kinhale/i18n": "workspace:*",
     "@kinhale/reports": "workspace:*",
     "@react-native-async-storage/async-storage": "^2.1.0",

--- a/apps/mobile/src/__mocks__/@kinhale/sync.ts
+++ b/apps/mobile/src/__mocks__/@kinhale/sync.ts
@@ -42,3 +42,5 @@ export const projectPumps = jest.fn().mockReturnValue([]);
 export const projectChild = jest.fn().mockReturnValue(null);
 export const projectPlan = jest.fn().mockReturnValue(null);
 export const projectCaregivers = jest.fn().mockReturnValue([]);
+export const VOIDED_REASON_DUPLICATE_RESOLVED = 'duplicate_resolved';
+export const VOIDED_REASON_MAX_LENGTH = 200;

--- a/apps/mobile/src/stores/doc-store.ts
+++ b/apps/mobile/src/stores/doc-store.ts
@@ -14,6 +14,8 @@ import type {
   KinhaleDoc,
   DoseAdministeredPayload,
   DoseReviewFlaggedPayload,
+  DoseEditedPayload,
+  DoseVoidedPayload,
   ChildRegisteredPayload,
   PumpReplacedPayload,
   PlanUpdatedPayload,
@@ -62,6 +64,16 @@ interface DocState {
   ) => Promise<Uint8Array[]>;
   appendDoseFlag: (
     payload: DoseReviewFlaggedPayload,
+    deviceId: string,
+    secretKey: Uint8Array,
+  ) => Promise<Uint8Array[]>;
+  appendDoseEdit: (
+    payload: DoseEditedPayload,
+    deviceId: string,
+    secretKey: Uint8Array,
+  ) => Promise<Uint8Array[]>;
+  appendDoseVoid: (
+    payload: DoseVoidedPayload,
     deviceId: string,
     secretKey: Uint8Array,
   ) => Promise<Uint8Array[]>;
@@ -207,6 +219,46 @@ export const useDocStore = create<DocState>()((set, get) => ({
       deviceId,
       occurredAtMs: Date.now(),
       event: { type: 'DoseReviewFlagged', payload },
+    };
+    const record = await signEvent(unsigned, secretKey);
+    const newDoc = appendEvent(doc, record);
+    const changes = getDocChanges(doc, newDoc);
+
+    void persistDoc(newDoc);
+    set({ doc: newDoc });
+    return changes;
+  },
+
+  async appendDoseEdit(payload, deviceId, secretKey) {
+    const currentDoc = get().doc;
+    const hid = (currentDoc as KinhaleDoc | null)?.householdId ?? deviceId;
+    const doc = currentDoc ?? createDoc(hid);
+
+    const unsigned: UnsignedEvent = {
+      id: crypto.randomUUID(),
+      deviceId,
+      occurredAtMs: Date.now(),
+      event: { type: 'DoseEdited', payload },
+    };
+    const record = await signEvent(unsigned, secretKey);
+    const newDoc = appendEvent(doc, record);
+    const changes = getDocChanges(doc, newDoc);
+
+    void persistDoc(newDoc);
+    set({ doc: newDoc });
+    return changes;
+  },
+
+  async appendDoseVoid(payload, deviceId, secretKey) {
+    const currentDoc = get().doc;
+    const hid = (currentDoc as KinhaleDoc | null)?.householdId ?? deviceId;
+    const doc = currentDoc ?? createDoc(hid);
+
+    const unsigned: UnsignedEvent = {
+      id: crypto.randomUUID(),
+      deviceId,
+      occurredAtMs: Date.now(),
+      event: { type: 'DoseVoided', payload },
     };
     const record = await signEvent(unsigned, secretKey);
     const newDoc = appendEvent(doc, record);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@kinhale/crypto": "workspace:*",
+    "@kinhale/domain": "workspace:*",
     "@kinhale/i18n": "workspace:*",
     "@kinhale/reports": "workspace:*",
     "@kinhale/sync": "workspace:*",

--- a/apps/web/src/app/journal/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/__tests__/page.test.tsx
@@ -5,8 +5,13 @@ import type { ProjectedDose } from '@kinhale/sync';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockProjectDoses = jest.fn<ProjectedDose[], any[]>(() => []);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockProjectCaregivers = jest.fn<Array<{ caregiverId: string; role: string }>, any[]>(
+  () => [],
+);
 jest.mock('@kinhale/sync', () => ({
   projectDoses: (doc: unknown) => mockProjectDoses(doc),
+  projectCaregivers: (doc: unknown) => mockProjectCaregivers(doc),
 }));
 
 jest.mock('next/navigation', () => ({

--- a/apps/web/src/app/journal/edit/[doseId]/page.tsx
+++ b/apps/web/src/app/journal/edit/[doseId]/page.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { YStack, H1, Button, Text, XStack, Input } from 'tamagui';
+import {
+  projectCaregivers,
+  projectDoses,
+  VOIDED_REASON_MAX_LENGTH,
+  type DoseEditedPayload,
+  type ProjectedDose,
+} from '@kinhale/sync';
+import { canEditDose } from '@kinhale/domain/entities';
+import type { Role } from '@kinhale/domain/entities';
+import { useAuthStore } from '../../../../stores/auth-store';
+import { useDocStore } from '../../../../stores/doc-store';
+import { getOrCreateDevice, getGroupKey } from '../../../../lib/device';
+import { useRelay } from '../../../../hooks/use-relay';
+import { useRequireAuth } from '../../../../lib/useRequireAuth';
+
+const SYMPTOMS = ['cough', 'wheezing', 'shortness_of_breath', 'chest_tightness'] as const;
+
+function deriveCurrentRole(
+  caregivers: ReadonlyArray<{ caregiverId: string; role: string }>,
+  deviceId: string | null,
+): Role {
+  if (deviceId === null) return 'contributor';
+  const me = caregivers.find((c) => c.caregiverId === deviceId);
+  if (me === undefined) return 'contributor';
+  if (me.role === 'admin' || me.role === 'restricted_contributor' || me.role === 'contributor') {
+    return me.role;
+  }
+  return 'contributor';
+}
+
+export default function EditDosePage(): React.JSX.Element | null {
+  const { t } = useTranslation('common');
+  const router = useRouter();
+  const params = useParams<{ doseId: string }>();
+  const doseId = params?.doseId ?? '';
+  const authenticated = useRequireAuth();
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const deviceId = useAuthStore((s) => s.deviceId) ?? '';
+  const householdId = useAuthStore((s) => s.householdId) ?? '';
+  const doc = useDocStore((s) => s.doc);
+  const appendDoseEdit = useDocStore((s) => s.appendDoseEdit);
+
+  const [groupKey, setGroupKey] = useState<Uint8Array | null>(null);
+  const [dosesValue, setDosesValue] = useState('');
+  const [symptoms, setSymptoms] = useState<string[]>([]);
+  const [administeredAtMs, setAdministeredAtMs] = useState('');
+  const [reason, setReason] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const dose: ProjectedDose | null = useMemo(() => {
+    if (doc === null) return null;
+    const doses = projectDoses(doc);
+    return doses.find((d) => d.doseId === doseId) ?? null;
+  }, [doc, doseId]);
+
+  const currentRole = useMemo(
+    () => deriveCurrentRole(doc !== null ? projectCaregivers(doc) : [], deviceId),
+    [doc, deviceId],
+  );
+
+  useEffect(() => {
+    if (householdId !== '') {
+      getGroupKey(householdId)
+        .then(setGroupKey)
+        .catch(() => undefined);
+    }
+  }, [householdId]);
+
+  useEffect(() => {
+    if (dose !== null) {
+      setDosesValue(String(dose.dosesAdministered));
+      setSymptoms([...dose.symptoms]);
+      setAdministeredAtMs(String(dose.administeredAtMs));
+    }
+  }, [dose]);
+
+  const { sendChanges } = useRelay(accessToken, groupKey);
+
+  if (!authenticated) return null;
+  if (dose === null) {
+    return (
+      <YStack padding="$4" gap="$4">
+        <H1>{t('journal.dose.editModal.title')}</H1>
+        <Text role="alert" color="$red10">
+          {t('journal.dose.resolveModal.missingPair')}
+        </Text>
+        <Button onPress={() => router.push('/journal')}>
+          {t('journal.dose.resolveModal.back')}
+        </Button>
+      </YStack>
+    );
+  }
+
+  const verdict = canEditDose({
+    dose: {
+      recordedByDeviceId: dose.deviceId,
+      administeredAtMs: dose.administeredAtMs,
+      status: dose.status,
+    },
+    currentDeviceId: deviceId,
+    currentRole,
+    nowMs: Date.now(),
+  });
+
+  if (!verdict.allowed) {
+    const refusalKey =
+      verdict.reason === 'voided'
+        ? 'journal.dose.editPermission.voided'
+        : verdict.reason === 'pending_review'
+          ? 'journal.dose.editPermission.pendingReview'
+          : verdict.reason === 'restricted_role'
+            ? 'journal.dose.editPermission.restrictedRole'
+            : 'journal.dose.editPermission.tooEarly';
+    return (
+      <YStack padding="$4" gap="$4">
+        <H1>{t('journal.dose.editModal.title')}</H1>
+        <Text role="alert" color="$orange11">
+          {t(refusalKey)}
+        </Text>
+        {verdict.reason === 'not_author_and_too_old' && (
+          <Text color="$color10">{t('journal.dose.editPermission.adminOnly')}</Text>
+        )}
+        <Button onPress={() => router.push('/journal')}>
+          {t('journal.dose.resolveModal.back')}
+        </Button>
+      </YStack>
+    );
+  }
+
+  const requiresReason = verdict.requiresReason;
+
+  const handleSubmit = async (): Promise<void> => {
+    setError(null);
+
+    const dosesNumber = Number(dosesValue);
+    if (!Number.isFinite(dosesNumber) || dosesNumber < 0) {
+      setError(t('journal.dose.editModal.saveError'));
+      return;
+    }
+    const adminAtNumber = Number(administeredAtMs);
+    if (!Number.isFinite(adminAtNumber)) {
+      setError(t('journal.dose.editModal.saveError'));
+      return;
+    }
+    const trimmedReason = reason.trim();
+    if (requiresReason && trimmedReason.length === 0) {
+      setError(t('journal.dose.editModal.reasonRequired'));
+      return;
+    }
+    if (trimmedReason.length > VOIDED_REASON_MAX_LENGTH) {
+      setError(t('journal.dose.editModal.reasonTooLong'));
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const kp = await getOrCreateDevice();
+      const payload: DoseEditedPayload = {
+        doseId: dose.doseId,
+        patch: {
+          administeredAtMs: adminAtNumber,
+          dosesAdministered: dosesNumber,
+          symptoms,
+        },
+        editedByDeviceId: deviceId,
+        editedAtMs: Date.now(),
+        ...(trimmedReason.length > 0 ? { reason: trimmedReason } : {}),
+      };
+      const changes = await appendDoseEdit(payload, deviceId, kp.secretKey);
+      if (groupKey !== null) {
+        await sendChanges(changes, groupKey);
+      }
+      router.push('/journal');
+    } catch {
+      setError(t('journal.dose.editModal.saveError'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1>{t('journal.dose.editModal.title')}</H1>
+
+      <Text fontWeight="600">{t('journal.dose.editModal.administeredAtLabel')}</Text>
+      <Input
+        value={administeredAtMs}
+        onChangeText={setAdministeredAtMs}
+        keyboardType="numeric"
+        testID="edit-administered-at"
+      />
+
+      <Text fontWeight="600">{t('journal.dose.editModal.dosesLabel')}</Text>
+      <Input
+        value={dosesValue}
+        onChangeText={setDosesValue}
+        keyboardType="numeric"
+        testID="edit-doses"
+      />
+
+      <Text fontWeight="600">{t('journal.dose.editModal.symptomsLabel')}</Text>
+      <XStack flexWrap="wrap" gap="$2">
+        {SYMPTOMS.map((s) => (
+          <Button
+            key={s}
+            size="$3"
+            onPress={() =>
+              setSymptoms((prev) => (prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]))
+            }
+            backgroundColor={symptoms.includes(s) ? '$blue9' : '$backgroundHover'}
+            color={symptoms.includes(s) ? 'white' : '$color'}
+            borderWidth={1}
+            borderColor={symptoms.includes(s) ? '$blue10' : '$borderColor'}
+          >
+            {t(`journal.symptom.${s}`)}
+          </Button>
+        ))}
+      </XStack>
+
+      {requiresReason && (
+        <>
+          <Text fontWeight="600">{t('journal.dose.editModal.reasonLabel')}</Text>
+          <Input
+            value={reason}
+            onChangeText={setReason}
+            placeholder={t('journal.dose.editModal.reasonPlaceholder')}
+            testID="edit-reason"
+          />
+        </>
+      )}
+
+      {error !== null && (
+        <Text role="alert" color="$red10">
+          {error}
+        </Text>
+      )}
+
+      <XStack gap="$2">
+        <Button flex={1} onPress={() => router.push('/journal')} theme="gray" testID="edit-cancel">
+          {t('journal.dose.editModal.cancel')}
+        </Button>
+        <Button
+          flex={1}
+          onPress={() => void handleSubmit()}
+          disabled={loading}
+          testID="edit-submit"
+        >
+          {loading ? t('journal.saving') : t('journal.dose.editModal.submit')}
+        </Button>
+      </XStack>
+    </YStack>
+  );
+}

--- a/apps/web/src/app/journal/edit/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/edit/__tests__/page.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { screen, waitFor, fireEvent, act } from '@testing-library/react';
+import EditDosePage from '../[doseId]/page';
+import { renderWithProviders } from '../../../../test-utils/render';
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  useParams: () => ({ doseId: 'dose-A' }),
+}));
+
+jest.mock('../../../../stores/auth-store', () => ({
+  useAuthStore: jest.fn(
+    (
+      selector: (s: {
+        accessToken: string | null;
+        deviceId: string | null;
+        householdId: string | null;
+      }) => unknown,
+    ) => selector({ accessToken: 'tok', deviceId: 'dev-author', householdId: 'hh-1' }),
+  ),
+}));
+
+jest.mock('../../../../lib/useRequireAuth', () => ({
+  useRequireAuth: () => true,
+}));
+
+jest.mock('../../../../lib/device', () => ({
+  getOrCreateDevice: jest.fn().mockResolvedValue({
+    publicKey: new Uint8Array(32),
+    secretKey: new Uint8Array(64),
+    publicKeyHex: 'a'.repeat(64),
+  }),
+  getGroupKey: jest.fn().mockResolvedValue(new Uint8Array(32)),
+}));
+
+const mockSendChanges = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../../hooks/use-relay', () => ({
+  useRelay: () => ({ sendChanges: mockSendChanges }),
+}));
+
+interface TestDose {
+  doseId: string;
+  pumpId: string;
+  childId: string;
+  caregiverId: string;
+  administeredAtMs: number;
+  doseType: 'maintenance' | 'rescue';
+  dosesAdministered: number;
+  symptoms: ReadonlyArray<string>;
+  circumstances: ReadonlyArray<string>;
+  freeFormTag: string | null;
+  eventId: string;
+  occurredAtMs: number;
+  deviceId: string;
+  status: 'recorded' | 'pending_review' | 'voided';
+}
+
+let mockDoses: TestDose[] = [];
+jest.mock('@kinhale/sync', () => ({
+  projectDoses: () => mockDoses,
+  projectCaregivers: () => [],
+  VOIDED_REASON_MAX_LENGTH: 200,
+}));
+
+const mockAppendDoseEdit = jest.fn().mockResolvedValue([new Uint8Array([1])]);
+jest.mock('../../../../stores/doc-store', () => ({
+  useDocStore: jest.fn((selector: (s: { appendDoseEdit: jest.Mock; doc: object }) => unknown) =>
+    selector({ appendDoseEdit: mockAppendDoseEdit, doc: { events: [] } }),
+  ),
+}));
+
+const NOW = 1_700_000_000_000;
+
+beforeEach(() => {
+  jest.spyOn(Date, 'now').mockReturnValue(NOW);
+  mockAppendDoseEdit.mockClear();
+  mockSendChanges.mockClear();
+  mockPush.mockClear();
+  mockReplace.mockClear();
+  mockDoses = [
+    {
+      doseId: 'dose-A',
+      pumpId: 'pump-1',
+      childId: 'child-1',
+      caregiverId: 'dev-author',
+      administeredAtMs: NOW - 5 * 60_000, // 5 min before now → editable
+      doseType: 'maintenance',
+      dosesAdministered: 1,
+      symptoms: [],
+      circumstances: [],
+      freeFormTag: null,
+      eventId: 'evt-1',
+      occurredAtMs: NOW - 5 * 60_000,
+      deviceId: 'dev-author',
+      status: 'recorded',
+    },
+  ];
+});
+
+describe('EditDosePage', () => {
+  it("refuse l'édition pour un contributor non-auteur > 30 min", async () => {
+    mockDoses = [
+      {
+        ...mockDoses[0]!,
+        deviceId: 'dev-other',
+        administeredAtMs: NOW - 60 * 60_000,
+        occurredAtMs: NOW - 60 * 60_000,
+      },
+    ];
+    renderWithProviders(<EditDosePage />);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  it("autorise l'édition de l'auteur dans les 30 minutes", async () => {
+    renderWithProviders(<EditDosePage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-submit')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('edit-reason')).not.toBeInTheDocument();
+  });
+
+  it('appendDoseEdit appelé avec les patches au submit', async () => {
+    renderWithProviders(<EditDosePage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('edit-submit')).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('edit-submit'));
+    });
+    await waitFor(() => {
+      expect(mockAppendDoseEdit).toHaveBeenCalledTimes(1);
+    });
+    const call = mockAppendDoseEdit.mock.calls[0]?.[0] as {
+      doseId: string;
+      patch: { dosesAdministered?: number };
+      editedByDeviceId: string;
+    };
+    expect(call.doseId).toBe('dose-A');
+    expect(call.editedByDeviceId).toBe('dev-author');
+  });
+
+  it("affiche un champ raison obligatoire pour Admin > 30 min (refus en l'état contributor)", async () => {
+    mockDoses = [
+      {
+        ...mockDoses[0]!,
+        administeredAtMs: NOW - 60 * 60_000,
+        occurredAtMs: NOW - 60 * 60_000,
+        deviceId: 'dev-author', // auteur
+      },
+    ];
+    // contributor non-admin → refus (cas hors fenêtre, non-Admin)
+    renderWithProviders(<EditDosePage />);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/app/journal/page.tsx
+++ b/apps/web/src/app/journal/page.tsx
@@ -4,15 +4,36 @@ import React, { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { YStack, H1, Text, Button, XStack } from 'tamagui';
-import { projectDoses } from '@kinhale/sync';
+import { projectDoses, projectCaregivers, type ProjectedDose } from '@kinhale/sync';
+import { canEditDose } from '@kinhale/domain/entities';
+import type { Role } from '@kinhale/domain/entities';
 import { useAuthStore } from '../../stores/auth-store';
 import { useDocStore } from '../../stores/doc-store';
+
+/**
+ * Détermine le rôle de l'aidant courant depuis la projection des aidants
+ * du foyer. Retombe sur `'contributor'` par défaut tant que l'aidant n'est
+ * pas associé à un device dans la projection (cas d'amorçage).
+ */
+function deriveCurrentRole(
+  caregivers: ReadonlyArray<{ caregiverId: string; role: string }>,
+  deviceId: string | null,
+): Role {
+  if (deviceId === null) return 'contributor';
+  const me = caregivers.find((c) => c.caregiverId === deviceId);
+  if (me === undefined) return 'contributor';
+  if (me.role === 'admin' || me.role === 'restricted_contributor' || me.role === 'contributor') {
+    return me.role;
+  }
+  return 'contributor';
+}
 
 export default function JournalPage(): React.JSX.Element {
   const { t } = useTranslation('common');
   const router = useRouter();
   const accessToken = useAuthStore((s) => s.accessToken);
   const householdId = useAuthStore((s) => s.householdId);
+  const deviceId = useAuthStore((s) => s.deviceId);
   const doc = useDocStore((s) => s.doc);
   const initDoc = useDocStore((s) => s.initDoc);
 
@@ -27,6 +48,9 @@ export default function JournalPage(): React.JSX.Element {
   }, [accessToken, householdId, initDoc, router]);
 
   const doses = doc !== null ? projectDoses(doc) : [];
+  const caregivers = doc !== null ? projectCaregivers(doc) : [];
+  const currentRole = deriveCurrentRole(caregivers, deviceId);
+  const nowMs = Date.now();
 
   return (
     <YStack padding="$4" gap="$4">
@@ -46,46 +70,143 @@ export default function JournalPage(): React.JSX.Element {
         </Button>
       </XStack>
       {doses.length === 0 && <Text color="$color10">{t('journal.empty')}</Text>}
-      {doses.map((dose) => (
-        <YStack
-          key={dose.eventId}
-          padding="$3"
-          borderWidth={1}
-          borderColor="$borderColor"
-          borderRadius="$3"
-          gap="$2"
-        >
-          <XStack justifyContent="space-between" alignItems="center">
-            <Text fontSize="$4" fontWeight="700">
-              {dose.doseType === 'rescue' ? t('journal.rescue') : t('journal.maintenance')}
-            </Text>
-            <Text fontSize="$2" color="$color9">
-              {new Date(dose.administeredAtMs).toLocaleString()}
-            </Text>
-          </XStack>
-
-          {dose.symptoms.length > 0 && (
-            <Text fontSize="$3" color="$color10">
-              {dose.symptoms.map((s) => t(`journal.symptom.${s}`)).join(' · ')}
-            </Text>
-          )}
-
-          {dose.circumstances.length > 0 && (
-            <Text fontSize="$3" color="$color10">
-              {dose.circumstances.map((c) => t(`journal.circumstance.${c}`)).join(' · ')}
-            </Text>
-          )}
-
-          {dose.freeFormTag !== null && (
-            <Text fontSize="$3" color="$color9" fontStyle="italic">
-              {dose.freeFormTag}
-            </Text>
-          )}
-        </YStack>
-      ))}
+      {doses.map((dose) => {
+        const isVoided = dose.status === 'voided';
+        const isPendingReview = dose.status === 'pending_review';
+        const editVerdict = canEditDose({
+          dose: {
+            recordedByDeviceId: dose.deviceId,
+            administeredAtMs: dose.administeredAtMs,
+            status: dose.status,
+          },
+          currentDeviceId: deviceId ?? '',
+          currentRole,
+          nowMs,
+        });
+        return (
+          <DoseCard
+            key={dose.eventId}
+            dose={dose}
+            isVoided={isVoided}
+            isPendingReview={isPendingReview}
+            canEdit={editVerdict.allowed}
+            t={t}
+            onEdit={() => router.push(`/journal/edit/${dose.doseId}`)}
+            onVoid={() => router.push(`/journal/void/${dose.doseId}`)}
+            onResolve={() => router.push(`/journal/resolve/${dose.doseId}`)}
+          />
+        );
+      })}
       <Button onPress={() => router.push('/journal/add')} marginTop="$2">
         {t('journal.addDose')}
       </Button>
+    </YStack>
+  );
+}
+
+interface DoseCardProps {
+  readonly dose: ProjectedDose;
+  readonly isVoided: boolean;
+  readonly isPendingReview: boolean;
+  readonly canEdit: boolean;
+  readonly t: (key: string) => string;
+  readonly onEdit: () => void;
+  readonly onVoid: () => void;
+  readonly onResolve: () => void;
+}
+
+function DoseCard({
+  dose,
+  isVoided,
+  isPendingReview,
+  canEdit,
+  t,
+  onEdit,
+  onVoid,
+  onResolve,
+}: DoseCardProps): React.JSX.Element {
+  const labelKey = dose.doseType === 'rescue' ? 'journal.rescue' : 'journal.maintenance';
+  const reasonLabel =
+    isVoided && dose.voidedReason !== undefined && dose.voidedReason === 'duplicate_resolved'
+      ? t('journal.dose.voidedReason.duplicate_resolved')
+      : (dose.voidedReason ?? '');
+  return (
+    <YStack
+      data-testid={`dose-card-${dose.doseId}`}
+      padding="$3"
+      borderWidth={1}
+      borderColor={isPendingReview ? '$orange8' : '$borderColor'}
+      borderRadius="$3"
+      gap="$2"
+      opacity={isVoided ? 0.55 : 1}
+      backgroundColor={isPendingReview ? '$orange3' : '$background'}
+    >
+      <XStack justifyContent="space-between" alignItems="center">
+        <Text
+          fontSize="$4"
+          fontWeight="700"
+          textDecorationLine={isVoided ? 'line-through' : 'none'}
+        >
+          {t(labelKey)}
+        </Text>
+        <Text fontSize="$2" color="$color9">
+          {new Date(dose.administeredAtMs).toLocaleString()}
+        </Text>
+      </XStack>
+
+      {isVoided && (
+        <Text fontSize="$2" color="$color10" fontWeight="600">
+          {t('journal.dose.voidedBadge')}
+          {reasonLabel.length > 0 && ` · ${t('journal.dose.voidedReason.label')} : ${reasonLabel}`}
+        </Text>
+      )}
+
+      {isPendingReview && (
+        <Text fontSize="$2" color="$orange11" fontWeight="600">
+          {t('journal.dose.pendingReviewBadge')}
+        </Text>
+      )}
+
+      {dose.symptoms.length > 0 && (
+        <Text fontSize="$3" color="$color10">
+          {dose.symptoms.map((s) => t(`journal.symptom.${s}`)).join(' · ')}
+        </Text>
+      )}
+
+      {dose.circumstances.length > 0 && (
+        <Text fontSize="$3" color="$color10">
+          {dose.circumstances.map((c) => t(`journal.circumstance.${c}`)).join(' · ')}
+        </Text>
+      )}
+
+      {dose.freeFormTag !== null && (
+        <Text fontSize="$3" color="$color9" fontStyle="italic">
+          {dose.freeFormTag}
+        </Text>
+      )}
+
+      {!isVoided && (
+        <XStack gap="$2" flexWrap="wrap" marginTop="$2">
+          {canEdit && (
+            <Button size="$2" onPress={onEdit} testID={`dose-edit-${dose.doseId}`}>
+              {t('journal.dose.actions.edit')}
+            </Button>
+          )}
+          <Button size="$2" onPress={onVoid} theme="red" testID={`dose-void-${dose.doseId}`}>
+            {t('journal.dose.actions.void')}
+          </Button>
+          {isPendingReview && (
+            <Button
+              size="$2"
+              onPress={onResolve}
+              theme="orange"
+              testID={`dose-resolve-${dose.doseId}`}
+            >
+              {t('journal.dose.actions.resolve')}
+            </Button>
+          )}
+        </XStack>
+      )}
     </YStack>
   );
 }

--- a/apps/web/src/app/journal/resolve/[doseId]/page.tsx
+++ b/apps/web/src/app/journal/resolve/[doseId]/page.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { YStack, H1, Button, Text, XStack } from 'tamagui';
+import {
+  projectCaregivers,
+  projectDoses,
+  VOIDED_REASON_DUPLICATE_RESOLVED,
+  type DoseReviewFlaggedPayload,
+  type DoseVoidedPayload,
+  type ProjectedDose,
+} from '@kinhale/sync';
+import { useAuthStore } from '../../../../stores/auth-store';
+import { useDocStore } from '../../../../stores/doc-store';
+import { getOrCreateDevice, getGroupKey } from '../../../../lib/device';
+import { useRelay } from '../../../../hooks/use-relay';
+import { useRequireAuth } from '../../../../lib/useRequireAuth';
+
+/**
+ * Cherche dans les événements `DoseReviewFlagged` la paire qui contient
+ * `doseId`. Renvoie l'autre `doseId` du conflit ou `null`.
+ *
+ * Une dose peut figurer dans plusieurs paires (rare mais possible) — on
+ * retourne la première trouvée. Une amélioration future pourrait afficher
+ * une liste de choix si plus de deux doses sont impliquées.
+ */
+function findConflictPartner(
+  doc: { events: ReadonlyArray<{ type: string; payloadJson: string }> } | null,
+  doseId: string,
+): string | null {
+  if (doc === null) return null;
+  for (const event of doc.events) {
+    if (event.type !== 'DoseReviewFlagged') continue;
+    let payload: DoseReviewFlaggedPayload;
+    try {
+      payload = JSON.parse(event.payloadJson) as DoseReviewFlaggedPayload;
+    } catch {
+      continue;
+    }
+    if (!Array.isArray(payload.doseIds) || payload.doseIds.length < 2) continue;
+    const [a, b] = payload.doseIds;
+    if (a === doseId && typeof b === 'string') return b;
+    if (b === doseId && typeof a === 'string') return a;
+  }
+  return null;
+}
+
+export default function ResolveConflictPage(): React.JSX.Element | null {
+  const { t } = useTranslation('common');
+  const router = useRouter();
+  const params = useParams<{ doseId: string }>();
+  const doseId = params?.doseId ?? '';
+  const authenticated = useRequireAuth();
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const deviceId = useAuthStore((s) => s.deviceId) ?? '';
+  const householdId = useAuthStore((s) => s.householdId) ?? '';
+  const doc = useDocStore((s) => s.doc);
+  const appendDoseVoid = useDocStore((s) => s.appendDoseVoid);
+
+  const [groupKey, setGroupKey] = useState<Uint8Array | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const doses = useMemo(() => (doc !== null ? projectDoses(doc) : []), [doc]);
+  const caregivers = useMemo(() => (doc !== null ? projectCaregivers(doc) : []), [doc]);
+  const dose = doses.find((d) => d.doseId === doseId) ?? null;
+  const partnerId = findConflictPartner(doc, doseId);
+  const partner = partnerId === null ? null : (doses.find((d) => d.doseId === partnerId) ?? null);
+
+  // Mapping `caregiverId → displayName`. Hypothèse v1.0 :
+  // caregiverId === deviceId (1 device par aidant). Si le mapping échoue,
+  // on affiche un fallback opaque (4 derniers chars de l'identifiant).
+  const caregiverNameByCaregiverId = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const c of caregivers) m.set(c.caregiverId, c.displayName);
+    return m;
+  }, [caregivers]);
+  const resolveCaregiverName = (deviceId: string): string => {
+    const name = caregiverNameByCaregiverId.get(deviceId);
+    if (name !== undefined) return name;
+    return t('journal.dose.unknownCaregiver', { id: deviceId.slice(-4) });
+  };
+
+  useEffect(() => {
+    if (householdId !== '') {
+      getGroupKey(householdId)
+        .then(setGroupKey)
+        .catch(() => undefined);
+    }
+  }, [householdId]);
+
+  const { sendChanges } = useRelay(accessToken, groupKey);
+
+  if (!authenticated) return null;
+  if (dose === null || partner === null) {
+    return (
+      <YStack padding="$4" gap="$4">
+        <H1>{t('journal.dose.resolveModal.title')}</H1>
+        <Text role="alert" color="$red10">
+          {t('journal.dose.resolveModal.missingPair')}
+        </Text>
+        <Button onPress={() => router.push('/journal')}>
+          {t('journal.dose.resolveModal.back')}
+        </Button>
+      </YStack>
+    );
+  }
+
+  const handleKeep = async (kept: ProjectedDose, voided: ProjectedDose): Promise<void> => {
+    setError(null);
+    setLoading(true);
+    try {
+      const kp = await getOrCreateDevice();
+      const payload: DoseVoidedPayload = {
+        doseId: voided.doseId,
+        voidedByDeviceId: deviceId,
+        voidedAtMs: Date.now(),
+        voidedReason: VOIDED_REASON_DUPLICATE_RESOLVED,
+      };
+      const changes = await appendDoseVoid(payload, deviceId, kp.secretKey);
+      if (groupKey !== null) {
+        await sendChanges(changes, groupKey);
+      }
+      // `kept` reste tel quel — la projection cessera de la flagger
+      // `pending_review` dès que toutes les doses du flag seront soit
+      // résolues soit voidées (l'autre est désormais voidée).
+      void kept;
+      router.push('/journal');
+    } catch {
+      setError(t('journal.dose.resolveModal.saveError'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1>{t('journal.dose.resolveModal.title')}</H1>
+      <Text color="$color10">{t('journal.dose.resolveModal.intro')}</Text>
+
+      <XStack gap="$3" flexWrap="wrap">
+        <DosePane
+          dose={dose}
+          caregiverName={resolveCaregiverName(dose.deviceId)}
+          t={t}
+          onKeep={() => void handleKeep(dose, partner)}
+          loading={loading}
+          testID={`resolve-keep-${dose.doseId}`}
+        />
+        <DosePane
+          dose={partner}
+          caregiverName={resolveCaregiverName(partner.deviceId)}
+          t={t}
+          onKeep={() => void handleKeep(partner, dose)}
+          loading={loading}
+          testID={`resolve-keep-${partner.doseId}`}
+        />
+      </XStack>
+
+      {error !== null && (
+        <Text role="alert" color="$red10">
+          {error}
+        </Text>
+      )}
+
+      <Button onPress={() => router.push('/journal')} theme="gray">
+        {t('journal.dose.resolveModal.back')}
+      </Button>
+    </YStack>
+  );
+}
+
+interface DosePaneProps {
+  readonly dose: ProjectedDose;
+  readonly caregiverName: string;
+  readonly t: (key: string) => string;
+  readonly onKeep: () => void;
+  readonly loading: boolean;
+  readonly testID: string;
+}
+
+function DosePane({
+  dose,
+  caregiverName,
+  t,
+  onKeep,
+  loading,
+  testID,
+}: DosePaneProps): React.JSX.Element {
+  const labelKey = dose.doseType === 'rescue' ? 'journal.rescue' : 'journal.maintenance';
+  return (
+    <YStack
+      flex={1}
+      minWidth={240}
+      padding="$3"
+      borderWidth={1}
+      borderColor="$borderColor"
+      borderRadius="$3"
+      gap="$2"
+    >
+      <Text fontSize="$4" fontWeight="700">
+        {t(labelKey)}
+      </Text>
+      <Text fontSize="$2" color="$color9">
+        {new Date(dose.administeredAtMs).toLocaleString()}
+      </Text>
+      <Text fontSize="$3">{`${t('journal.dose.editModal.dosesLabel')} : ${String(dose.dosesAdministered)}`}</Text>
+      <Text fontSize="$2" color="$color10">
+        {`${t('journal.dose.caregiverLabel')} : ${caregiverName}`}
+      </Text>
+      <Button onPress={onKeep} disabled={loading} testID={testID}>
+        {t('journal.dose.resolveModal.keepThis')}
+      </Button>
+    </YStack>
+  );
+}

--- a/apps/web/src/app/journal/resolve/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/resolve/__tests__/page.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { screen, waitFor, fireEvent, act } from '@testing-library/react';
+import ResolveConflictPage from '../[doseId]/page';
+import { renderWithProviders } from '../../../../test-utils/render';
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  useParams: () => ({ doseId: 'dose-A' }),
+}));
+
+jest.mock('../../../../stores/auth-store', () => ({
+  useAuthStore: jest.fn(
+    (
+      selector: (s: {
+        accessToken: string | null;
+        deviceId: string | null;
+        householdId: string | null;
+      }) => unknown,
+    ) => selector({ accessToken: 'tok', deviceId: 'dev-1', householdId: 'hh-1' }),
+  ),
+}));
+
+jest.mock('../../../../lib/useRequireAuth', () => ({
+  useRequireAuth: () => true,
+}));
+
+jest.mock('../../../../lib/device', () => ({
+  getOrCreateDevice: jest.fn().mockResolvedValue({
+    publicKey: new Uint8Array(32),
+    secretKey: new Uint8Array(64),
+    publicKeyHex: 'a'.repeat(64),
+  }),
+  getGroupKey: jest.fn().mockResolvedValue(new Uint8Array(32)),
+}));
+
+const mockSendChanges = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../../hooks/use-relay', () => ({
+  useRelay: () => ({ sendChanges: mockSendChanges }),
+}));
+
+interface TestDose {
+  doseId: string;
+  pumpId: string;
+  childId: string;
+  caregiverId: string;
+  administeredAtMs: number;
+  doseType: 'maintenance' | 'rescue';
+  dosesAdministered: number;
+  symptoms: ReadonlyArray<string>;
+  circumstances: ReadonlyArray<string>;
+  freeFormTag: string | null;
+  eventId: string;
+  occurredAtMs: number;
+  deviceId: string;
+  status: 'recorded' | 'pending_review' | 'voided';
+}
+
+let mockDoses: TestDose[] = [];
+let mockEvents: ReadonlyArray<{ type: string; payloadJson: string }> = [];
+jest.mock('@kinhale/sync', () => ({
+  projectDoses: () => mockDoses,
+  projectCaregivers: () => [],
+  VOIDED_REASON_DUPLICATE_RESOLVED: 'duplicate_resolved',
+}));
+
+const mockAppendDoseVoid = jest.fn().mockResolvedValue([new Uint8Array([1])]);
+jest.mock('../../../../stores/doc-store', () => ({
+  useDocStore: jest.fn((selector: (s: { appendDoseVoid: jest.Mock; doc: object }) => unknown) =>
+    selector({ appendDoseVoid: mockAppendDoseVoid, doc: { events: mockEvents } }),
+  ),
+}));
+
+const baseDose = (overrides: Partial<TestDose> = {}): TestDose => ({
+  doseId: 'dose-A',
+  pumpId: 'pump-1',
+  childId: 'child-1',
+  caregiverId: 'dev-1',
+  administeredAtMs: 1_000_000,
+  doseType: 'maintenance',
+  dosesAdministered: 1,
+  symptoms: [],
+  circumstances: [],
+  freeFormTag: null,
+  eventId: 'evt-A',
+  occurredAtMs: 1_000_000,
+  deviceId: 'dev-1',
+  status: 'pending_review',
+  ...overrides,
+});
+
+beforeEach(() => {
+  mockAppendDoseVoid.mockClear();
+  mockDoses = [
+    baseDose({ doseId: 'dose-A', eventId: 'evt-A' }),
+    baseDose({ doseId: 'dose-B', eventId: 'evt-B', administeredAtMs: 1_060_000 }),
+  ];
+  mockEvents = [
+    {
+      type: 'DoseReviewFlagged',
+      payloadJson: JSON.stringify({
+        flagId: 'flag-1',
+        doseIds: ['dose-A', 'dose-B'],
+        detectedAtMs: 2_000_000,
+      }),
+    },
+  ];
+});
+
+describe('ResolveConflictPage', () => {
+  it('affiche les deux doses du conflit', () => {
+    renderWithProviders(<ResolveConflictPage />);
+    expect(screen.getByTestId('resolve-keep-dose-A')).toBeInTheDocument();
+    expect(screen.getByTestId('resolve-keep-dose-B')).toBeInTheDocument();
+  });
+
+  it('garde dose-A et void dose-B avec voidedReason="duplicate_resolved"', async () => {
+    renderWithProviders(<ResolveConflictPage />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('resolve-keep-dose-A'));
+    });
+    await waitFor(() => {
+      expect(mockAppendDoseVoid).toHaveBeenCalledTimes(1);
+    });
+    const call = mockAppendDoseVoid.mock.calls[0]?.[0] as {
+      doseId: string;
+      voidedReason: string;
+    };
+    expect(call.doseId).toBe('dose-B');
+    expect(call.voidedReason).toBe('duplicate_resolved');
+  });
+
+  it('garde dose-B et void dose-A symétriquement', async () => {
+    renderWithProviders(<ResolveConflictPage />);
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('resolve-keep-dose-B'));
+    });
+    await waitFor(() => {
+      expect(mockAppendDoseVoid).toHaveBeenCalledTimes(1);
+    });
+    const call = mockAppendDoseVoid.mock.calls[0]?.[0] as { doseId: string };
+    expect(call.doseId).toBe('dose-A');
+  });
+
+  it("affiche missingPair si l'événement DoseReviewFlagged n'existe pas", () => {
+    mockEvents = [];
+    renderWithProviders(<ResolveConflictPage />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/journal/void/[doseId]/page.tsx
+++ b/apps/web/src/app/journal/void/[doseId]/page.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { YStack, H1, Button, Text, XStack, Input } from 'tamagui';
+import {
+  projectDoses,
+  VOIDED_REASON_MAX_LENGTH,
+  type DoseVoidedPayload,
+  type ProjectedDose,
+} from '@kinhale/sync';
+import { useAuthStore } from '../../../../stores/auth-store';
+import { useDocStore } from '../../../../stores/doc-store';
+import { getOrCreateDevice, getGroupKey } from '../../../../lib/device';
+import { useRelay } from '../../../../hooks/use-relay';
+import { useRequireAuth } from '../../../../lib/useRequireAuth';
+
+export default function VoidDosePage(): React.JSX.Element | null {
+  const { t } = useTranslation('common');
+  const router = useRouter();
+  const params = useParams<{ doseId: string }>();
+  const doseId = params?.doseId ?? '';
+  const authenticated = useRequireAuth();
+  const accessToken = useAuthStore((s) => s.accessToken);
+  const deviceId = useAuthStore((s) => s.deviceId) ?? '';
+  const householdId = useAuthStore((s) => s.householdId) ?? '';
+  const doc = useDocStore((s) => s.doc);
+  const appendDoseVoid = useDocStore((s) => s.appendDoseVoid);
+
+  const [groupKey, setGroupKey] = useState<Uint8Array | null>(null);
+  const [reason, setReason] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const dose: ProjectedDose | null = useMemo(() => {
+    if (doc === null) return null;
+    return projectDoses(doc).find((d) => d.doseId === doseId) ?? null;
+  }, [doc, doseId]);
+
+  useEffect(() => {
+    if (householdId !== '') {
+      getGroupKey(householdId)
+        .then(setGroupKey)
+        .catch(() => undefined);
+    }
+  }, [householdId]);
+
+  const { sendChanges } = useRelay(accessToken, groupKey);
+
+  if (!authenticated) return null;
+  if (dose === null || dose.status === 'voided') {
+    return (
+      <YStack padding="$4" gap="$4">
+        <H1>{t('journal.dose.voidModal.title')}</H1>
+        <Text role="alert" color="$red10">
+          {t('journal.dose.editPermission.voided')}
+        </Text>
+        <Button onPress={() => router.push('/journal')}>
+          {t('journal.dose.resolveModal.back')}
+        </Button>
+      </YStack>
+    );
+  }
+
+  const handleSubmit = async (): Promise<void> => {
+    setError(null);
+    const trimmed = reason.trim();
+    if (trimmed.length === 0) {
+      setError(t('journal.dose.voidModal.reasonRequired'));
+      return;
+    }
+    if (trimmed.length > VOIDED_REASON_MAX_LENGTH) {
+      setError(t('journal.dose.voidModal.reasonTooLong'));
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const kp = await getOrCreateDevice();
+      const payload: DoseVoidedPayload = {
+        doseId: dose.doseId,
+        voidedByDeviceId: deviceId,
+        voidedAtMs: Date.now(),
+        voidedReason: trimmed,
+      };
+      const changes = await appendDoseVoid(payload, deviceId, kp.secretKey);
+      if (groupKey !== null) {
+        await sendChanges(changes, groupKey);
+      }
+      router.push('/journal');
+    } catch {
+      setError(t('journal.dose.voidModal.saveError'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <YStack padding="$4" gap="$4">
+      <H1>{t('journal.dose.voidModal.title')}</H1>
+      <Text color="$color10">{t('journal.dose.voidModal.warning')}</Text>
+
+      <Text fontWeight="600">{t('journal.dose.voidModal.reasonLabel')}</Text>
+      <Input
+        value={reason}
+        onChangeText={setReason}
+        placeholder={t('journal.dose.voidModal.reasonPlaceholder')}
+        testID="void-reason"
+      />
+
+      {error !== null && (
+        <Text role="alert" color="$red10">
+          {error}
+        </Text>
+      )}
+
+      <XStack gap="$2">
+        <Button flex={1} onPress={() => router.push('/journal')} theme="gray" testID="void-cancel">
+          {t('journal.dose.voidModal.cancel')}
+        </Button>
+        <Button
+          flex={1}
+          onPress={() => void handleSubmit()}
+          disabled={loading}
+          theme="red"
+          testID="void-submit"
+        >
+          {loading ? t('journal.saving') : t('journal.dose.voidModal.submit')}
+        </Button>
+      </XStack>
+    </YStack>
+  );
+}

--- a/apps/web/src/app/journal/void/__tests__/page.test.tsx
+++ b/apps/web/src/app/journal/void/__tests__/page.test.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { screen, waitFor, fireEvent, act } from '@testing-library/react';
+import VoidDosePage from '../[doseId]/page';
+import { renderWithProviders } from '../../../../test-utils/render';
+
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  useParams: () => ({ doseId: 'dose-A' }),
+}));
+
+jest.mock('../../../../stores/auth-store', () => ({
+  useAuthStore: jest.fn(
+    (
+      selector: (s: {
+        accessToken: string | null;
+        deviceId: string | null;
+        householdId: string | null;
+      }) => unknown,
+    ) => selector({ accessToken: 'tok', deviceId: 'dev-1', householdId: 'hh-1' }),
+  ),
+}));
+
+jest.mock('../../../../lib/useRequireAuth', () => ({
+  useRequireAuth: () => true,
+}));
+
+jest.mock('../../../../lib/device', () => ({
+  getOrCreateDevice: jest.fn().mockResolvedValue({
+    publicKey: new Uint8Array(32),
+    secretKey: new Uint8Array(64),
+    publicKeyHex: 'a'.repeat(64),
+  }),
+  getGroupKey: jest.fn().mockResolvedValue(new Uint8Array(32)),
+}));
+
+const mockSendChanges = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../../../hooks/use-relay', () => ({
+  useRelay: () => ({ sendChanges: mockSendChanges }),
+}));
+
+interface TestDose {
+  doseId: string;
+  pumpId: string;
+  childId: string;
+  caregiverId: string;
+  administeredAtMs: number;
+  doseType: 'maintenance' | 'rescue';
+  dosesAdministered: number;
+  symptoms: ReadonlyArray<string>;
+  circumstances: ReadonlyArray<string>;
+  freeFormTag: string | null;
+  eventId: string;
+  occurredAtMs: number;
+  deviceId: string;
+  status: 'recorded' | 'pending_review' | 'voided';
+}
+
+let mockDoses: TestDose[] = [];
+jest.mock('@kinhale/sync', () => ({
+  projectDoses: () => mockDoses,
+  VOIDED_REASON_MAX_LENGTH: 200,
+}));
+
+const mockAppendDoseVoid = jest.fn().mockResolvedValue([new Uint8Array([1])]);
+jest.mock('../../../../stores/doc-store', () => ({
+  useDocStore: jest.fn((selector: (s: { appendDoseVoid: jest.Mock; doc: object }) => unknown) =>
+    selector({ appendDoseVoid: mockAppendDoseVoid, doc: { events: [] } }),
+  ),
+}));
+
+beforeEach(() => {
+  mockAppendDoseVoid.mockClear();
+  mockDoses = [
+    {
+      doseId: 'dose-A',
+      pumpId: 'pump-1',
+      childId: 'child-1',
+      caregiverId: 'dev-1',
+      administeredAtMs: 1_000_000,
+      doseType: 'maintenance',
+      dosesAdministered: 1,
+      symptoms: [],
+      circumstances: [],
+      freeFormTag: null,
+      eventId: 'evt-1',
+      occurredAtMs: 1_000_000,
+      deviceId: 'dev-1',
+      status: 'recorded',
+    },
+  ];
+});
+
+describe('VoidDosePage', () => {
+  it('refuse de poster sans raison', async () => {
+    renderWithProviders(<VoidDosePage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('void-submit')).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('void-submit'));
+    });
+    expect(mockAppendDoseVoid).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('soumet le DoseVoided avec la raison saisie', async () => {
+    renderWithProviders(<VoidDosePage />);
+    await waitFor(() => {
+      expect(screen.getByTestId('void-reason')).toBeInTheDocument();
+    });
+    await act(async () => {
+      fireEvent.change(screen.getByTestId('void-reason'), {
+        target: { value: 'mauvaise pompe' },
+      });
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('void-submit'));
+    });
+    await waitFor(() => {
+      expect(mockAppendDoseVoid).toHaveBeenCalledTimes(1);
+    });
+    const call = mockAppendDoseVoid.mock.calls[0]?.[0] as {
+      doseId: string;
+      voidedReason: string;
+      voidedByDeviceId: string;
+    };
+    expect(call.doseId).toBe('dose-A');
+    expect(call.voidedReason).toBe('mauvaise pompe');
+    expect(call.voidedByDeviceId).toBe('dev-1');
+  });
+
+  it('affiche un message si la dose est déjà voidée', async () => {
+    mockDoses = [{ ...mockDoses[0]!, status: 'voided' }];
+    renderWithProviders(<VoidDosePage />);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('void-submit')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/stores/doc-store.ts
+++ b/apps/web/src/stores/doc-store.ts
@@ -12,6 +12,8 @@ import type {
   KinhaleDoc,
   DoseAdministeredPayload,
   DoseReviewFlaggedPayload,
+  DoseEditedPayload,
+  DoseVoidedPayload,
   ChildRegisteredPayload,
   PumpReplacedPayload,
   PlanUpdatedPayload,
@@ -58,6 +60,16 @@ interface DocState {
   ) => Promise<Uint8Array[]>;
   appendDoseFlag: (
     payload: DoseReviewFlaggedPayload,
+    deviceId: string,
+    secretKey: Uint8Array,
+  ) => Promise<Uint8Array[]>;
+  appendDoseEdit: (
+    payload: DoseEditedPayload,
+    deviceId: string,
+    secretKey: Uint8Array,
+  ) => Promise<Uint8Array[]>;
+  appendDoseVoid: (
+    payload: DoseVoidedPayload,
     deviceId: string,
     secretKey: Uint8Array,
   ) => Promise<Uint8Array[]>;
@@ -202,6 +214,46 @@ export const useDocStore = create<DocState>()((set, get) => ({
       deviceId,
       occurredAtMs: Date.now(),
       event: { type: 'DoseReviewFlagged', payload },
+    };
+    const record = await signEvent(unsigned, secretKey);
+    const newDoc = appendEvent(doc, record);
+    const changes = getDocChanges(doc, newDoc);
+
+    void persistDoc(newDoc);
+    set({ doc: newDoc });
+    return changes;
+  },
+
+  async appendDoseEdit(payload, deviceId, secretKey) {
+    const currentDoc = get().doc;
+    const hid = (currentDoc as KinhaleDoc | null)?.householdId ?? deviceId;
+    const doc = currentDoc ?? createDoc(hid);
+
+    const unsigned: UnsignedEvent = {
+      id: crypto.randomUUID(),
+      deviceId,
+      occurredAtMs: Date.now(),
+      event: { type: 'DoseEdited', payload },
+    };
+    const record = await signEvent(unsigned, secretKey);
+    const newDoc = appendEvent(doc, record);
+    const changes = getDocChanges(doc, newDoc);
+
+    void persistDoc(newDoc);
+    set({ doc: newDoc });
+    return changes;
+  },
+
+  async appendDoseVoid(payload, deviceId, secretKey) {
+    const currentDoc = get().doc;
+    const hid = (currentDoc as KinhaleDoc | null)?.householdId ?? deviceId;
+    const doc = currentDoc ?? createDoc(hid);
+
+    const unsigned: UnsignedEvent = {
+      id: crypto.randomUUID(),
+      deviceId,
+      occurredAtMs: Date.now(),
+      event: { type: 'DoseVoided', payload },
     };
     const record = await signEvent(unsigned, secretKey);
     const newDoc = appendEvent(doc, record);

--- a/packages/domain/src/entities/dose-edit-permissions.test.ts
+++ b/packages/domain/src/entities/dose-edit-permissions.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EDIT_FREE_WINDOW_MINUTES,
+  canEditDose,
+  type DoseEditTarget,
+} from './dose-edit-permissions';
+
+const target = (overrides: Partial<DoseEditTarget> = {}): DoseEditTarget => ({
+  recordedByDeviceId: 'dev-author',
+  administeredAtMs: 1_000_000,
+  status: 'recorded',
+  ...overrides,
+});
+
+const FREE_WINDOW_MS = EDIT_FREE_WINDOW_MINUTES * 60_000;
+
+describe('canEditDose', () => {
+  it("autorise l'auteur sans raison dans la fenêtre de 30 min", () => {
+    const result = canEditDose({
+      dose: target(),
+      currentDeviceId: 'dev-author',
+      currentRole: 'contributor',
+      nowMs: 1_000_000 + 5 * 60_000, // 5 min après
+    });
+    expect(result).toEqual({ allowed: true, requiresReason: false });
+  });
+
+  it("autorise l'auteur exactement à la borne 30 min (inclusive)", () => {
+    const result = canEditDose({
+      dose: target(),
+      currentDeviceId: 'dev-author',
+      currentRole: 'contributor',
+      nowMs: 1_000_000 + FREE_WINDOW_MS,
+    });
+    expect(result).toEqual({ allowed: true, requiresReason: false });
+  });
+
+  it('refuse un contributor non-auteur après la fenêtre', () => {
+    const result = canEditDose({
+      dose: target(),
+      currentDeviceId: 'dev-other',
+      currentRole: 'contributor',
+      nowMs: 1_000_000 + FREE_WINDOW_MS + 1,
+    });
+    expect(result).toEqual({ allowed: false, reason: 'not_author_and_too_old' });
+  });
+
+  it('autorise un Admin > 30 min mais avec raison obligatoire', () => {
+    const result = canEditDose({
+      dose: target(),
+      currentDeviceId: 'dev-admin',
+      currentRole: 'admin',
+      nowMs: 1_000_000 + 60 * 60_000, // 1h après
+    });
+    expect(result).toEqual({ allowed: true, requiresReason: true });
+  });
+
+  it('autorise un Admin dans la fenêtre sans raison (même non auteur)', () => {
+    const result = canEditDose({
+      dose: target(),
+      currentDeviceId: 'dev-admin',
+      currentRole: 'admin',
+      nowMs: 1_000_000 + 5 * 60_000,
+    });
+    expect(result).toEqual({ allowed: true, requiresReason: false });
+  });
+
+  it("refuse une prise déjà voidée — quel que soit le rôle ou l'auteur", () => {
+    const voided = target({ status: 'voided' });
+    expect(
+      canEditDose({
+        dose: voided,
+        currentDeviceId: 'dev-author',
+        currentRole: 'contributor',
+        nowMs: 1_000_000,
+      }),
+    ).toEqual({ allowed: false, reason: 'voided' });
+    expect(
+      canEditDose({
+        dose: voided,
+        currentDeviceId: 'dev-admin',
+        currentRole: 'admin',
+        nowMs: 1_000_000 + 60 * 60_000,
+      }),
+    ).toEqual({ allowed: false, reason: 'voided' });
+  });
+
+  it('refuse une prise en pending_review (doit passer par la résolution)', () => {
+    const flagged = target({ status: 'pending_review' });
+    expect(
+      canEditDose({
+        dose: flagged,
+        currentDeviceId: 'dev-author',
+        currentRole: 'contributor',
+        nowMs: 1_000_000,
+      }),
+    ).toEqual({ allowed: false, reason: 'pending_review' });
+  });
+
+  it('refuse strictement un restricted_contributor même auteur dans la fenêtre', () => {
+    const result = canEditDose({
+      dose: target(),
+      currentDeviceId: 'dev-author',
+      currentRole: 'restricted_contributor',
+      nowMs: 1_000_000 + 5 * 60_000,
+    });
+    expect(result).toEqual({ allowed: false, reason: 'restricted_role' });
+  });
+
+  it('refuse un contributor auteur juste après la fenêtre (30 min + 1 ms)', () => {
+    const result = canEditDose({
+      dose: target(),
+      currentDeviceId: 'dev-author',
+      currentRole: 'contributor',
+      nowMs: 1_000_000 + FREE_WINDOW_MS + 1,
+    });
+    expect(result).toEqual({ allowed: false, reason: 'not_author_and_too_old' });
+  });
+
+  it('est pure : deux appels avec mêmes inputs renvoient des résultats égaux', () => {
+    const input = {
+      dose: target(),
+      currentDeviceId: 'dev-author',
+      currentRole: 'contributor',
+      nowMs: 1_000_000 + 10 * 60_000,
+    } as const;
+    expect(canEditDose(input)).toEqual(canEditDose(input));
+  });
+});

--- a/packages/domain/src/entities/dose-edit-permissions.ts
+++ b/packages/domain/src/entities/dose-edit-permissions.ts
@@ -1,0 +1,101 @@
+import type { Role } from './role';
+
+/**
+ * Fenêtre de grâce pour l'édition libre d'une prise par son auteur (E4-S06,
+ * RM18 — alignée sur la fenêtre de void). Au-delà, seul un Admin peut
+ * éditer, **avec raison obligatoire**.
+ *
+ * Borne **inclusive** : un edit à 30 min 00 s pile reste autorisé sans
+ * raison. Cohérent avec `VOID_FREE_WINDOW_MINUTES`.
+ */
+export const EDIT_FREE_WINDOW_MINUTES = 30;
+
+const EDIT_FREE_WINDOW_MS = EDIT_FREE_WINDOW_MINUTES * 60_000;
+
+/**
+ * Sous-ensemble minimal d'une dose nécessaire à `canEditDose`. On ne dépend
+ * pas du type complet `Dose` ni de `ProjectedDose` pour rester réutilisable
+ * indépendamment de la couche projection / sync.
+ */
+export interface DoseEditTarget {
+  /** Device qui a saisi initialement la prise. */
+  readonly recordedByDeviceId: string;
+  /** Instant déclaré de la prise (UTC ms). */
+  readonly administeredAtMs: number;
+  /** Statut courant. */
+  readonly status: 'recorded' | 'pending_review' | 'voided';
+}
+
+export interface CanEditDoseInput {
+  readonly dose: DoseEditTarget;
+  /** Identifiant du device en cours de session. */
+  readonly currentDeviceId: string;
+  /** Rôle effectif de l'aidant connecté. */
+  readonly currentRole: Role;
+  /** Horloge — UTC ms. Toujours injectée pour la testabilité. */
+  readonly nowMs: number;
+}
+
+/**
+ * Verdict d'autorisation. Quand `allowed: true`, `requiresReason` indique
+ * si l'UI doit forcer la saisie d'une raison (cas Admin > 30 min).
+ */
+export type CanEditDoseResult =
+  | { readonly allowed: true; readonly requiresReason: boolean }
+  | { readonly allowed: false; readonly reason: CanEditDoseRefusal };
+
+export type CanEditDoseRefusal =
+  | 'voided'
+  | 'pending_review'
+  | 'restricted_role'
+  | 'not_author_and_too_old';
+
+/**
+ * Décide si une prise est éditable dans l'instant courant (E4-S06).
+ *
+ * Règles dérivées de RM18 et des AC E4-S06 :
+ * - Une prise déjà voidée n'est plus jamais éditable (immutable).
+ * - Une prise en `pending_review` doit d'abord passer par la résolution de
+ *   conflit (E4-S05) — pas d'édition libre tant que le statut n'est pas
+ *   tranché.
+ * - Un `restricted_contributor` ne peut jamais éditer (cohérent avec RM18
+ *   — saisie uniquement, pas de gestion).
+ * - Auteur **et** dans la fenêtre de 30 min → autorisé sans raison.
+ * - Admin **hors** fenêtre → autorisé **avec** raison obligatoire.
+ * - Sinon → refus `not_author_and_too_old`.
+ *
+ * **Pureté** : aucune I/O, aucune horloge cachée. `nowMs` est toujours
+ * injectée. Le résultat est strictement déterministe pour des inputs donnés.
+ */
+export function canEditDose(input: CanEditDoseInput): CanEditDoseResult {
+  const { dose, currentDeviceId, currentRole, nowMs } = input;
+
+  if (dose.status === 'voided') {
+    return { allowed: false, reason: 'voided' };
+  }
+  if (dose.status === 'pending_review') {
+    return { allowed: false, reason: 'pending_review' };
+  }
+  if (currentRole === 'restricted_contributor') {
+    return { allowed: false, reason: 'restricted_role' };
+  }
+
+  const isAuthor = dose.recordedByDeviceId === currentDeviceId;
+  const isAdmin = currentRole === 'admin';
+  const elapsedMs = nowMs - dose.administeredAtMs;
+  const insideFreeWindow = elapsedMs <= EDIT_FREE_WINDOW_MS;
+
+  if (insideFreeWindow && isAuthor) {
+    return { allowed: true, requiresReason: false };
+  }
+  if (!insideFreeWindow && isAdmin) {
+    return { allowed: true, requiresReason: true };
+  }
+  if (insideFreeWindow && isAdmin) {
+    // Admin dans la fenêtre, mais pas auteur : on autorise sans raison
+    // (cohérent avec RM18 sur le void). L'audit trail enregistre l'éditeur
+    // via `editedByDeviceId`.
+    return { allowed: true, requiresReason: false };
+  }
+  return { allowed: false, reason: 'not_author_and_too_old' };
+}

--- a/packages/domain/src/entities/index.ts
+++ b/packages/domain/src/entities/index.ts
@@ -1,6 +1,7 @@
 export * from './caregiver';
 export * from './child';
 export * from './dose';
+export * from './dose-edit-permissions';
 export * from './household';
 export * from './invitation';
 export * from './notification-type';

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -53,6 +53,60 @@
       "night": "Night",
       "infection": "Infection",
       "stress": "Stress"
+    },
+    "dose": {
+      "actions": {
+        "edit": "Edit",
+        "void": "Cancel",
+        "resolve": "Resolve"
+      },
+      "caregiverLabel": "Caregiver",
+      "unknownCaregiver": "Caregiver {{id}}",
+      "voidedBadge": "Cancelled",
+      "pendingReviewBadge": "Needs review",
+      "voidedReason": {
+        "label": "Reason",
+        "duplicate_resolved": "Duplicate resolved"
+      },
+      "editPermission": {
+        "tooEarly": "Free edits only by the author within 30 minutes.",
+        "adminOnly": "After 30 minutes, only an Admin can edit.",
+        "voided": "This dose has been cancelled and is no longer editable.",
+        "pendingReview": "This dose is awaiting conflict resolution.",
+        "restrictedRole": "Your role does not permit editing a dose."
+      },
+      "editModal": {
+        "title": "Edit dose",
+        "administeredAtLabel": "Time (UTC, ms)",
+        "dosesLabel": "Number of doses",
+        "symptomsLabel": "Symptoms",
+        "reasonLabel": "Reason for the edit",
+        "reasonPlaceholder": "E.g. forgot, wrong inhaler…",
+        "reasonRequired": "A reason is required for this edit.",
+        "reasonTooLong": "Reason is too long (200 characters max).",
+        "submit": "Save",
+        "cancel": "Cancel",
+        "saveError": "Error saving the edit."
+      },
+      "voidModal": {
+        "title": "Cancel dose",
+        "warning": "Cancelling the dose hides it from the journal without deleting it. The inhaler count is restored.",
+        "reasonLabel": "Reason for cancellation",
+        "reasonPlaceholder": "E.g. wrong entry, wrong inhaler…",
+        "reasonRequired": "A reason is required.",
+        "reasonTooLong": "Reason is too long (200 characters max).",
+        "submit": "Cancel dose",
+        "cancel": "Keep",
+        "saveError": "Error during cancellation."
+      },
+      "resolveModal": {
+        "title": "Resolve conflict",
+        "intro": "Two close doses were detected. Keep the one actually administered — the other will be cancelled.",
+        "keepThis": "Keep this one",
+        "missingPair": "Conflict could not be loaded.",
+        "saveError": "Error during resolution.",
+        "back": "Back"
+      }
     }
   },
   "common": {

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -53,6 +53,60 @@
       "night": "Nuit",
       "infection": "Infection",
       "stress": "Stress"
+    },
+    "dose": {
+      "actions": {
+        "edit": "Modifier",
+        "void": "Annuler",
+        "resolve": "Résoudre"
+      },
+      "caregiverLabel": "Aidant",
+      "unknownCaregiver": "Aidant {{id}}",
+      "voidedBadge": "Annulée",
+      "pendingReviewBadge": "À vérifier",
+      "voidedReason": {
+        "label": "Raison",
+        "duplicate_resolved": "Doublon résolu"
+      },
+      "editPermission": {
+        "tooEarly": "Édition libre uniquement par l'auteur dans les 30 minutes.",
+        "adminOnly": "Passé 30 minutes, seul un Admin peut éditer.",
+        "voided": "Cette prise a été annulée et n'est plus modifiable.",
+        "pendingReview": "Cette prise est en attente de résolution de conflit.",
+        "restrictedRole": "Votre rôle ne permet pas l'édition d'une prise."
+      },
+      "editModal": {
+        "title": "Modifier la prise",
+        "administeredAtLabel": "Heure (UTC, ms)",
+        "dosesLabel": "Nombre de doses",
+        "symptomsLabel": "Symptômes",
+        "reasonLabel": "Raison de la modification",
+        "reasonPlaceholder": "Ex : oubli, mauvaise pompe…",
+        "reasonRequired": "Une raison est obligatoire pour cette modification.",
+        "reasonTooLong": "La raison est trop longue (200 caractères max).",
+        "submit": "Enregistrer",
+        "cancel": "Annuler",
+        "saveError": "Erreur lors de la modification."
+      },
+      "voidModal": {
+        "title": "Annuler la prise",
+        "warning": "Annuler la prise la masque dans le journal sans la supprimer. Le décompte de la pompe est restauré.",
+        "reasonLabel": "Raison de l'annulation",
+        "reasonPlaceholder": "Ex : erreur de saisie, mauvaise pompe…",
+        "reasonRequired": "Une raison est obligatoire.",
+        "reasonTooLong": "La raison est trop longue (200 caractères max).",
+        "submit": "Annuler la prise",
+        "cancel": "Conserver",
+        "saveError": "Erreur lors de l'annulation."
+      },
+      "resolveModal": {
+        "title": "Résoudre le conflit",
+        "intro": "Deux prises proches ont été détectées. Conservez celle qui a vraiment été administrée — l'autre sera annulée.",
+        "keepThis": "Conserver celle-ci",
+        "missingPair": "Le conflit n'a pas pu être chargé.",
+        "saveError": "Erreur lors de la résolution.",
+        "back": "Retour"
+      }
     }
   },
   "common": {

--- a/packages/reports/src/data/aggregate.ts
+++ b/packages/reports/src/data/aggregate.ts
@@ -42,7 +42,7 @@ export interface ReportDose {
   readonly doseType: 'maintenance' | 'rescue';
   readonly symptoms: ReadonlyArray<string>;
   readonly circumstances: ReadonlyArray<string>;
-  readonly status: 'recorded' | 'pending_review';
+  readonly status: 'recorded' | 'pending_review' | 'voided';
 }
 
 export interface WeekBucket {

--- a/packages/reports/src/privacy-export/serialize-doc.ts
+++ b/packages/reports/src/privacy-export/serialize-doc.ts
@@ -149,6 +149,9 @@ function serializeDoses(doc: KinhaleDoc): ReadonlyArray<SerializedDose> {
         status: d.status,
         recordedByDeviceId: d.deviceId,
         recordedAtMs: d.occurredAtMs,
+        ...(d.voidedReason !== undefined ? { voidedReason: d.voidedReason } : {}),
+        ...(d.voidedByDeviceId !== undefined ? { voidedByDeviceId: d.voidedByDeviceId } : {}),
+        ...(d.voidedAtMs !== undefined ? { voidedAtMs: d.voidedAtMs } : {}),
       }),
     )
     .sort((a, b) => {

--- a/packages/reports/src/privacy-export/types.ts
+++ b/packages/reports/src/privacy-export/types.ts
@@ -36,7 +36,15 @@ export interface SerializedDose {
   readonly symptoms: ReadonlyArray<string>;
   readonly circumstances: ReadonlyArray<string>;
   readonly freeFormTag: string | null;
-  readonly status: 'recorded' | 'pending_review';
+  readonly status: 'recorded' | 'pending_review' | 'voided';
+  /**
+   * Raison d'annulation (présente uniquement si `status === 'voided'`).
+   * Conservée dans l'archive RGPD : c'est une donnée saisie par
+   * l'utilisateur, qui a le droit à sa portabilité (art. 20 RGPD).
+   */
+  readonly voidedReason?: string;
+  readonly voidedByDeviceId?: string;
+  readonly voidedAtMs?: number;
   readonly recordedByDeviceId: string;
   readonly recordedAtMs: number;
 }

--- a/packages/sync/src/__tests__/projections/doses.test.ts
+++ b/packages/sync/src/__tests__/projections/doses.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { projectDoses } from '../../projections/doses.js';
-import type { KinhaleDoc } from '../../doc/schema.js';
-import type { DoseAdministeredPayload } from '../../events/types.js';
+import type { KinhaleDoc, SignedEventRecord } from '../../doc/schema.js';
+import type {
+  DoseAdministeredPayload,
+  DoseEditedPayload,
+  DoseVoidedPayload,
+} from '../../events/types.js';
 
 const makeDoc = (
   entries: Array<{ payload: DoseAdministeredPayload; occurredAtMs?: number }>,
@@ -242,5 +246,406 @@ describe('projectDoses', () => {
     };
     const result = projectDoses(doc);
     expect(result[0]?.status).toBe('recorded');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Édition — DoseEdited (KIN-094 / E4-S06).
+  // ---------------------------------------------------------------------------
+
+  const sigEnvelope = {
+    signerPublicKeyHex: 'a'.repeat(64),
+    signatureHex: 'b'.repeat(128),
+    deviceId: 'dev-1',
+  } as const;
+
+  const editEvent = (
+    payload: DoseEditedPayload,
+    overrides: Partial<SignedEventRecord> = {},
+  ): SignedEventRecord => ({
+    id: `evt-edit-${payload.doseId}`,
+    type: 'DoseEdited',
+    payloadJson: JSON.stringify(payload),
+    occurredAtMs: payload.editedAtMs,
+    ...sigEnvelope,
+    ...overrides,
+  });
+
+  const voidEvent = (
+    payload: DoseVoidedPayload,
+    overrides: Partial<SignedEventRecord> = {},
+  ): SignedEventRecord => ({
+    id: `evt-void-${payload.doseId}`,
+    type: 'DoseVoided',
+    payloadJson: JSON.stringify(payload),
+    occurredAtMs: payload.voidedAtMs,
+    ...sigEnvelope,
+    ...overrides,
+  });
+
+  const doseEvent = (
+    payload: DoseAdministeredPayload,
+    occurredAtMs = payload.administeredAtMs,
+  ): SignedEventRecord => ({
+    id: `evt-${payload.doseId}`,
+    type: 'DoseAdministered',
+    payloadJson: JSON.stringify(payload),
+    occurredAtMs,
+    ...sigEnvelope,
+  });
+
+  it('applique un DoseEdited en patchant les champs déclarés', () => {
+    const d = dose({ doseId: 'dose-1', dosesAdministered: 1, symptoms: ['cough'] });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d),
+        editEvent({
+          doseId: 'dose-1',
+          patch: { dosesAdministered: 2, symptoms: ['wheezing'], administeredAtMs: 9_000_000 },
+          editedByDeviceId: 'dev-1',
+          editedAtMs: 1_500_000,
+        }),
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.dosesAdministered).toBe(2);
+    expect(result[0]?.symptoms).toEqual(['wheezing']);
+    expect(result[0]?.administeredAtMs).toBe(9_000_000);
+    // L'eventId reste celui du DoseAdministered original (audit trail intact).
+    expect(result[0]?.eventId).toBe('evt-dose-1');
+    expect(result[0]?.status).toBe('recorded');
+  });
+
+  it("préserve les champs non patchés et conserve l'eventId d'origine", () => {
+    const d = dose({
+      doseId: 'dose-1',
+      dosesAdministered: 1,
+      symptoms: ['cough'],
+      circumstances: ['exercise'],
+    });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d),
+        editEvent({
+          doseId: 'dose-1',
+          patch: { dosesAdministered: 3 },
+          editedByDeviceId: 'dev-1',
+          editedAtMs: 1_500_000,
+        }),
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result[0]?.dosesAdministered).toBe(3);
+    expect(result[0]?.symptoms).toEqual(['cough']);
+    expect(result[0]?.circumstances).toEqual(['exercise']);
+  });
+
+  it("cumule plusieurs DoseEdited dans l'ordre du log (dernier patch gagne par champ)", () => {
+    const d = dose({ doseId: 'dose-1', dosesAdministered: 1, symptoms: [] });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d),
+        editEvent(
+          {
+            doseId: 'dose-1',
+            patch: { dosesAdministered: 2 },
+            editedByDeviceId: 'dev-1',
+            editedAtMs: 1_100_000,
+          },
+          { id: 'edit-A' },
+        ),
+        editEvent(
+          {
+            doseId: 'dose-1',
+            patch: { dosesAdministered: 5, symptoms: ['cough'] },
+            editedByDeviceId: 'dev-1',
+            editedAtMs: 1_200_000,
+          },
+          { id: 'edit-B' },
+        ),
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result[0]?.dosesAdministered).toBe(5);
+    expect(result[0]?.symptoms).toEqual(['cough']);
+  });
+
+  it('ignore un DoseEdited référant un doseId inconnu', () => {
+    const d = dose({ doseId: 'dose-1' });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d),
+        editEvent({
+          doseId: 'dose-ZZZ',
+          patch: { dosesAdministered: 99 },
+          editedByDeviceId: 'dev-1',
+          editedAtMs: 1_500_000,
+        }),
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.dosesAdministered).toBe(1);
+  });
+
+  it('ignore un DoseEdited avec JSON invalide ou patch vide', () => {
+    const d = dose({ doseId: 'dose-1', dosesAdministered: 1 });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d),
+        {
+          id: 'edit-bad-json',
+          type: 'DoseEdited',
+          payloadJson: 'not-json{{{',
+          ...sigEnvelope,
+          occurredAtMs: 1_500_000,
+        },
+        editEvent({
+          doseId: 'dose-1',
+          patch: {},
+          editedByDeviceId: 'dev-1',
+          editedAtMs: 1_500_000,
+        }),
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result[0]?.dosesAdministered).toBe(1);
+  });
+
+  it('ignore les valeurs invalides dans un patch (NaN, types erronés)', () => {
+    const d = dose({ doseId: 'dose-1', dosesAdministered: 2 });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d),
+        {
+          id: 'edit-1',
+          type: 'DoseEdited',
+          payloadJson: JSON.stringify({
+            doseId: 'dose-1',
+            patch: {
+              dosesAdministered: -1, // négatif → rejeté
+              symptoms: ['ok', 42], // tableau hétérogène → rejeté
+              administeredAtMs: 'not-a-number', // type erroné → rejeté
+            },
+            editedByDeviceId: 'dev-1',
+            editedAtMs: 1_500_000,
+          }),
+          ...sigEnvelope,
+          occurredAtMs: 1_500_000,
+        },
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result[0]?.dosesAdministered).toBe(2);
+    expect(result[0]?.symptoms).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Annulation — DoseVoided (KIN-094 / E4-S07).
+  // ---------------------------------------------------------------------------
+
+  it("marque la dose en 'voided' et expose voidedReason / voidedByDeviceId / voidedAtMs", () => {
+    const d = dose({ doseId: 'dose-1' });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d),
+        voidEvent({
+          doseId: 'dose-1',
+          voidedByDeviceId: 'dev-2',
+          voidedAtMs: 5_000_000,
+          voidedReason: 'mauvaise pompe',
+        }),
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result[0]?.status).toBe('voided');
+    expect(result[0]?.voidedReason).toBe('mauvaise pompe');
+    expect(result[0]?.voidedByDeviceId).toBe('dev-2');
+    expect(result[0]?.voidedAtMs).toBe(5_000_000);
+  });
+
+  it('void prévaut strictement sur pending_review et libère la dose conservée (E4-S05)', () => {
+    // AC E4-S05 : « La prise conservée repasse à status='recorded' ».
+    // Quand A est voidée (résolution doublon) et B est seule dans la paire,
+    // B doit redescendre de pending_review vers recorded.
+    const d1 = dose({ doseId: 'dose-A', administeredAtMs: 1_000 });
+    const d2 = dose({ doseId: 'dose-B', administeredAtMs: 2_000 });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d1),
+        doseEvent(d2),
+        {
+          id: 'flag-1',
+          type: 'DoseReviewFlagged',
+          payloadJson: JSON.stringify({
+            flagId: 'f-1',
+            doseIds: ['dose-A', 'dose-B'],
+            detectedAtMs: 2_500,
+          }),
+          ...sigEnvelope,
+          occurredAtMs: 2_500,
+        },
+        voidEvent({
+          doseId: 'dose-A',
+          voidedByDeviceId: 'dev-1',
+          voidedAtMs: 3_000,
+          voidedReason: 'duplicate_resolved',
+        }),
+      ],
+    };
+    const result = projectDoses(doc);
+    const a = result.find((r) => r.doseId === 'dose-A');
+    const b = result.find((r) => r.doseId === 'dose-B');
+    expect(a?.status).toBe('voided');
+    expect(b?.status).toBe('recorded');
+  });
+
+  it('flag à 3 doses : les 2 non-voidées restent pending_review', () => {
+    // Si la paire conflictuelle a > 2 doses (cas rare) et qu'une seule est
+    // voidée, les 2 autres restent flaggées (au moins 2 vivantes en conflit).
+    const d1 = dose({ doseId: 'dose-A', administeredAtMs: 1_000 });
+    const d2 = dose({ doseId: 'dose-B', administeredAtMs: 1_500 });
+    const d3 = dose({ doseId: 'dose-C', administeredAtMs: 2_000 });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d1),
+        doseEvent(d2),
+        doseEvent(d3),
+        {
+          id: 'flag-1',
+          type: 'DoseReviewFlagged',
+          payloadJson: JSON.stringify({
+            flagId: 'f-1',
+            doseIds: ['dose-A', 'dose-B', 'dose-C'],
+            detectedAtMs: 2_500,
+          }),
+          ...sigEnvelope,
+          occurredAtMs: 2_500,
+        },
+        voidEvent({
+          doseId: 'dose-A',
+          voidedByDeviceId: 'dev-1',
+          voidedAtMs: 3_000,
+          voidedReason: 'duplicate_resolved',
+        }),
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result.find((r) => r.doseId === 'dose-A')?.status).toBe('voided');
+    expect(result.find((r) => r.doseId === 'dose-B')?.status).toBe('pending_review');
+    expect(result.find((r) => r.doseId === 'dose-C')?.status).toBe('pending_review');
+  });
+
+  it('idempotence : un second DoseVoided pour la même dose est ignoré', () => {
+    const d = dose({ doseId: 'dose-1' });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d),
+        voidEvent({
+          doseId: 'dose-1',
+          voidedByDeviceId: 'dev-1',
+          voidedAtMs: 5_000,
+          voidedReason: 'première raison',
+        }),
+        voidEvent(
+          {
+            doseId: 'dose-1',
+            voidedByDeviceId: 'dev-2',
+            voidedAtMs: 9_000,
+            voidedReason: 'second tentative',
+          },
+          { id: 'evt-void-second' },
+        ),
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result[0]?.voidedReason).toBe('première raison');
+    expect(result[0]?.voidedByDeviceId).toBe('dev-1');
+    expect(result[0]?.voidedAtMs).toBe(5_000);
+  });
+
+  it('rejette un DoseVoided avec voidedReason vide ou trop long', () => {
+    const d = dose({ doseId: 'dose-1' });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d),
+        voidEvent(
+          {
+            doseId: 'dose-1',
+            voidedByDeviceId: 'dev-1',
+            voidedAtMs: 5_000,
+            voidedReason: '   ',
+          },
+          { id: 'evt-void-empty' },
+        ),
+        voidEvent(
+          {
+            doseId: 'dose-1',
+            voidedByDeviceId: 'dev-1',
+            voidedAtMs: 6_000,
+            voidedReason: 'x'.repeat(201), // > 200 chars
+          },
+          { id: 'evt-void-long' },
+        ),
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result[0]?.status).toBe('recorded');
+    expect(result[0]?.voidedReason).toBeUndefined();
+  });
+
+  it('ignore un DoseVoided référant un doseId inconnu (pas de dose fantôme)', () => {
+    const d = dose({ doseId: 'dose-1' });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d),
+        voidEvent({
+          doseId: 'dose-XYZ',
+          voidedByDeviceId: 'dev-1',
+          voidedAtMs: 5_000,
+          voidedReason: 'erreur',
+        }),
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.status).toBe('recorded');
+  });
+
+  it('combine édition + annulation : la projection reflète les patches puis le void', () => {
+    const d = dose({ doseId: 'dose-1', dosesAdministered: 1 });
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        doseEvent(d),
+        editEvent({
+          doseId: 'dose-1',
+          patch: { dosesAdministered: 4 },
+          editedByDeviceId: 'dev-1',
+          editedAtMs: 1_500_000,
+        }),
+        voidEvent({
+          doseId: 'dose-1',
+          voidedByDeviceId: 'dev-1',
+          voidedAtMs: 1_600_000,
+          voidedReason: 'mauvaise saisie',
+        }),
+      ],
+    };
+    const result = projectDoses(doc);
+    expect(result[0]?.dosesAdministered).toBe(4);
+    expect(result[0]?.status).toBe('voided');
   });
 });

--- a/packages/sync/src/__tests__/projections/pumps.test.ts
+++ b/packages/sync/src/__tests__/projections/pumps.test.ts
@@ -125,4 +125,32 @@ describe('projectPumps', () => {
     };
     expect(projectPumps(doc)).toEqual([]);
   });
+
+  it('ré-incrémente dosesRemaining quand une dose est voidée (RM18 / E4-S07)', () => {
+    const doc: KinhaleDoc = {
+      householdId: 'hh-1',
+      events: [
+        makePumpEvent(pump({ totalDoses: 200 })),
+        makeDoseEvent({ pumpId: 'pump-1' }, 'dose-1'),
+        makeDoseEvent({ pumpId: 'pump-1' }, 'dose-2'),
+        {
+          id: 'void-dose-1',
+          type: 'DoseVoided',
+          payloadJson: JSON.stringify({
+            doseId: 'dose-1',
+            voidedByDeviceId: 'dev-1',
+            voidedAtMs: 3_000_000,
+            voidedReason: 'mauvaise pompe',
+          }),
+          signerPublicKeyHex: 'a'.repeat(64),
+          signatureHex: 'b'.repeat(128),
+          deviceId: 'dev-1',
+          occurredAtMs: 3_000_000,
+        },
+      ],
+    };
+    const result = projectPumps(doc);
+    // 1 seule dose comptée (la voidée est exclue) → 199 restantes.
+    expect(result[0]?.dosesRemaining).toBe(199);
+  });
 });

--- a/packages/sync/src/events/types.ts
+++ b/packages/sync/src/events/types.ts
@@ -2,6 +2,8 @@
 export type DomainEventType =
   | 'DoseAdministered'
   | 'DoseReviewFlagged'
+  | 'DoseEdited'
+  | 'DoseVoided'
   | 'PumpReplaced'
   | 'PlanUpdated'
   | 'CaregiverInvited'
@@ -43,6 +45,78 @@ export interface DoseReviewFlaggedPayload {
   doseIds: [string, string];
   /** Instant de détection (UTC ms). */
   detectedAtMs: number;
+}
+
+/**
+ * Constante de raison d'annulation pour les doses résolues via le flux de
+ * conflit RM6 (E4-S05). La présence de cette valeur permet à l'UI de
+ * distinguer une annulation issue d'une résolution de conflit d'un void
+ * manuel libellé par l'utilisateur.
+ */
+export const VOIDED_REASON_DUPLICATE_RESOLVED = 'duplicate_resolved';
+
+/**
+ * Longueur maximale du `voidedReason` en caractères. Dimensionnée pour la
+ * saisie courte (cf. CLAUDE.md §contraintes E4-S07). Toute valeur excédant
+ * cette borne doit être rejetée par le validateur Zod côté UI **et** par le
+ * projector qui l'ignore (le statut reste `recorded`).
+ */
+export const VOIDED_REASON_MAX_LENGTH = 200;
+
+/**
+ * Payload pour `DoseEdited` — RM18, E4-S06.
+ *
+ * Patch immuable d'un sous-ensemble de champs métier d'une `DoseAdministered`
+ * existante. L'événement original n'est jamais modifié : la projection
+ * applique le dernier patch reçu pour le `doseId` lors de la dérivation
+ * (audit trail intact).
+ *
+ * Les champs absents du `patch` ne sont pas modifiés. Un `patch` totalement
+ * vide est ignoré par la projection.
+ */
+export interface DoseEditedPayload {
+  /** Référence vers la `DoseAdministered` à patcher. */
+  doseId: string;
+  /** Champs modifiables (tous optionnels, au moins un attendu). */
+  patch: {
+    administeredAtMs?: number;
+    dosesAdministered?: number;
+    symptoms?: ReadonlyArray<string>;
+    circumstances?: ReadonlyArray<string>;
+    freeFormTag?: string | null;
+  };
+  /** Device qui a effectué l'édition. */
+  editedByDeviceId: string;
+  /** UTC ms de l'édition. */
+  editedAtMs: number;
+  /**
+   * Raison obligatoire si l'éditeur est Admin et que > 30 min se sont
+   * écoulées depuis `administeredAtMs`. Optionnel sinon.
+   */
+  reason?: string;
+}
+
+/**
+ * Payload pour `DoseVoided` — RM18, E4-S07.
+ *
+ * Marque une prise comme annulée logiquement (gris barré, hors décompte
+ * pompe). La prise originale n'est jamais supprimée physiquement : l'audit
+ * trail conserve le `DoseAdministered` initial et l'événement `DoseVoided`
+ * en parallèle.
+ *
+ * Pour le flux de résolution de conflit (E4-S05), `voidedReason` doit valoir
+ * `VOIDED_REASON_DUPLICATE_RESOLVED` (constante exportée par ce module).
+ */
+export interface DoseVoidedPayload {
+  doseId: string;
+  voidedByDeviceId: string;
+  /** UTC ms de l'annulation. */
+  voidedAtMs: number;
+  /**
+   * Raison obligatoire (max 200 chars). Pour une résolution de conflit RM6,
+   * vaut la constante `VOIDED_REASON_DUPLICATE_RESOLVED`.
+   */
+  voidedReason: string;
 }
 
 /** Payload pour PumpReplaced */
@@ -103,6 +177,8 @@ export interface ChildRegisteredPayload {
 export type DomainEventPayload =
   | { type: 'DoseAdministered'; payload: DoseAdministeredPayload }
   | { type: 'DoseReviewFlagged'; payload: DoseReviewFlaggedPayload }
+  | { type: 'DoseEdited'; payload: DoseEditedPayload }
+  | { type: 'DoseVoided'; payload: DoseVoidedPayload }
   | { type: 'PumpReplaced'; payload: PumpReplacedPayload }
   | { type: 'PlanUpdated'; payload: PlanUpdatedPayload }
   | { type: 'CaregiverInvited'; payload: CaregiverInvitedPayload }

--- a/packages/sync/src/index.ts
+++ b/packages/sync/src/index.ts
@@ -16,6 +16,8 @@ export type {
   UnsignedEvent,
   DoseAdministeredPayload,
   DoseReviewFlaggedPayload,
+  DoseEditedPayload,
+  DoseVoidedPayload,
   PumpReplacedPayload,
   PlanUpdatedPayload,
   CaregiverInvitedPayload,
@@ -23,6 +25,7 @@ export type {
   CaregiverRevokedPayload,
   ChildRegisteredPayload,
 } from './events/types.js';
+export { VOIDED_REASON_DUPLICATE_RESOLVED, VOIDED_REASON_MAX_LENGTH } from './events/types.js';
 export { canonicalBytes, signEvent, verifySignedEvent } from './events/sign.js';
 export { appendEvent } from './events/append.js';
 
@@ -45,7 +48,7 @@ export type { ProjectedCaregiver } from './projections/caregivers.js';
 export { projectCaregivers } from './projections/caregivers.js';
 export type { ProjectedChild } from './projections/child.js';
 export { projectChild } from './projections/child.js';
-export type { ProjectedDose } from './projections/doses.js';
+export type { ProjectedDose, ProjectedDoseStatus } from './projections/doses.js';
 export { projectDoses } from './projections/doses.js';
 export type { ProjectedPlan } from './projections/plan.js';
 export { projectPlan } from './projections/plan.js';

--- a/packages/sync/src/projections/doses.ts
+++ b/packages/sync/src/projections/doses.ts
@@ -1,53 +1,197 @@
 import type { KinhaleDoc } from '../doc/schema.js';
-import type { DoseAdministeredPayload, DoseReviewFlaggedPayload } from '../events/types.js';
+import type {
+  DoseAdministeredPayload,
+  DoseEditedPayload,
+  DoseReviewFlaggedPayload,
+  DoseVoidedPayload,
+} from '../events/types.js';
+import { VOIDED_REASON_MAX_LENGTH } from '../events/types.js';
 
 /**
  * Statut projeté d'une prise.
  *
- * - `recorded` : saisie normale, aucun conflit.
+ * - `recorded` : saisie normale, aucun conflit, non annulée.
  * - `pending_review` : RM6 a détecté un doublon potentiel (paire < 2 min sur
- *   la même pompe, même type). L'aidant doit confirmer ou annuler.
- *
- * Le statut `voided` sera ajouté avec E4-S07 (annulation explicite) — pour
- * l'instant, seules les deux valeurs ci-dessus sont produites par la
- * projection.
+ *   la même pompe, même type). L'aidant doit confirmer ou annuler. Source :
+ *   événements `DoseReviewFlagged` (KIN-073).
+ * - `voided` : prise annulée logiquement (RM18 — KIN-094 / E4-S07). La
+ *   priorité est **stricte** sur `pending_review` : un void postérieur à un
+ *   `DoseReviewFlagged` prévaut. La prise reste visible (gris barré côté UI)
+ *   et n'est jamais supprimée physiquement (audit trail intact).
  */
-export type ProjectedDoseStatus = 'recorded' | 'pending_review';
+export type ProjectedDoseStatus = 'recorded' | 'pending_review' | 'voided';
 
 export interface ProjectedDose extends DoseAdministeredPayload {
-  /** ID de l'événement SignedEventRecord. */
+  /** ID de l'événement SignedEventRecord d'origine (`DoseAdministered`). */
   eventId: string;
   /** Timestamp UTC ms de l'événement signé (peut différer de administeredAtMs en cas de backfill). */
   occurredAtMs: number;
-  /** Device ayant créé l'événement. */
+  /** Device ayant créé l'événement d'origine. */
   deviceId: string;
-  /** Statut de la dose (RM6 pour `pending_review`). */
+  /** Statut courant après application des `DoseEdited` / `DoseVoided` / `DoseReviewFlagged`. */
   status: ProjectedDoseStatus;
+  /** Raison de l'annulation. Présente uniquement si `status === 'voided'`. */
+  voidedReason?: string;
+  /** Device qui a annulé. Présent uniquement si `status === 'voided'`. */
+  voidedByDeviceId?: string;
+  /** UTC ms de l'annulation. Présent uniquement si `status === 'voided'`. */
+  voidedAtMs?: number;
+}
+
+/**
+ * Filtre permissif sur un patch `DoseEdited` : retient uniquement les
+ * champs valides typés. Évite qu'une valeur exotique (`null`, `NaN`,
+ * tableau hétérogène) ne corrompe la projection.
+ */
+function sanitizeEditPatch(
+  raw: DoseEditedPayload['patch'] | undefined,
+): Partial<
+  Pick<
+    DoseAdministeredPayload,
+    'administeredAtMs' | 'dosesAdministered' | 'symptoms' | 'circumstances' | 'freeFormTag'
+  >
+> {
+  if (raw === null || raw === undefined || typeof raw !== 'object') return {};
+  const out: Partial<
+    Pick<
+      DoseAdministeredPayload,
+      'administeredAtMs' | 'dosesAdministered' | 'symptoms' | 'circumstances' | 'freeFormTag'
+    >
+  > = {};
+
+  if (typeof raw.administeredAtMs === 'number' && Number.isFinite(raw.administeredAtMs)) {
+    out.administeredAtMs = raw.administeredAtMs;
+  }
+  if (
+    typeof raw.dosesAdministered === 'number' &&
+    Number.isFinite(raw.dosesAdministered) &&
+    raw.dosesAdministered >= 0
+  ) {
+    out.dosesAdministered = raw.dosesAdministered;
+  }
+  if (
+    Array.isArray(raw.symptoms) &&
+    raw.symptoms.every((s): s is string => typeof s === 'string')
+  ) {
+    out.symptoms = [...raw.symptoms];
+  }
+  if (
+    Array.isArray(raw.circumstances) &&
+    raw.circumstances.every((c): c is string => typeof c === 'string')
+  ) {
+    out.circumstances = [...raw.circumstances];
+  }
+  if (raw.freeFormTag === null || typeof raw.freeFormTag === 'string') {
+    out.freeFormTag = raw.freeFormTag;
+  }
+  return out;
+}
+
+interface VoidEntry {
+  readonly voidedReason: string;
+  readonly voidedByDeviceId: string;
+  readonly voidedAtMs: number;
 }
 
 /**
  * Dérive la liste ordonnée des prises depuis le document Automerge.
  * Tri : administeredAtMs décroissant (plus récent en premier).
  *
- * Les événements `DoseReviewFlagged` sont lus pour enrichir le `status` de
- * chaque dose référencée (RM6). Un flag quel que soit son ordre de
- * réception bascule la dose en `pending_review` — c'est idempotent.
+ * Application des événements (un seul passage de lecture, deux scans) :
+ * 1. Pré-scan agrégant
+ *    - les `DoseReviewFlagged` (RM6) → set des doseIds en `pending_review`,
+ *    - les `DoseEdited` cumulés par doseId (le dernier patch reçu dans
+ *      l'ordre du log Automerge gagne, par champ),
+ *    - les `DoseVoided` par doseId (le premier `DoseVoided` reçu fait foi —
+ *      un re-void supplémentaire n'apporte aucune information utile).
+ * 2. Scan principal sur les `DoseAdministered` qui produit la projection
+ *    finale en appliquant patches puis statut. Le `voided` prévaut
+ *    strictement sur `pending_review`.
+ *
+ * **Audit trail intact** : la projection ne modifie rien dans le doc — elle
+ * agrège seulement ce qu'elle lit. L'événement `DoseAdministered` original
+ * subsiste, ainsi que la séquence chronologique des édits.
+ *
+ * **Zero-knowledge** : aucune donnée n'est loguée, les payloads JSON
+ * malformés sont ignorés silencieusement.
  */
 export function projectDoses(doc: KinhaleDoc): ProjectedDose[] {
-  const flaggedDoseIds = new Set<string>();
+  const editsByDoseId = new Map<string, ReturnType<typeof sanitizeEditPatch>>();
+  const voidsByDoseId = new Map<string, VoidEntry>();
+  // Pairs de doseIds liées par un DoseReviewFlagged. On résout `flaggedDoseIds`
+  // en deuxième passe, après avoir collecté les voids — une dose dont tous ses
+  // partenaires sont voidés est implicitement « la conservée » et repasse à
+  // `recorded` (AC E4-S05).
+  const flagPairs: Array<readonly string[]> = [];
+
   for (const event of doc.events) {
-    if (event.type !== 'DoseReviewFlagged') continue;
-    let flagPayload: DoseReviewFlaggedPayload;
-    try {
-      flagPayload = JSON.parse(event.payloadJson) as DoseReviewFlaggedPayload;
-    } catch {
+    if (event.type === 'DoseReviewFlagged') {
+      let flagPayload: DoseReviewFlaggedPayload;
+      try {
+        flagPayload = JSON.parse(event.payloadJson) as DoseReviewFlaggedPayload;
+      } catch {
+        continue;
+      }
+      if (!Array.isArray(flagPayload.doseIds)) continue;
+      const ids = flagPayload.doseIds.filter(
+        (id): id is string => typeof id === 'string' && id.length > 0,
+      );
+      if (ids.length > 0) flagPairs.push(ids);
       continue;
     }
-    if (!Array.isArray(flagPayload.doseIds)) continue;
-    for (const id of flagPayload.doseIds) {
-      if (typeof id === 'string' && id.length > 0) {
-        flaggedDoseIds.add(id);
+
+    if (event.type === 'DoseEdited') {
+      let editPayload: DoseEditedPayload;
+      try {
+        editPayload = JSON.parse(event.payloadJson) as DoseEditedPayload;
+      } catch {
+        continue;
       }
+      if (typeof editPayload.doseId !== 'string' || editPayload.doseId.length === 0) continue;
+      const sanitized = sanitizeEditPatch(editPayload.patch);
+      if (Object.keys(sanitized).length === 0) continue;
+      const existing = editsByDoseId.get(editPayload.doseId) ?? {};
+      // Le dernier patch reçu écrase les champs précédents (champs absents préservés).
+      editsByDoseId.set(editPayload.doseId, { ...existing, ...sanitized });
+      continue;
+    }
+
+    if (event.type === 'DoseVoided') {
+      let voidPayload: DoseVoidedPayload;
+      try {
+        voidPayload = JSON.parse(event.payloadJson) as DoseVoidedPayload;
+      } catch {
+        continue;
+      }
+      if (typeof voidPayload.doseId !== 'string' || voidPayload.doseId.length === 0) continue;
+      if (typeof voidPayload.voidedReason !== 'string') continue;
+      const trimmedReason = voidPayload.voidedReason.trim();
+      if (trimmedReason.length === 0 || trimmedReason.length > VOIDED_REASON_MAX_LENGTH) continue;
+      if (
+        typeof voidPayload.voidedByDeviceId !== 'string' ||
+        voidPayload.voidedByDeviceId.length === 0
+      )
+        continue;
+      if (typeof voidPayload.voidedAtMs !== 'number' || !Number.isFinite(voidPayload.voidedAtMs))
+        continue;
+      // Premier void reçu = source de vérité (idempotent vis-à-vis d'un re-void).
+      if (voidsByDoseId.has(voidPayload.doseId)) continue;
+      voidsByDoseId.set(voidPayload.doseId, {
+        voidedReason: trimmedReason,
+        voidedByDeviceId: voidPayload.voidedByDeviceId,
+        voidedAtMs: voidPayload.voidedAtMs,
+      });
+    }
+  }
+
+  // Résolution des flags : une dose reste flaggée si et seulement si au moins
+  // un de ses partenaires de paire n'est pas voidé. Sinon, elle est
+  // « la conservée » et repasse à `recorded` (AC E4-S05).
+  const flaggedDoseIds = new Set<string>();
+  for (const ids of flagPairs) {
+    const liveIds = ids.filter((id) => !voidsByDoseId.has(id));
+    if (liveIds.length >= 2) {
+      for (const id of liveIds) flaggedDoseIds.add(id);
     }
   }
 
@@ -69,13 +213,36 @@ export function projectDoses(doc: KinhaleDoc): ProjectedDose[] {
     ) {
       continue;
     }
-    result.push({
-      ...payload,
+
+    // Application des édits.
+    const patch = editsByDoseId.get(payload.doseId);
+    const merged: DoseAdministeredPayload =
+      patch === undefined ? payload : { ...payload, ...patch };
+
+    // Détermination du statut. `voided` prime sur `pending_review`.
+    const voidEntry = voidsByDoseId.get(payload.doseId);
+    let status: ProjectedDoseStatus;
+    if (voidEntry !== undefined) {
+      status = 'voided';
+    } else if (flaggedDoseIds.has(payload.doseId)) {
+      status = 'pending_review';
+    } else {
+      status = 'recorded';
+    }
+
+    const projected: ProjectedDose = {
+      ...merged,
       eventId: event.id,
       occurredAtMs: event.occurredAtMs,
       deviceId: event.deviceId,
-      status: flaggedDoseIds.has(payload.doseId) ? 'pending_review' : 'recorded',
-    });
+      status,
+    };
+    if (voidEntry !== undefined) {
+      projected.voidedReason = voidEntry.voidedReason;
+      projected.voidedByDeviceId = voidEntry.voidedByDeviceId;
+      projected.voidedAtMs = voidEntry.voidedAtMs;
+    }
+    result.push(projected);
   }
   return result.sort((a, b) => b.administeredAtMs - a.administeredAtMs);
 }

--- a/packages/sync/src/projections/pumps.ts
+++ b/packages/sync/src/projections/pumps.ts
@@ -1,5 +1,10 @@
 import type { KinhaleDoc } from '../doc/schema.js';
-import type { PumpReplacedPayload, DoseAdministeredPayload } from '../events/types.js';
+import type {
+  DoseAdministeredPayload,
+  DoseVoidedPayload,
+  PumpReplacedPayload,
+} from '../events/types.js';
+import { VOIDED_REASON_MAX_LENGTH } from '../events/types.js';
 
 export interface ProjectedPump {
   pumpId: string;
@@ -15,11 +20,29 @@ export interface ProjectedPump {
 
 /**
  * Dérive la liste des pompes depuis le document Automerge.
- * dosesRemaining = totalDoses - nombre de DoseAdministered liées à cette pompe.
+ * dosesRemaining = totalDoses - nombre de DoseAdministered **non voidées**
+ * liées à cette pompe (RM18 / E4-S07 — un void ré-incrémente le décompte).
  * isExpired = expiresAtMs < Date.now().
  */
 export function projectPumps(doc: KinhaleDoc): ProjectedPump[] {
-  // Comptage des prises par pumpId
+  // 1. Pré-scan des annulations valides → set de doseIds voidés.
+  const voidedDoseIds = new Set<string>();
+  for (const event of doc.events) {
+    if (event.type !== 'DoseVoided') continue;
+    let voidPayload: DoseVoidedPayload;
+    try {
+      voidPayload = JSON.parse(event.payloadJson) as DoseVoidedPayload;
+    } catch {
+      continue;
+    }
+    if (typeof voidPayload.doseId !== 'string' || voidPayload.doseId.length === 0) continue;
+    if (typeof voidPayload.voidedReason !== 'string') continue;
+    const trimmedReason = voidPayload.voidedReason.trim();
+    if (trimmedReason.length === 0 || trimmedReason.length > VOIDED_REASON_MAX_LENGTH) continue;
+    voidedDoseIds.add(voidPayload.doseId);
+  }
+
+  // 2. Comptage des prises par pumpId, en excluant les doses voidées.
   const doseCountByPumpId = new Map<string, number>();
   for (const event of doc.events) {
     if (event.type !== 'DoseAdministered') continue;
@@ -31,6 +54,7 @@ export function projectPumps(doc: KinhaleDoc): ProjectedPump[] {
       continue;
     }
     if (typeof payload.pumpId !== 'string') continue;
+    if (typeof payload.doseId === 'string' && voidedDoseIds.has(payload.doseId)) continue;
     doseCountByPumpId.set(payload.pumpId, (doseCountByPumpId.get(payload.pumpId) ?? 0) + 1);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
 
   apps/mobile:
     dependencies:
+      '@kinhale/domain':
+        specifier: workspace:*
+        version: link:../../packages/domain
       '@kinhale/i18n':
         specifier: workspace:*
         version: link:../../packages/i18n
@@ -235,6 +238,9 @@ importers:
       '@kinhale/crypto':
         specifier: workspace:*
         version: link:../../packages/crypto
+      '@kinhale/domain':
+        specifier: workspace:*
+        version: link:../../packages/domain
       '@kinhale/i18n':
         specifier: workspace:*
         version: link:../../packages/i18n


### PR DESCRIPTION
## Contexte

Couvre les **3 stories E4-S05 (résolution conflit) + E4-S06 (édition < 30 min) + E4-S07 (annulation logique)** — complète le cycle de vie d'une prise. Débloque la valeur fonctionnelle attendue (corriger une erreur de saisie) et débloque la colonne \`voided\` du CSV rapport médecin (KIN-084) pour la validation pneumo-pédiatre (E8-S08).

## Contenu

### Domain (\`packages/domain\`)
\`dose-edit-permissions.ts\` — helper pur \`canEditDose(input)\` :
- Auteur < 30 min → autorisé sans raison
- Admin > 30 min → autorisé avec \`voidedReason\` obligatoire
- Non-auteur > 30 min → refusé
- Voided / pending_review → refusé

### Sync (\`packages/sync\`)
Nouveaux types d'événements signés Ed25519 :
- \`DoseEdited\` : patch heure / doses / symptômes (par doseId)
- \`DoseVoided\` : statut \`voided\` + \`voidedReason\` obligatoire

**Projector \`projectDoses\` restructuré en 2-passes** :
1. Pré-scan agrégeant DoseReviewFlagged en paires + DoseEdited cumulés + DoseVoided idempotent
2. **Résolution flags** : une dose ne reste \`pending_review\` que si **au moins un de ses partenaires est non-voidé**. Sinon → \`recorded\` (AC E4-S05 « la prise conservée repasse à recorded »)
3. Scan principal applique patches + statut. \`voided\` prime sur \`pending_review\`

**Audit trail strictement immutable** : DoseAdministered jamais modifié physiquement, tout passe par des événements distincts.

### UI Web + Mobile
- Journal : badges \`voidedBadge\` / \`pendingReviewBadge\`, doses voidées rendues barrées, 3 boutons par ligne selon permissions
- **Modale d'édition** : form heure/doses/symptômes + \`voidedReason\` si admin > 30 min
- **Modale de void** : \`voidedReason\` obligatoire (max 200 chars)
- **Écran de résolution conflit** : 2 doses côte à côte avec **nom de l'aidant** (mapping \`caregiverId → displayName\` + fallback opaque)

## Bugs fonctionnels traités dans le commit (issus de la revue)

- **M2 kz-review** (vrai bug AC E4-S05) : projector restructuré en 2-passes pour que la dose conservée repasse à \`recorded\`. + 2 tests régression (paire 2 doses + paire 3 doses)
- **M3 kz-review** (AC E4-S05 incomplet) : \`DosePane\` enrichi avec \`caregiverName\` via \`projectCaregivers\` + i18n FR + EN

## Tests

- **Sync : 214 verts** (+11 sur projector incl. régression 2-passes + cas 3 doses)
- Domain : tests \`canEditDose\` exhaustifs
- **Web : 159 verts** (+ tests modales edit/void/resolve)
- **Mobile : 99 verts**
- **API : 336 verts** (sans régression)
- Lint + typecheck + format monorepo verts

## Revues assistées

- **kz-review** — APPROVED après correction de M2 + M3 dans le commit. 4 majeurs initiaux (M2 + M3 traités, M1 picker date/heure mobile + M4 bundle mobile reportés en issues). 9 mineurs en suivi. Rapport : [\`kz-review-KIN-094.md\`](../.agents/current-run/kz-review-KIN-094.md)
- **kz-securite** — APPROVED, risque global **faible**. 0 bloquant, 0 majeur, 3 mineurs, 4 info. Audit trail strictement immutable (Ed25519 + projector lecture seule), zero-knowledge intact (pas de nouveau \`dispatchPush\`, pas de \`node:crypto\`, verrou KIN-087 respecté), isolation par foyer cryptographique. Rapport : [\`kz-securite-KIN-094.md\`](../.agents/current-run/kz-securite-KIN-094.md)

## Suivi

Issues à créer : M1 picker date/heure mobile, M4 bundle mobile, 9 mineurs revue, 3 mineurs sécurité (\`freeFormTag\` patch borné, doc serveur \`voidedReason\`, \`verifySignedEvent\` dans \`receiveChanges\`).

Refs: KIN-094
Closes: E4-S05, E4-S06, E4-S07