### PR TITLE
fix(infra): copie complète des manifests pnpm dans les Dockerfiles

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -7,14 +7,21 @@ RUN apk add --no-cache libc6-compat
 
 WORKDIR /app
 
-# Copie minimaliste pour optimiser le cache docker
+# Manifests workspace complets : pnpm install --frozen-lockfile exige
+# tous les package.json du workspace, sinon il omet silencieusement
+# les dépendances des workspaces transitifs absents.
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
 COPY apps/api/package.json ./apps/api/
+COPY apps/web/package.json ./apps/web/
+COPY apps/mobile/package.json ./apps/mobile/
 COPY packages/crypto/package.json ./packages/crypto/
 COPY packages/domain/package.json ./packages/domain/
 COPY packages/eslint-config/package.json ./packages/eslint-config/
-COPY packages/tsconfig/package.json ./packages/tsconfig/
+COPY packages/i18n/package.json ./packages/i18n/
+COPY packages/reports/package.json ./packages/reports/
+COPY packages/sync/package.json ./packages/sync/
 COPY packages/test-utils/package.json ./packages/test-utils/
+COPY packages/tsconfig/package.json ./packages/tsconfig/
 
 RUN pnpm install --frozen-lockfile
 

--- a/apps/api/Dockerfile.prod
+++ b/apps/api/Dockerfile.prod
@@ -25,14 +25,21 @@ RUN apk add --no-cache libc6-compat python3 make g++ \
  && corepack enable \
  && corepack prepare pnpm@10.33.0 --activate
 
-# Manifests first to maximise Docker layer caching.
+# Manifests workspace complets : pnpm install --frozen-lockfile exige
+# tous les package.json du workspace, sinon il omet silencieusement
+# les dépendances des workspaces transitifs absents.
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
 COPY apps/api/package.json ./apps/api/
+COPY apps/web/package.json ./apps/web/
+COPY apps/mobile/package.json ./apps/mobile/
 COPY packages/crypto/package.json ./packages/crypto/
 COPY packages/domain/package.json ./packages/domain/
 COPY packages/eslint-config/package.json ./packages/eslint-config/
-COPY packages/tsconfig/package.json ./packages/tsconfig/
+COPY packages/i18n/package.json ./packages/i18n/
+COPY packages/reports/package.json ./packages/reports/
+COPY packages/sync/package.json ./packages/sync/
 COPY packages/test-utils/package.json ./packages/test-utils/
+COPY packages/tsconfig/package.json ./packages/tsconfig/
 
 # Install full deps (tsx is in devDependencies but required at runtime).
 RUN --mount=type=cache,id=pnpm-store-api,target=/root/.local/share/pnpm/store \

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -7,16 +7,21 @@ RUN apk add --no-cache libc6-compat
 
 WORKDIR /app
 
-# Copie minimaliste pour optimiser le cache docker
+# Manifests workspace complets : pnpm install --frozen-lockfile exige
+# tous les package.json du workspace, sinon il omet silencieusement
+# les dépendances des workspaces transitifs absents.
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY apps/api/package.json ./apps/api/
 COPY apps/web/package.json ./apps/web/
+COPY apps/mobile/package.json ./apps/mobile/
 COPY packages/crypto/package.json ./packages/crypto/
-COPY packages/sync/package.json ./packages/sync/
 COPY packages/domain/package.json ./packages/domain/
-COPY packages/i18n/package.json ./packages/i18n/
 COPY packages/eslint-config/package.json ./packages/eslint-config/
-COPY packages/tsconfig/package.json ./packages/tsconfig/
+COPY packages/i18n/package.json ./packages/i18n/
+COPY packages/reports/package.json ./packages/reports/
+COPY packages/sync/package.json ./packages/sync/
 COPY packages/test-utils/package.json ./packages/test-utils/
+COPY packages/tsconfig/package.json ./packages/tsconfig/
 
 RUN pnpm install --frozen-lockfile
 

--- a/apps/web/Dockerfile.prod
+++ b/apps/web/Dockerfile.prod
@@ -25,16 +25,21 @@ RUN apk add --no-cache libc6-compat python3 make g++ \
  && corepack enable \
  && corepack prepare pnpm@10.33.0 --activate
 
+# Manifests workspace complets : pnpm install --frozen-lockfile exige
+# tous les package.json du workspace, sinon il omet silencieusement
+# les dépendances des workspaces transitifs absents.
 COPY pnpm-lock.yaml pnpm-workspace.yaml package.json turbo.json tsconfig.base.json ./
+COPY apps/api/package.json ./apps/api/
 COPY apps/web/package.json ./apps/web/
+COPY apps/mobile/package.json ./apps/mobile/
 COPY packages/crypto/package.json ./packages/crypto/
-COPY packages/sync/package.json ./packages/sync/
 COPY packages/domain/package.json ./packages/domain/
+COPY packages/eslint-config/package.json ./packages/eslint-config/
 COPY packages/i18n/package.json ./packages/i18n/
 COPY packages/reports/package.json ./packages/reports/
-COPY packages/eslint-config/package.json ./packages/eslint-config/
-COPY packages/tsconfig/package.json ./packages/tsconfig/
+COPY packages/sync/package.json ./packages/sync/
 COPY packages/test-utils/package.json ./packages/test-utils/
+COPY packages/tsconfig/package.json ./packages/tsconfig/
 
 RUN --mount=type=cache,id=pnpm-store-web,target=/root/.local/share/pnpm/store \
     pnpm install --frozen-lockfile --prefer-offline


### PR DESCRIPTION
## Contexte

Le bootstrap Docker dev (et probablement prod) était cassé après l'ajout de dépendances récentes (`@fastify/rate-limit` ajouté dans KIN-095, chaîne `@automerge/automerge` côté Web). Au runtime, l'API plantait avec `Cannot find package '@fastify/rate-limit'` et le Web SSR avec `Cannot find module '@automerge/automerge'`, malgré leur présence dans `pnpm-lock.yaml`.

## Cause root

`pnpm install --frozen-lockfile` exécuté dans le Dockerfile **ne reçoit qu'un sous-ensemble des `package.json`** du workspace (le `COPY` initial omettait `apps/web`, `apps/mobile`, `packages/{i18n,reports,sync}` selon le Dockerfile). Quand pnpm voit un workspace incomplet, il **omet silencieusement** les dépendances des workspaces manquants — install partiel sans erreur.

## Fix

Les 4 Dockerfiles (dev + prod × api + web) copient désormais les **11 `package.json`** du workspace avant `pnpm install`. Aucune dépendance ajoutée — le fix expose uniquement des deps déjà figées au lockfile.

## Fichiers modifiés

- `apps/api/Dockerfile`
- `apps/api/Dockerfile.prod`
- `apps/web/Dockerfile`
- `apps/web/Dockerfile.prod`

## Validation

**Dev (bootstrap from-scratch)** :
```bash
docker compose -f infra/docker/docker-compose.yml --env-file infra/docker/.env.docker down -v
docker compose -f infra/docker/docker-compose.yml --env-file infra/docker/.env.docker up -d --build
# → API /health 200, Web / 200, sans `pnpm install` à la volée
```

**Prod (deps stage build à blanc)** :
```bash
docker build -f apps/api/Dockerfile.prod --target deps -t test-api-prod-deps ./
docker build -f apps/web/Dockerfile.prod --target deps -t test-web-prod-deps ./
# → exit 0 sur les deux ; le `pnpm --filter @kinhale/api typecheck` intégré au stage `deps` API passe.
```

## Revues automatisées (workflow Kinhale)

Conformément au workflow `kz-review` + `kz-securite` obligatoire avant ouverture de PR (cf. CLAUDE.md) :

### kz-review — ✅ Approuvé
- Cohérence parfaite entre les 4 Dockerfiles (mêmes 11 COPY, ordre alphabétique).
- Cause root correctement identifiée et corrigée au bon niveau (build-time, pas patch runtime).
- Test d'acceptation reproductible et validé.
- Pas de sur-engineering.
- Rapport complet : `.agents/current-run/kz-review-docker-deps-bootstrap.md`.

### kz-securite — ✅ PASS (risque faible)
- Aucun secret introduit, aucune dépendance ajoutée, aucun lifecycle script malveillant exposé.
- Posture sécurité prod intacte (`USER kinhale:1001`, `tini`, healthcheck, multi-stage, pas de toolchain native dans runtime).
- Findings : 2 INFO non bloquants (enrichir `.dockerignore` quand le pipeline EAS sera intégré ; viser `--filter <app>...` à terme pour minimiser les images prod).
- Rapport complet : `.agents/current-run/kz-securite-docker-deps-bootstrap.md`.

## Suivi recommandé (hors scope)

- 🟡 Garde-fou anti-dérive : un script `scripts/check-docker-manifests.sh` qui diffe la liste réelle des `package.json` workspace vs. les `COPY` effectifs des Dockerfiles. À discuter dans un ticket dédié.
- 🟡 Test CI bootstrap from-scratch (`down -v && up --build` puis `curl /health`) pour bloquer toute régression future.
- 🟡 SBOM + signature Cosign sur les images GHCR (structurant pour la livraison v1.0 self-hosting, KIN-091).

## Test plan

- [ ] CI verte (lint + typecheck + tests)
- [ ] Reviewer : `docker compose down -v && up -d --build` from this branch → API + Web 200 sans intervention
- [ ] Reviewer : `docker build -f apps/{api,web}/Dockerfile.prod --target deps .` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)