### PR TITLE
feat(ui,web,i18n,a11y): refonte page d'accueil — dashboard clinical-calm desktop + mobile (KIN-106)

### DIFF
--- a/apps/web/src/app/auth/verify/__tests__/page.test.tsx
+++ b/apps/web/src/app/auth/verify/__tests__/page.test.tsx
@@ -84,6 +84,27 @@ describe('VerifyPage', () => {
       expect(screen.getByText(/Échec de la vérification|Verification failed/i)).toBeInTheDocument();
     });
   });
+
+  it('redirige vers le dashboard d’accueil (/) après vérification réussie', async () => {
+    const { apiFetch } = jest.requireMock('../../../../lib/api-client') as {
+      apiFetch: jest.Mock;
+    };
+    const fakeJwtPayload = Buffer.from(
+      JSON.stringify({ sub: 'u1', deviceId: 'd1', householdId: 'h1' }),
+    ).toString('base64');
+    // Premier appel : /auth/verify renvoie l'accessToken.
+    // Second appel : /auth/register-device renvoie OK.
+    apiFetch
+      .mockResolvedValueOnce({ accessToken: `header.${fakeJwtPayload}.sig` })
+      .mockResolvedValueOnce({});
+    searchParamsGet.mockReturnValue('valid-token');
+
+    renderWithProviders(<VerifyPage />);
+    await flush();
+    await waitFor(() => {
+      expect(pushMock).toHaveBeenCalledWith('/');
+    });
+  });
 });
 
 jest.setTimeout(15000);

--- a/apps/web/src/app/auth/verify/page.tsx
+++ b/apps/web/src/app/auth/verify/page.tsx
@@ -71,7 +71,9 @@ function VerifyInner(): React.JSX.Element {
           }
           // 409 = device already registered — expected on repeat visits
         }
-        router.push('/journal');
+        // Redirige vers le dashboard d'accueil — depuis KIN-106, `/` est le
+        // tableau de bord Home et non plus une landing publique.
+        router.push('/');
       } catch {
         setErrorCode('verify-error');
       }

--- a/apps/web/src/app/page.test.tsx
+++ b/apps/web/src/app/page.test.tsx
@@ -1,25 +1,53 @@
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { renderWithProviders } from '../test-utils/render';
 import HomePage from './page';
 
+const replaceMock = jest.fn();
+const pushMock = jest.fn();
+
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
 }));
+
+const authStoreMock = jest.fn();
 
 jest.mock('../stores/auth-store', () => ({
-  useAuthStore: jest.fn((selector: (s: { accessToken: null }) => unknown) =>
-    selector({ accessToken: null }),
-  ),
+  useAuthStore: (selector: (s: { accessToken: string | null }) => unknown): unknown =>
+    selector(authStoreMock()),
 }));
 
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 4; i += 1) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+};
+
 describe('HomePage', () => {
-  it('affiche le titre Kinhale', () => {
-    renderWithProviders(<HomePage />);
-    expect(screen.getByText('Kinhale')).toBeInTheDocument();
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('affiche le sous-titre en français par défaut', () => {
+  it("redirige vers /auth quand l'utilisateur n'est pas authentifié", async () => {
+    authStoreMock.mockReturnValue({ accessToken: null });
     renderWithProviders(<HomePage />);
-    expect(screen.getByText('Coordonnez les soins de votre enfant')).toBeInTheDocument();
+    await flush();
+    expect(replaceMock).toHaveBeenCalledWith('/auth');
+  });
+
+  it('affiche le tableau de bord quand authentifié', async () => {
+    authStoreMock.mockReturnValue({ accessToken: 'token-fake' });
+    renderWithProviders(<HomePage />);
+    await flush();
+    // Le HomeDashboard rend le titre du programme du jour, signature
+    // visuelle fiable que le composant de dashboard est bien monté.
+    expect(screen.getByText(/Programme du jour|Today's schedule/i)).toBeInTheDocument();
+    // Disclaimer médical RM27 toujours présent.
+    expect(
+      screen.getByText(/remplace pas un avis médical|substitute for medical advice/i),
+    ).toBeInTheDocument();
   });
 });
+
+jest.setTimeout(15000);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
-import { HomeDashboard, HomeWebDashboard } from '@kinhale/ui/home';
+import { HomeDashboard, HomeWebDashboard, type HomeNavItem } from '@kinhale/ui/home';
 import { useAuthStore } from '../stores/auth-store';
 import { buildHomeMessages } from '../lib/home/messages';
 import { mockHomeData } from '../lib/home/mock-data';
@@ -46,6 +46,37 @@ export default function HomePage(): React.JSX.Element | null {
 
   const messages = React.useMemo(() => buildHomeMessages(t), [t]);
 
+  // Sidebar nav (desktop) localisée — clés `home.dashboard.nav.*` côté
+  // i18n FR + EN. La règle non-négociable Kinhale impose i18n dès le
+  // commit #1 — pas de fallback hardcodé côté composant partagé.
+  const navItems = React.useMemo<HomeNavItem[]>(
+    () => [
+      { key: 'home', label: t('home.dashboard.nav.home'), active: true },
+      {
+        key: 'history',
+        label: t('home.dashboard.nav.history'),
+        onPress: () => router.push('/journal'),
+      },
+      { key: 'pumps', label: t('home.dashboard.nav.pumps') },
+      {
+        key: 'caregivers',
+        label: t('home.dashboard.nav.caregivers'),
+        onPress: () => router.push('/caregivers'),
+      },
+      {
+        key: 'reports',
+        label: t('home.dashboard.nav.reports'),
+        onPress: () => router.push('/reports'),
+      },
+      {
+        key: 'settings',
+        label: t('home.dashboard.nav.settings'),
+        onPress: () => router.push('/settings/notifications'),
+      },
+    ],
+    [router, t],
+  );
+
   if (!hydrated || accessToken === null || isDesktop === null) {
     return null;
   }
@@ -57,7 +88,14 @@ export default function HomePage(): React.JSX.Element | null {
   };
 
   if (isDesktop) {
-    return <HomeWebDashboard messages={messages} data={mockHomeData} handlers={handlers} />;
+    return (
+      <HomeWebDashboard
+        messages={messages}
+        data={mockHomeData}
+        handlers={handlers}
+        navItems={navItems}
+      />
+    );
   }
 
   return <HomeDashboard messages={messages} data={mockHomeData} handlers={handlers} />;

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,31 +1,64 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
-import { YStack, H1, Text, Button } from 'tamagui';
+import { HomeDashboard, HomeWebDashboard } from '@kinhale/ui/home';
 import { useAuthStore } from '../stores/auth-store';
+import { buildHomeMessages } from '../lib/home/messages';
+import { mockHomeData } from '../lib/home/mock-data';
 
-export default function HomePage(): React.JSX.Element {
+const DESKTOP_BREAKPOINT_PX = 1024;
+
+export default function HomePage(): React.JSX.Element | null {
   const { t } = useTranslation('common');
   const router = useRouter();
   const accessToken = useAuthStore((s) => s.accessToken);
 
-  useEffect(() => {
-    if (accessToken !== null) {
-      router.push('/journal');
-    }
-  }, [accessToken, router]);
+  // Le store zustand est persisté en localStorage. Au premier rendu côté
+  // client, `accessToken` vaut `null` AVANT l'hydratation, puis prend la
+  // vraie valeur. On attend donc le pump d'hydratation avant de décider
+  // d'un redirect — sans ça, un utilisateur déjà connecté est renvoyé
+  // sur /auth à chaque rechargement.
+  const [hydrated, setHydrated] = useState(false);
+  // `isDesktop` ne se calcule que côté client : matchMedia n'existe pas
+  // pendant le SSR. On rend null le temps de l'hydratation pour éviter un
+  // flash mobile→desktop sur les écrans larges.
+  const [isDesktop, setIsDesktop] = useState<boolean | null>(null);
 
-  return (
-    <YStack padding="$4" gap="$4" alignItems="center" justifyContent="center" flex={1}>
-      <H1>{t('home.title')}</H1>
-      <Text fontSize="$5" textAlign="center">
-        {t('home.subtitle')}
-      </Text>
-      <Button onPress={() => router.push('/auth')} width="100%" maxWidth={400}>
-        {t('home.getStarted')}
-      </Button>
-    </YStack>
-  );
+  useEffect(() => {
+    setHydrated(true);
+    if (typeof window !== 'undefined') {
+      const mq = window.matchMedia(`(min-width: ${DESKTOP_BREAKPOINT_PX}px)`);
+      const update = (): void => setIsDesktop(mq.matches);
+      update();
+      mq.addEventListener('change', update);
+      return () => mq.removeEventListener('change', update);
+    }
+    return undefined;
+  }, []);
+
+  useEffect(() => {
+    if (hydrated && accessToken === null) {
+      router.replace('/auth');
+    }
+  }, [hydrated, accessToken, router]);
+
+  const messages = React.useMemo(() => buildHomeMessages(t), [t]);
+
+  if (!hydrated || accessToken === null || isDesktop === null) {
+    return null;
+  }
+
+  const handlers = {
+    onPressMaint: (): void => router.push('/journal/add?kind=maint'),
+    onPressRescue: (): void => router.push('/journal/add?kind=rescue'),
+    onPressHistory: (): void => router.push('/journal'),
+  };
+
+  if (isDesktop) {
+    return <HomeWebDashboard messages={messages} data={mockHomeData} handlers={handlers} />;
+  }
+
+  return <HomeDashboard messages={messages} data={mockHomeData} handlers={handlers} />;
 }

--- a/apps/web/src/lib/home/messages.ts
+++ b/apps/web/src/lib/home/messages.ts
@@ -1,0 +1,74 @@
+import type { TFunction } from 'i18next';
+import type { HomeDashboardMessages, InhalerView, ScheduleSlotState } from '@kinhale/ui/home';
+
+// Construit l'objet `HomeDashboardMessages` attendu par les composants
+// partagés à partir d'un `t()` i18next courant. Centralise le mapping pour
+// ne pas dupliquer entre la version web et la future variante mobile.
+export function buildHomeMessages(t: TFunction<'common'>): HomeDashboardMessages {
+  const stateLabels: Record<ScheduleSlotState, string> = {
+    done: t('home.dashboard.scheduleStateLabels.done'),
+    pending: t('home.dashboard.scheduleStateLabels.pending'),
+    overdue: t('home.dashboard.scheduleStateLabels.overdue'),
+    missed: t('home.dashboard.scheduleStateLabels.missed'),
+  };
+
+  return {
+    childName: t('home.dashboard.childName'),
+    dateLabel: new Intl.DateTimeFormat('fr-CA', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+    }).format(new Date()),
+    roleLabel: t('home.dashboard.roleLabel'),
+
+    status: {
+      onTrackTitle: t('home.dashboard.status.onTrackTitle'),
+      onTrackSub: t('home.dashboard.status.onTrackSub'),
+      dueTitle: t('home.dashboard.status.dueTitle'),
+      dueSub: t('home.dashboard.status.dueSub'),
+      overdueTitle: t('home.dashboard.status.overdueTitle'),
+      overdueSub: t('home.dashboard.status.overdueSub'),
+    },
+
+    scheduleTitle: t('home.dashboard.scheduleTitle'),
+    scheduleStateLabels: stateLabels,
+
+    inventoryTitle: t('home.dashboard.inventoryTitle'),
+    refillSoonLabel: t('home.dashboard.refillSoonLabel'),
+    formatDosesLeft: (n: number): string => t('home.dashboard.dosesLeft', { n }),
+    formatExpiryStatus: (
+      inh: InhalerView,
+    ): { kind: 'normal' | 'soon' | 'expired'; label: string } => {
+      // Heuristique simple : maquette uniquement, pas de données réelles ici.
+      // Le wiring vers @kinhale/sync (date d'expiration projetée) viendra dans
+      // une PR ultérieure quand on remplacera les données mockées.
+      const expiryDate = new Date(inh.expiry);
+      const now = new Date();
+      const daysUntil = Math.floor((expiryDate.getTime() - now.getTime()) / (24 * 60 * 60 * 1000));
+      if (daysUntil < 0) {
+        return { kind: 'expired', label: t('home.dashboard.expiry.expired') };
+      }
+      const dateLabel = new Intl.DateTimeFormat('fr-CA', {
+        day: 'numeric',
+        month: 'short',
+      }).format(expiryDate);
+      if (daysUntil < 45) {
+        return { kind: 'soon', label: t('home.dashboard.expiry.soon', { date: dateLabel }) };
+      }
+      return { kind: 'normal', label: t('home.dashboard.expiry.normal', { date: dateLabel }) };
+    },
+
+    activityTitle: t('home.dashboard.activityTitle'),
+    historyLabel: t('home.dashboard.historyLabel'),
+    formatBy: (name: string): string => t('home.dashboard.by', { name }),
+
+    caregiversTitle: t('home.dashboard.caregiversTitle'),
+    syncPendingLabel: t('home.dashboard.syncPendingLabel'),
+
+    quickActionCaption: t('home.dashboard.quickActionCaption'),
+    quickMaintLabel: t('home.dashboard.quickMaint'),
+    quickRescueLabel: t('home.dashboard.quickRescue'),
+
+    notMedicalDevice: t('home.dashboard.notMedicalDevice'),
+  };
+}

--- a/apps/web/src/lib/home/mock-data.ts
+++ b/apps/web/src/lib/home/mock-data.ts
@@ -1,0 +1,121 @@
+import type {
+  ActivityItem,
+  CaregiverView,
+  HomeDashboardData,
+  InhalerView,
+  ScheduleSlot,
+} from '@kinhale/ui/home';
+
+// Données mockées plausibles pour le dashboard Home, calées sur la maquette
+// `docs/design/handoffs/2026-04-26-clinical-calm/project/Kinhale Home.html`.
+//
+// **Ce fichier est temporaire** : il sera remplacé par les projections
+// `@kinhale/sync` réelles (doses, pompes, aidants depuis le doc Automerge
+// chiffré local) dans une PR ultérieure dédiée au wiring.
+//
+// Pourquoi mocker maintenant : la PR-A refonde le rendu visuel du dashboard
+// pour matcher la maquette. Brancher les vraies données implique aussi de
+// retoucher les flux de projection — séparer les deux changements rend la
+// revue beaucoup plus simple et limite le blast radius si un bug visuel
+// nécessite un revert.
+
+const today = new Date();
+function inDays(n: number): string {
+  const d = new Date(today);
+  d.setDate(d.getDate() + n);
+  return d.toISOString();
+}
+
+const inhalersMock: InhalerView[] = [
+  {
+    id: 'i-fluticasone',
+    name: 'Fluticasone 50',
+    contextLabel: 'Fond · matin et soir',
+    kind: 'maint',
+    doses: 142,
+    total: 200,
+    expiry: inDays(180),
+  },
+  {
+    id: 'i-salbu-home',
+    name: 'Salbutamol 100',
+    contextLabel: 'Secours · maison',
+    kind: 'rescue',
+    doses: 22,
+    total: 200,
+    expiry: inDays(38),
+    isLow: true,
+  },
+  {
+    id: 'i-salbu-daycare',
+    name: 'Salbutamol 100',
+    contextLabel: 'Secours · garderie',
+    kind: 'rescue',
+    doses: 168,
+    total: 200,
+    expiry: inDays(220),
+  },
+];
+
+const scheduleMock: ScheduleSlot[] = [
+  { label: 'Matin', time: '8h00', state: 'done' },
+  { label: 'Midi', time: '12h00', state: 'pending' },
+  { label: 'Soir', time: '20h00', state: 'pending' },
+];
+
+const activityMock: ActivityItem[] = [
+  {
+    id: 'a1',
+    kind: 'maint',
+    label: 'Fluticasone — 1 dose',
+    who: 'Sandrine',
+    time: '8h05',
+    ago: 'il y a 3 h',
+  },
+  {
+    id: 'a2',
+    kind: 'rescue',
+    label: 'Salbutamol — 2 doses',
+    who: 'Garderie',
+    time: 'hier 14h22',
+    ago: 'hier',
+    cause: 'Effort',
+  },
+];
+
+const caregiversMock: CaregiverView[] = [
+  {
+    id: 'c1',
+    name: 'Sandrine',
+    roleLabel: 'Admin',
+    initial: 'S',
+    online: true,
+    accentColor: 'oklch(56% 0.07 235)',
+  },
+  {
+    id: 'c2',
+    name: 'Marc',
+    roleLabel: 'Co-parent',
+    initial: 'M',
+    online: false,
+    accentColor: 'oklch(58% 0.115 35)',
+  },
+  {
+    id: 'c3',
+    name: 'Garderie',
+    roleLabel: 'Restreint',
+    initial: 'G',
+    online: true,
+    syncPending: true,
+    accentColor: 'oklch(72% 0.115 75)',
+  },
+];
+
+export const mockHomeData: HomeDashboardData = {
+  role: 'contributor',
+  time: 'on-track',
+  scheduleSlots: scheduleMock,
+  inhalers: inhalersMock,
+  activity: activityMock,
+  caregivers: caregiversMock,
+};

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -6,6 +6,14 @@
     "dashboard": {
       "childName": "Your child",
       "roleLabel": "Co-parent",
+      "nav": {
+        "home": "Home",
+        "history": "History",
+        "pumps": "My inhalers",
+        "caregivers": "Caregivers",
+        "reports": "Reports",
+        "settings": "Settings"
+      },
       "status": {
         "onTrackTitle": "All on track",
         "onTrackSub": "No action needed right now.",

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -2,7 +2,43 @@
   "home": {
     "title": "Kinhale",
     "subtitle": "Coordinate your child's care",
-    "getStarted": "Get started"
+    "getStarted": "Get started",
+    "dashboard": {
+      "childName": "Your child",
+      "roleLabel": "Co-parent",
+      "status": {
+        "onTrackTitle": "All on track",
+        "onTrackSub": "No action needed right now.",
+        "dueTitle": "Controller dose due",
+        "dueSub": "Time for the controller is near.",
+        "overdueTitle": "Controller dose overdue",
+        "overdueSub": "Please confirm the dose as soon as possible."
+      },
+      "scheduleTitle": "Today's schedule",
+      "scheduleStateLabels": {
+        "done": "done",
+        "pending": "upcoming",
+        "overdue": "overdue",
+        "missed": "missed"
+      },
+      "inventoryTitle": "My inhalers",
+      "refillSoonLabel": "Refill soon",
+      "dosesLeft": "{{n}} doses",
+      "expiry": {
+        "expired": "Expired",
+        "soon": "Expires {{date}}",
+        "normal": "Expires {{date}}"
+      },
+      "activityTitle": "Recent activity",
+      "historyLabel": "History",
+      "by": "by {{name}}",
+      "caregiversTitle": "Caregivers",
+      "syncPendingLabel": "Sync pending",
+      "quickActionCaption": "Log a dose",
+      "quickMaint": "Controller",
+      "quickRescue": "Rescue",
+      "notMedicalDevice": "Not a substitute for medical advice."
+    }
   },
   "nav": {
     "home": "Home",

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -6,6 +6,14 @@
     "dashboard": {
       "childName": "Votre enfant",
       "roleLabel": "Co-parent",
+      "nav": {
+        "home": "Accueil",
+        "history": "Historique",
+        "pumps": "Mes pompes",
+        "caregivers": "Aidants",
+        "reports": "Rapports",
+        "settings": "Réglages"
+      },
       "status": {
         "onTrackTitle": "Tout est à jour",
         "onTrackSub": "Aucune action requise pour l'instant.",

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -2,7 +2,43 @@
   "home": {
     "title": "Kinhale",
     "subtitle": "Coordonnez les soins de votre enfant",
-    "getStarted": "Commencer"
+    "getStarted": "Commencer",
+    "dashboard": {
+      "childName": "Votre enfant",
+      "roleLabel": "Co-parent",
+      "status": {
+        "onTrackTitle": "Tout est à jour",
+        "onTrackSub": "Aucune action requise pour l'instant.",
+        "dueTitle": "Prise de fond prévue",
+        "dueSub": "C'est bientôt l'heure du contrôleur.",
+        "overdueTitle": "Prise de fond en retard",
+        "overdueSub": "Confirmez la dose dès que possible."
+      },
+      "scheduleTitle": "Programme du jour",
+      "scheduleStateLabels": {
+        "done": "fait",
+        "pending": "à venir",
+        "overdue": "en retard",
+        "missed": "manqué"
+      },
+      "inventoryTitle": "Mes pompes",
+      "refillSoonLabel": "Renouveler bientôt",
+      "dosesLeft": "{{n}} doses",
+      "expiry": {
+        "expired": "Expirée",
+        "soon": "Expire le {{date}}",
+        "normal": "Expire le {{date}}"
+      },
+      "activityTitle": "Activité récente",
+      "historyLabel": "Historique",
+      "by": "par {{name}}",
+      "caregiversTitle": "Aidants",
+      "syncPendingLabel": "Sync en attente",
+      "quickActionCaption": "Enregistrer une prise",
+      "quickMaint": "Fond",
+      "quickRescue": "Secours",
+      "notMedicalDevice": "Ne remplace pas un avis médical."
+    }
   },
   "nav": {
     "home": "Accueil",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,6 +11,7 @@
     ".": "./src/index.ts",
     "./theme": "./src/theme/index.ts",
     "./auth": "./src/components/auth/index.ts",
+    "./home": "./src/components/home/index.ts",
     "./icons": "./src/icons/index.ts"
   },
   "scripts": {

--- a/packages/ui/src/components/home/Activity.tsx
+++ b/packages/ui/src/components/home/Activity.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { ArrowRightIcon, InhalerMaintIcon, InhalerRescueIcon } from '../../icons';
+import { Section } from './Section';
+import { SectionHeader } from './SectionHeader';
+import type { ActivityItem } from './types';
+
+interface ActivityProps {
+  title: string;
+  items: ActivityItem[];
+  /** Localised "by {name}" template used on each row. */
+  formatBy: (name: string) => string;
+  historyLabel: string;
+  onPressHistory?: (() => void) | undefined;
+  emptyState?: React.ReactNode;
+}
+
+export function Activity({
+  title,
+  items,
+  formatBy,
+  historyLabel,
+  onPressHistory,
+  emptyState,
+}: ActivityProps): React.JSX.Element {
+  return (
+    <Section>
+      <SectionHeader
+        label={title}
+        action={
+          <XStack
+            gap="$1"
+            alignItems="center"
+            cursor="pointer"
+            {...(onPressHistory ? { onPress: onPressHistory } : {})}
+          >
+            <Text fontSize={12} color="$maint" fontWeight="500">
+              {historyLabel}
+            </Text>
+            <Text color="$maint" display="flex" alignItems="center">
+              <ArrowRightIcon size={11} color="currentColor" />
+            </Text>
+          </XStack>
+        }
+      />
+
+      {items.length === 0 && emptyState}
+
+      <YStack>
+        {items.map((it, i) => {
+          const isRescue = it.kind === 'rescue';
+          return (
+            <XStack
+              key={it.id}
+              gap="$3"
+              alignItems="center"
+              paddingVertical="$2.5"
+              borderTopWidth={i === 0 ? 0 : 0.5}
+              borderTopColor="$borderColor"
+            >
+              <Text
+                width={28}
+                height={28}
+                borderRadius={8}
+                backgroundColor={isRescue ? '$rescueSoft' : '$maintSoft'}
+                color={isRescue ? '$rescue' : '$maint'}
+                alignItems="center"
+                justifyContent="center"
+                flexShrink={0}
+                display="flex"
+              >
+                {isRescue ? (
+                  <InhalerRescueIcon size={15} color="currentColor" />
+                ) : (
+                  <InhalerMaintIcon size={15} color="currentColor" />
+                )}
+              </Text>
+
+              <YStack flex={1} minWidth={0}>
+                <XStack alignItems="baseline" gap="$1.5" flexWrap="wrap">
+                  <Text fontSize={13.5} color="$color" fontWeight="500">
+                    {it.label}
+                  </Text>
+                  {it.cause && (
+                    <Stack
+                      paddingHorizontal="$1.5"
+                      paddingVertical={1}
+                      backgroundColor="$rescueSoft"
+                      borderRadius={9999}
+                    >
+                      <Text fontSize={11} color="$rescueInk" fontWeight="500">
+                        {it.cause}
+                      </Text>
+                    </Stack>
+                  )}
+                </XStack>
+                <Text fontSize={12} color="$colorMore" marginTop={2}>
+                  {formatBy(it.who)} · {it.ago}
+                  {it.syncNote ? ` · ${it.syncNote}` : ''}
+                </Text>
+              </YStack>
+
+              <Text fontSize={12} color="$colorMore" fontFamily="$mono">
+                {it.time}
+              </Text>
+            </XStack>
+          );
+        })}
+      </YStack>
+    </Section>
+  );
+}

--- a/packages/ui/src/components/home/BottomActionBar.tsx
+++ b/packages/ui/src/components/home/BottomActionBar.tsx
@@ -1,0 +1,121 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { InhalerMaintIcon, InhalerRescueIcon } from '../../icons';
+
+interface BottomActionBarProps {
+  /** Section subtitle ("Log a dose"). */
+  caption: string;
+  maintLabel: string;
+  rescueLabel: string;
+  onPressMaint?: (() => void) | undefined;
+  onPressRescue?: (() => void) | undefined;
+}
+
+export function BottomActionBar({
+  caption,
+  maintLabel,
+  rescueLabel,
+  onPressMaint,
+  onPressRescue,
+}: BottomActionBarProps): React.JSX.Element {
+  return (
+    <YStack
+      // `position: sticky` n'existe pas en RN ; on passe par style natif côté
+      // web. Sur mobile, le bar reste juste en bas du flux normal — le scroll
+      // du parent ScrollView gère l'effet attendu.
+      style={{ position: 'sticky' }}
+      bottom={0}
+      left={0}
+      right={0}
+      zIndex={30}
+      paddingHorizontal="$4"
+      paddingTop="$2.5"
+      paddingBottom="$5"
+      backgroundColor="$background"
+      borderTopWidth={0.5}
+      borderTopColor="$borderColor"
+    >
+      <Text
+        fontSize={10}
+        color="$colorMore"
+        textTransform="uppercase"
+        letterSpacing="0.08em"
+        fontWeight="600"
+        textAlign="center"
+        marginBottom="$2"
+      >
+        {caption}
+      </Text>
+      <XStack gap="$2.5">
+        {/* Maintenance button (filled accent) */}
+        <Stack
+          flex={1}
+          backgroundColor="$maint"
+          borderRadius={20}
+          paddingVertical="$3.5"
+          paddingHorizontal="$2.5"
+          alignItems="center"
+          justifyContent="center"
+          minHeight={76}
+          cursor="pointer"
+          pressStyle={{ opacity: 0.85 }}
+          onPress={onPressMaint}
+          accessibilityRole="button"
+          accessibilityLabel={maintLabel}
+        >
+          <Stack
+            width={38}
+            height={38}
+            borderRadius={12}
+            backgroundColor="rgba(255,255,255,0.18)"
+            alignItems="center"
+            justifyContent="center"
+            marginBottom="$1.5"
+          >
+            <InhalerMaintIcon size={26} color="white" />
+          </Stack>
+          <Text fontSize={13} fontWeight="600" color="white" letterSpacing="0.01em">
+            {maintLabel}
+          </Text>
+        </Stack>
+
+        {/* Rescue button (outline) */}
+        <Stack
+          flex={1}
+          backgroundColor="$surface"
+          borderWidth={1.5}
+          borderColor="$rescue"
+          borderRadius={20}
+          paddingVertical="$3.5"
+          paddingHorizontal="$2.5"
+          alignItems="center"
+          justifyContent="center"
+          minHeight={76}
+          cursor="pointer"
+          pressStyle={{ opacity: 0.7 }}
+          onPress={onPressRescue}
+          accessibilityRole="button"
+          accessibilityLabel={rescueLabel}
+        >
+          <Text
+            width={38}
+            height={38}
+            borderRadius={12}
+            backgroundColor="$rescueSoft"
+            alignItems="center"
+            justifyContent="center"
+            marginBottom="$1.5"
+            color="$rescue"
+            display="flex"
+          >
+            <InhalerRescueIcon size={26} color="currentColor" />
+          </Text>
+          <Text fontSize={13} fontWeight="600" color="$rescue" letterSpacing="0.01em">
+            {rescueLabel}
+          </Text>
+        </Stack>
+      </XStack>
+    </YStack>
+  );
+}

--- a/packages/ui/src/components/home/Caregivers.tsx
+++ b/packages/ui/src/components/home/Caregivers.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { ScrollView, Stack, Text, XStack, YStack } from 'tamagui';
+
+import { Section } from './Section';
+import { SectionHeader } from './SectionHeader';
+import type { CaregiverView } from './types';
+
+interface CaregiversProps {
+  title: string;
+  caregivers: CaregiverView[];
+  syncPendingLabel: string;
+}
+
+export function Caregivers({
+  title,
+  caregivers,
+  syncPendingLabel,
+}: CaregiversProps): React.JSX.Element {
+  return (
+    <Section>
+      <SectionHeader label={title} />
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <XStack gap="$4">
+          {caregivers.map((p) => (
+            <YStack key={p.id} alignItems="center" gap="$1.5" minWidth={56}>
+              <Stack position="relative">
+                <Stack
+                  width={44}
+                  height={44}
+                  borderRadius={9999}
+                  backgroundColor="$surface2"
+                  alignItems="center"
+                  justifyContent="center"
+                  borderWidth={0.5}
+                  borderColor="$borderColor"
+                >
+                  <Text fontSize={16} fontWeight="600" color={p.accentColor}>
+                    {p.initial}
+                  </Text>
+                </Stack>
+                <Stack
+                  position="absolute"
+                  bottom={-1}
+                  right={-1}
+                  width={12}
+                  height={12}
+                  borderRadius={9999}
+                  backgroundColor={p.online ? '$ok' : '$colorFaint'}
+                  borderWidth={2}
+                  borderColor="$surface"
+                />
+              </Stack>
+              <Text fontSize={11} color="$colorMuted" fontWeight="500" textAlign="center">
+                {p.name}
+              </Text>
+              <Text
+                fontSize={10}
+                color="$colorFaint"
+                textTransform="uppercase"
+                letterSpacing="0.06em"
+              >
+                {p.syncPending ? syncPendingLabel : p.roleLabel}
+              </Text>
+            </YStack>
+          ))}
+        </XStack>
+      </ScrollView>
+    </Section>
+  );
+}

--- a/packages/ui/src/components/home/DaycareRestrictedView.tsx
+++ b/packages/ui/src/components/home/DaycareRestrictedView.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import { Stack, Text, YStack } from 'tamagui';
+
+import { CheckIcon, ClockIcon, InhalerMaintIcon } from '../../icons';
+
+interface DaycareRestrictedViewProps {
+  childName: string;
+  sectionLabel: string;
+  promptLabel: string;
+  doneLabel: string;
+  buttonLabel: string;
+  sessionLabel: string;
+  disclaimer: string;
+  onPressGiven?: (() => void) | undefined;
+}
+
+export function DaycareRestrictedView({
+  childName,
+  sectionLabel,
+  promptLabel,
+  doneLabel,
+  buttonLabel,
+  sessionLabel,
+  disclaimer,
+  onPressGiven,
+}: DaycareRestrictedViewProps): React.JSX.Element {
+  const [given, setGiven] = React.useState(false);
+
+  const handlePress = (): void => {
+    setGiven(true);
+    onPressGiven?.();
+  };
+
+  return (
+    <YStack flex={1} padding="$4" gap="$3.5">
+      <YStack
+        padding="$4"
+        backgroundColor="$surface"
+        borderRadius={20}
+        borderWidth={0.5}
+        borderColor="$borderColor"
+      >
+        <Text
+          fontSize={11}
+          color="$colorMore"
+          textTransform="uppercase"
+          letterSpacing="0.08em"
+          fontWeight="600"
+        >
+          {sectionLabel}
+        </Text>
+        <Text
+          fontSize={24}
+          lineHeight={28}
+          marginTop={8}
+          fontWeight="500"
+          color="$color"
+          letterSpacing="-0.02em"
+        >
+          {childName}
+        </Text>
+        <Text fontSize={13} color="$colorMuted" marginTop={4}>
+          {given ? doneLabel : promptLabel}
+        </Text>
+      </YStack>
+
+      <Stack
+        backgroundColor={given ? '$okSoft' : '$maint'}
+        borderRadius={20}
+        paddingVertical="$6"
+        paddingHorizontal="$4"
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="center"
+        gap="$3"
+        minHeight={96}
+        cursor={given ? 'default' : 'pointer'}
+        {...(given ? {} : { pressStyle: { opacity: 0.9 }, onPress: handlePress })}
+        accessibilityRole="button"
+        accessibilityLabel={given ? doneLabel : buttonLabel}
+        accessibilityState={{ disabled: given }}
+      >
+        <Stack
+          width={44}
+          height={44}
+          borderRadius={12}
+          backgroundColor={given ? '$ok' : 'rgba(255,255,255,0.18)'}
+          alignItems="center"
+          justifyContent="center"
+          flexShrink={0}
+        >
+          {given ? (
+            <CheckIcon size={22} color="white" />
+          ) : (
+            <InhalerMaintIcon size={24} color="white" />
+          )}
+        </Stack>
+        <Text
+          fontSize={20}
+          fontWeight="500"
+          color={given ? '$okInk' : 'white'}
+          letterSpacing="-0.02em"
+        >
+          {given ? doneLabel : buttonLabel}
+        </Text>
+      </Stack>
+
+      <Text
+        flexDirection="row"
+        alignItems="center"
+        justifyContent="center"
+        gap="$2"
+        color="$colorMore"
+        display="flex"
+      >
+        <ClockIcon size={12} color="currentColor" />
+        <Text fontSize={12} color="$colorMore">
+          {sessionLabel}
+        </Text>
+      </Text>
+
+      <YStack flex={1} />
+
+      <Text fontSize={11} color="$colorFaint" textAlign="center" fontStyle="italic">
+        {disclaimer}
+      </Text>
+    </YStack>
+  );
+}

--- a/packages/ui/src/components/home/HomeDashboard.tsx
+++ b/packages/ui/src/components/home/HomeDashboard.tsx
@@ -1,0 +1,193 @@
+import * as React from 'react';
+import { ScrollView, Text, Theme, YStack } from 'tamagui';
+
+import { Activity } from './Activity';
+import { BottomActionBar } from './BottomActionBar';
+import { Caregivers } from './Caregivers';
+import { DaycareRestrictedView } from './DaycareRestrictedView';
+import { Inventory } from './Inventory';
+import { KinhaleHeader } from './KinhaleHeader';
+import { ScheduleStrip } from './ScheduleStrip';
+import { StatusHero } from './StatusHero';
+import type {
+  ActivityItem,
+  CaregiverRole,
+  CaregiverView,
+  InhalerView,
+  ScheduleSlot,
+  ScheduleSlotState,
+  StatusTime,
+} from './types';
+
+export interface HomeDashboardMessages {
+  // Header
+  childName: string;
+  dateLabel: string;
+  roleLabel: string;
+  // Status hero
+  status: {
+    onTrackTitle: string;
+    onTrackSub: string;
+    dueTitle: string;
+    dueSub: string;
+    overdueTitle: string;
+    overdueSub: string;
+  };
+  // Schedule
+  scheduleTitle: string;
+  scheduleStateLabels: Record<ScheduleSlotState, string>;
+  // Inventory
+  inventoryTitle: string;
+  refillSoonLabel: string;
+  formatDosesLeft: (n: number) => string;
+  formatExpiryStatus: (inh: InhalerView) => { kind: 'normal' | 'soon' | 'expired'; label: string };
+  inventoryEmpty?: React.ReactNode;
+  // Activity
+  activityTitle: string;
+  historyLabel: string;
+  formatBy: (name: string) => string;
+  activityEmpty?: React.ReactNode;
+  // Caregivers
+  caregiversTitle: string;
+  syncPendingLabel: string;
+  // Bottom bar
+  quickActionCaption: string;
+  quickMaintLabel: string;
+  quickRescueLabel: string;
+  // Disclaimer
+  notMedicalDevice: string;
+  // Daycare-restricted view
+  daycareView?: {
+    sectionLabel: string;
+    promptLabel: string;
+    doneLabel: string;
+    buttonLabel: string;
+    sessionLabel: string;
+  };
+}
+
+export interface HomeDashboardData {
+  role: CaregiverRole;
+  time: StatusTime;
+  scheduleSlots: ScheduleSlot[];
+  inhalers: InhalerView[];
+  activity: ActivityItem[];
+  caregivers: CaregiverView[];
+}
+
+export interface HomeDashboardHandlers {
+  onPressMaint?: (() => void) | undefined;
+  onPressRescue?: (() => void) | undefined;
+  onPressHistory?: (() => void) | undefined;
+  onPressDaycareGiven?: (() => void) | undefined;
+}
+
+export interface HomeDashboardProps {
+  messages: HomeDashboardMessages;
+  data: HomeDashboardData;
+  handlers?: HomeDashboardHandlers;
+  /** Defaults to `kinhale_light`. Pass `kinhale_dark` for the dark theme. */
+  theme?: 'kinhale_light' | 'kinhale_dark';
+}
+
+/** The full Home dashboard for an authenticated caregiver. */
+export function HomeDashboard({
+  messages,
+  data,
+  handlers,
+  theme = 'kinhale_light',
+}: HomeDashboardProps): React.JSX.Element {
+  const { role, time, scheduleSlots, inhalers, activity, caregivers } = data;
+
+  if (role === 'restricted' && messages.daycareView) {
+    return (
+      <Theme name={theme}>
+        <YStack flex={1} backgroundColor="$background">
+          <KinhaleHeader
+            dateLabel={messages.dateLabel}
+            childName={messages.childName}
+            roleLabel={messages.roleLabel}
+            role={role}
+          />
+          <DaycareRestrictedView
+            childName={messages.childName}
+            sectionLabel={messages.daycareView.sectionLabel}
+            promptLabel={messages.daycareView.promptLabel}
+            doneLabel={messages.daycareView.doneLabel}
+            buttonLabel={messages.daycareView.buttonLabel}
+            sessionLabel={messages.daycareView.sessionLabel}
+            disclaimer={messages.notMedicalDevice}
+            onPressGiven={handlers?.onPressDaycareGiven}
+          />
+        </YStack>
+      </Theme>
+    );
+  }
+
+  return (
+    <Theme name={theme}>
+      <YStack flex={1} backgroundColor="$background">
+        <ScrollView style={{ flex: 1 }} contentContainerStyle={{ paddingBottom: 8 }}>
+          <KinhaleHeader
+            dateLabel={messages.dateLabel}
+            childName={messages.childName}
+            roleLabel={messages.roleLabel}
+            role={role}
+          />
+
+          <YStack paddingHorizontal="$4" paddingBottom="$5" gap="$3.5">
+            <StatusHero time={time} messages={messages.status} />
+
+            <ScheduleStrip
+              title={messages.scheduleTitle}
+              slots={scheduleSlots}
+              stateLabels={messages.scheduleStateLabels}
+            />
+
+            <Inventory
+              title={messages.inventoryTitle}
+              inhalers={inhalers}
+              formatDosesLeft={messages.formatDosesLeft}
+              formatExpiryStatus={messages.formatExpiryStatus}
+              refillSoonLabel={messages.refillSoonLabel}
+              emptyState={messages.inventoryEmpty}
+            />
+
+            <Activity
+              title={messages.activityTitle}
+              items={activity}
+              formatBy={messages.formatBy}
+              historyLabel={messages.historyLabel}
+              onPressHistory={handlers?.onPressHistory}
+              emptyState={messages.activityEmpty}
+            />
+
+            <Caregivers
+              title={messages.caregiversTitle}
+              caregivers={caregivers}
+              syncPendingLabel={messages.syncPendingLabel}
+            />
+
+            <Text
+              fontSize={11}
+              color="$colorFaint"
+              textAlign="center"
+              paddingVertical="$2"
+              fontStyle="italic"
+            >
+              {messages.notMedicalDevice}
+            </Text>
+          </YStack>
+        </ScrollView>
+
+        <BottomActionBar
+          caption={messages.quickActionCaption}
+          maintLabel={messages.quickMaintLabel}
+          rescueLabel={messages.quickRescueLabel}
+          onPressMaint={handlers?.onPressMaint}
+          onPressRescue={handlers?.onPressRescue}
+        />
+      </YStack>
+    </Theme>
+  );
+}

--- a/packages/ui/src/components/home/HomeWebDashboard.tsx
+++ b/packages/ui/src/components/home/HomeWebDashboard.tsx
@@ -42,29 +42,34 @@ import type {
 // d'espacement et d'éléments (avatars sidebar, dock pill flottant, etc.)
 // suffisamment distincts pour justifier un composant dédié.
 
+export interface HomeNavItem {
+  key: string;
+  label: string;
+  active?: boolean;
+  onPress?: (() => void) | undefined;
+}
+
 export interface HomeWebDashboardProps {
   messages: HomeDashboardMessages;
   data: HomeDashboardData;
   handlers?: HomeDashboardHandlers | undefined;
-  navItems?: ReadonlyArray<{ key: string; label: string; active?: boolean }>;
+  /**
+   * Items de navigation de la sidebar. Doivent être déjà localisés (le
+   * composant `@kinhale/ui/home` reste pure-presentational ; l'app
+   * appelante construit les libellés via son hook i18n).
+   * Required pour respecter la règle non-négociable Kinhale FR+EN dès
+   * le commit #1 — pas de fallback hardcodé.
+   */
+  navItems: ReadonlyArray<HomeNavItem>;
   /** Defaults to `kinhale_light`. */
   theme?: 'kinhale_light' | 'kinhale_dark';
 }
-
-const DEFAULT_NAV_ITEMS = [
-  { key: 'home', label: 'Accueil', active: true },
-  { key: 'history', label: 'Historique' },
-  { key: 'pumps', label: 'Mes pompes' },
-  { key: 'caregivers', label: 'Aidants' },
-  { key: 'reports', label: 'Rapports' },
-  { key: 'settings', label: 'Réglages' },
-] as const;
 
 export function HomeWebDashboard({
   messages,
   data,
   handlers,
-  navItems = DEFAULT_NAV_ITEMS,
+  navItems,
   theme = 'kinhale_light',
 }: HomeWebDashboardProps): React.JSX.Element {
   const { time, scheduleSlots, inhalers, activity, caregivers } = data;
@@ -108,7 +113,7 @@ function WebSidebar({
   caregiversTitle,
   caregivers,
 }: {
-  navItems: ReadonlyArray<{ key: string; label: string; active?: boolean }>;
+  navItems: ReadonlyArray<HomeNavItem>;
   caregiversTitle: string;
   caregivers: CaregiverView[];
 }): React.JSX.Element {
@@ -160,6 +165,9 @@ function WebSidebar({
           gap={10}
           borderWidth={0}
           hoverStyle={{ backgroundColor: '$surface2' }}
+          {...(item.onPress ? { onPress: item.onPress } : {})}
+          accessibilityRole="link"
+          accessibilityLabel={item.label}
         >
           <Stack
             width={6}
@@ -279,6 +287,8 @@ function WebMain({
             {messages.dateLabel}
           </Text>
           <Text
+            tag="h1"
+            margin={0}
             fontFamily="$heading"
             fontSize={22}
             fontWeight="500"
@@ -375,10 +385,25 @@ function WebStatusHero({
   const isOverdue = time === 'overdue';
   const isEvening = time === 'evening';
   const tone = isOverdue
-    ? { bg: '$amberSoft' as const, dot: '$amber' as const, ink: '$amberInk' as const }
+    ? {
+        bg: '$amberSoft' as const,
+        dot: '$amber' as const,
+        dotVar: 'var(--amber)',
+        ink: '$amberInk' as const,
+      }
     : isEvening
-      ? { bg: '$maintSoft' as const, dot: '$maint' as const, ink: '$maintInk' as const }
-      : { bg: '$okSoft' as const, dot: '$ok' as const, ink: '$okInk' as const };
+      ? {
+          bg: '$maintSoft' as const,
+          dot: '$maint' as const,
+          dotVar: 'var(--maint)',
+          ink: '$maintInk' as const,
+        }
+      : {
+          bg: '$okSoft' as const,
+          dot: '$ok' as const,
+          dotVar: 'var(--ok)',
+          ink: '$okInk' as const,
+        };
   const title = isOverdue ? status.overdueTitle : isEvening ? status.dueTitle : status.onTrackTitle;
   const sub = isOverdue ? status.overdueSub : isEvening ? status.dueSub : status.onTrackSub;
 
@@ -398,11 +423,24 @@ function WebStatusHero({
         borderRadius={5}
         backgroundColor={tone.dot}
         marginTop={10}
-        // halo doux 5px autour du pastille
-        style={{ boxShadow: 'inset 0 0 0 0 transparent, 0 0 0 5px var(--okSoft)' }}
+        // Halo doux 5 px autour de la pastille — teinté avec la même
+        // couleur que le dot (alpha 18 %) pour respecter la maquette
+        // (kz-design-review J1) : overdue → halo ambre, evening → halo
+        // maint, on-track → halo OK.
+        style={{
+          boxShadow: `0 0 0 5px color-mix(in oklch, ${tone.dotVar} 18%, transparent)`,
+        }}
       />
       <YStack flex={1}>
-        <Text fontFamily="$heading" fontSize={28} lineHeight={32} fontWeight="500" color={tone.ink}>
+        <Text
+          tag="h2"
+          margin={0}
+          fontFamily="$heading"
+          fontSize={28}
+          lineHeight={32}
+          fontWeight="500"
+          color={tone.ink}
+        >
           {title}
         </Text>
         <Text fontSize={14} color="$colorMuted" marginTop={4}>
@@ -433,6 +471,8 @@ function WebScheduleStrip({
       padding={20}
     >
       <Text
+        tag="h2"
+        margin={0}
         fontSize={11}
         color="$colorMore"
         textTransform="uppercase"
@@ -530,6 +570,8 @@ function WebActivity({
     >
       <XStack alignItems="center" justifyContent="space-between" marginBottom={8}>
         <Text
+          tag="h2"
+          margin={0}
           fontSize={11}
           color="$colorMore"
           textTransform="uppercase"
@@ -643,6 +685,8 @@ function WebPumpRail({
       padding={20}
     >
       <Text
+        tag="h2"
+        margin={0}
         fontSize={11}
         color="$colorMore"
         textTransform="uppercase"

--- a/packages/ui/src/components/home/HomeWebDashboard.tsx
+++ b/packages/ui/src/components/home/HomeWebDashboard.tsx
@@ -1,0 +1,889 @@
+import * as React from 'react';
+import { Stack, Text, Theme, XStack, YStack } from 'tamagui';
+
+import {
+  AlertIcon,
+  ArrowRightIcon,
+  ClockIcon,
+  InhalerMaintIcon,
+  InhalerRescueIcon,
+} from '../../icons';
+import { BrandIcon } from '../auth/icons';
+import type {
+  HomeDashboardData,
+  HomeDashboardHandlers,
+  HomeDashboardMessages,
+} from './HomeDashboard';
+import type {
+  ActivityItem,
+  CaregiverView,
+  InhalerView,
+  ScheduleSlot,
+  ScheduleSlotState,
+} from './types';
+
+// Variante desktop du tableau de bord Kinhale, alignée sur la maquette
+// `docs/design/handoffs/2026-04-26-clinical-calm/project/Kinhale Home.html`
+// (composant `KinhaleWeb`, ~lignes 4141-5050).
+//
+// Layout :
+//   ┌──────────┬───────────────────────────────────────┐
+//   │          │  Top bar (date + nom enfant + role)   │
+//   │ Sidebar  ├──────────────────┬────────────────────┤
+//   │ (224 px) │  Status hero     │  Right rail :      │
+//   │          │  Schedule strip  │  Mes pompes        │
+//   │          │  Activity        │                    │
+//   │          ├──────────────────┴────────────────────┤
+//   │          │   Floating action dock (sticky)       │
+//   └──────────┴───────────────────────────────────────┘
+//
+// Les composants partagés mobile (BottomActionBar, Inventory, …) ne sont
+// pas réutilisés ici car la maquette desktop a des choix de typographie,
+// d'espacement et d'éléments (avatars sidebar, dock pill flottant, etc.)
+// suffisamment distincts pour justifier un composant dédié.
+
+export interface HomeWebDashboardProps {
+  messages: HomeDashboardMessages;
+  data: HomeDashboardData;
+  handlers?: HomeDashboardHandlers | undefined;
+  navItems?: ReadonlyArray<{ key: string; label: string; active?: boolean }>;
+  /** Defaults to `kinhale_light`. */
+  theme?: 'kinhale_light' | 'kinhale_dark';
+}
+
+const DEFAULT_NAV_ITEMS = [
+  { key: 'home', label: 'Accueil', active: true },
+  { key: 'history', label: 'Historique' },
+  { key: 'pumps', label: 'Mes pompes' },
+  { key: 'caregivers', label: 'Aidants' },
+  { key: 'reports', label: 'Rapports' },
+  { key: 'settings', label: 'Réglages' },
+] as const;
+
+export function HomeWebDashboard({
+  messages,
+  data,
+  handlers,
+  navItems = DEFAULT_NAV_ITEMS,
+  theme = 'kinhale_light',
+}: HomeWebDashboardProps): React.JSX.Element {
+  const { time, scheduleSlots, inhalers, activity, caregivers } = data;
+
+  return (
+    <Theme name={theme}>
+      <Stack
+        position="absolute"
+        top={0}
+        right={0}
+        bottom={0}
+        left={0}
+        backgroundColor="$background"
+        overflow="hidden"
+        // grid 224px sidebar + 1fr main — pas supporté par Tamagui props,
+        // on passe par display:grid via style natif.
+        style={{ display: 'grid', gridTemplateColumns: '224px 1fr' }}
+      >
+        <WebSidebar
+          navItems={navItems}
+          caregiversTitle={messages.caregiversTitle}
+          caregivers={caregivers}
+        />
+        <WebMain
+          messages={messages}
+          time={time}
+          scheduleSlots={scheduleSlots}
+          inhalers={inhalers}
+          activity={activity}
+          handlers={handlers}
+        />
+      </Stack>
+    </Theme>
+  );
+}
+
+// ── Sidebar (224 px) ─────────────────────────────────────────────────────
+
+function WebSidebar({
+  navItems,
+  caregiversTitle,
+  caregivers,
+}: {
+  navItems: ReadonlyArray<{ key: string; label: string; active?: boolean }>;
+  caregiversTitle: string;
+  caregivers: CaregiverView[];
+}): React.JSX.Element {
+  return (
+    <YStack
+      tag="aside"
+      borderRightWidth={0.5}
+      borderRightColor="$borderColor"
+      paddingHorizontal={14}
+      paddingVertical={20}
+      gap={4}
+      backgroundColor="$surface"
+      style={{ overflow: 'auto' }}
+    >
+      {/* Logo + wordmark */}
+      <XStack alignItems="center" gap={10} paddingHorizontal={8} paddingTop={4} paddingBottom={18}>
+        <Stack
+          width={28}
+          height={28}
+          borderRadius={8}
+          backgroundColor="$maint"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <BrandIcon size={15} color="#ffffff" />
+        </Stack>
+        <Text
+          fontFamily="$heading"
+          fontSize={17}
+          fontWeight="600"
+          letterSpacing={-0.17}
+          color="$color"
+        >
+          Kinhale
+        </Text>
+      </XStack>
+
+      {/* Nav items */}
+      {navItems.map((item) => (
+        <XStack
+          key={item.key}
+          tag="button"
+          paddingHorizontal={10}
+          paddingVertical={9}
+          borderRadius={8}
+          backgroundColor={item.active ? '$surface2' : 'transparent'}
+          cursor="pointer"
+          alignItems="center"
+          gap={10}
+          borderWidth={0}
+          hoverStyle={{ backgroundColor: '$surface2' }}
+        >
+          <Stack
+            width={6}
+            height={6}
+            borderRadius={3}
+            backgroundColor={item.active ? '$maint' : '$borderColorStrong'}
+          />
+          <Text
+            fontSize={13.5}
+            fontWeight={item.active ? '600' : '500'}
+            color={item.active ? '$color' : '$colorMuted'}
+            fontFamily="$body"
+          >
+            {item.label}
+          </Text>
+        </XStack>
+      ))}
+
+      <YStack flex={1} minHeight={16} />
+
+      {/* Caregivers card en pied */}
+      <YStack
+        padding={12}
+        borderRadius={12}
+        backgroundColor="$surface2"
+        borderWidth={0.5}
+        borderColor="$borderColor"
+      >
+        <Text
+          fontSize={10}
+          color="$colorMore"
+          textTransform="uppercase"
+          letterSpacing={0.8}
+          fontWeight="600"
+        >
+          {caregiversTitle}
+        </Text>
+        <XStack marginTop={8}>
+          {caregivers.slice(0, 4).map((c, i) => (
+            <Stack
+              key={c.id}
+              width={26}
+              height={26}
+              borderRadius={13}
+              marginLeft={i === 0 ? 0 : -8}
+              borderWidth={1.5}
+              borderColor="$surface2"
+              alignItems="center"
+              justifyContent="center"
+              style={{
+                background: `color-mix(in oklch, ${c.accentColor} 18%, var(--surface))`,
+              }}
+            >
+              <Text
+                fontSize={11}
+                fontWeight="600"
+                fontFamily="$heading"
+                textTransform="uppercase"
+                style={{ color: c.accentColor }}
+              >
+                {c.initial}
+              </Text>
+            </Stack>
+          ))}
+        </XStack>
+      </YStack>
+    </YStack>
+  );
+}
+
+// ── Main column ──────────────────────────────────────────────────────────
+
+function WebMain({
+  messages,
+  time,
+  scheduleSlots,
+  inhalers,
+  activity,
+  handlers,
+}: {
+  messages: HomeDashboardMessages;
+  time: HomeDashboardData['time'];
+  scheduleSlots: ScheduleSlot[];
+  inhalers: InhalerView[];
+  activity: ActivityItem[];
+  handlers?: HomeDashboardHandlers | undefined;
+}): React.JSX.Element {
+  return (
+    <YStack tag="main" flex={1} minHeight={0} position="relative" style={{ overflow: 'auto' }}>
+      {/* Top bar sticky */}
+      <XStack
+        paddingHorizontal={28}
+        paddingVertical={18}
+        alignItems="center"
+        justifyContent="space-between"
+        borderBottomWidth={0.5}
+        borderBottomColor="$borderColor"
+        zIndex={5}
+        // sticky top + backdrop-filter passent par style natif (Tamagui ne
+        // supporte pas position:'sticky' en typings stricts).
+        style={{
+          position: 'sticky',
+          top: 0,
+          background: 'color-mix(in oklch, var(--background) 90%, transparent)',
+          backdropFilter: 'blur(12px)',
+          WebkitBackdropFilter: 'blur(12px)',
+        }}
+      >
+        <YStack>
+          <Text
+            fontSize={11}
+            color="$colorMore"
+            textTransform="uppercase"
+            letterSpacing={1.1}
+            fontWeight="600"
+          >
+            {messages.dateLabel}
+          </Text>
+          <Text
+            fontFamily="$heading"
+            fontSize={22}
+            fontWeight="500"
+            letterSpacing={-0.22}
+            color="$color"
+            marginTop={2}
+          >
+            {messages.childName}
+          </Text>
+        </YStack>
+        <XStack alignItems="center" gap={12}>
+          <XStack
+            paddingHorizontal={12}
+            paddingVertical={6}
+            borderRadius={99}
+            backgroundColor="$surface"
+            borderWidth={0.5}
+            borderColor="$borderColor"
+            alignItems="center"
+            gap={8}
+          >
+            <Stack
+              width={6}
+              height={6}
+              borderRadius={3}
+              backgroundColor="$ok"
+              style={{ boxShadow: '0 0 0 3px var(--okSoft)' }}
+            />
+            <Text fontSize={12} color="$colorMuted">
+              {messages.roleLabel}
+            </Text>
+          </XStack>
+        </XStack>
+      </XStack>
+
+      {/* Content grid 1.5fr + 1fr */}
+      <Stack
+        paddingHorizontal={28}
+        paddingTop={24}
+        paddingBottom={120}
+        gap={24}
+        style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1.5fr) minmax(0, 1fr)' }}
+      >
+        <YStack gap={16} minWidth={0}>
+          <WebStatusHero time={time} status={messages.status} />
+          <WebScheduleStrip
+            title={messages.scheduleTitle}
+            stateLabels={messages.scheduleStateLabels}
+            slots={scheduleSlots}
+          />
+          <WebActivity
+            title={messages.activityTitle}
+            historyLabel={messages.historyLabel}
+            items={activity}
+            formatBy={messages.formatBy}
+            onPressHistory={handlers?.onPressHistory}
+          />
+        </YStack>
+
+        <YStack tag="aside" gap={16} minWidth={0}>
+          <WebPumpRail
+            title={messages.inventoryTitle}
+            inhalers={inhalers}
+            formatDosesLeft={messages.formatDosesLeft}
+            formatExpiryStatus={messages.formatExpiryStatus}
+            refillSoonLabel={messages.refillSoonLabel}
+          />
+          <Text fontSize={11} color="$colorFaint" textAlign="center" fontStyle="italic">
+            {messages.notMedicalDevice}
+          </Text>
+        </YStack>
+      </Stack>
+
+      <WebActionDock
+        caption={messages.quickActionCaption}
+        maintLabel={messages.quickMaintLabel}
+        rescueLabel={messages.quickRescueLabel}
+        onPressMaint={handlers?.onPressMaint}
+        onPressRescue={handlers?.onPressRescue}
+      />
+    </YStack>
+  );
+}
+
+// ── Status hero (web) ────────────────────────────────────────────────────
+
+function WebStatusHero({
+  time,
+  status,
+}: {
+  time: HomeDashboardData['time'];
+  status: HomeDashboardMessages['status'];
+}): React.JSX.Element {
+  const isOverdue = time === 'overdue';
+  const isEvening = time === 'evening';
+  const tone = isOverdue
+    ? { bg: '$amberSoft' as const, dot: '$amber' as const, ink: '$amberInk' as const }
+    : isEvening
+      ? { bg: '$maintSoft' as const, dot: '$maint' as const, ink: '$maintInk' as const }
+      : { bg: '$okSoft' as const, dot: '$ok' as const, ink: '$okInk' as const };
+  const title = isOverdue ? status.overdueTitle : isEvening ? status.dueTitle : status.onTrackTitle;
+  const sub = isOverdue ? status.overdueSub : isEvening ? status.dueSub : status.onTrackSub;
+
+  return (
+    <XStack
+      padding={24}
+      borderRadius="$radius.7"
+      backgroundColor={tone.bg}
+      borderWidth={0.5}
+      borderColor="$borderColor"
+      alignItems="flex-start"
+      gap={16}
+    >
+      <Stack
+        width={10}
+        height={10}
+        borderRadius={5}
+        backgroundColor={tone.dot}
+        marginTop={10}
+        // halo doux 5px autour du pastille
+        style={{ boxShadow: 'inset 0 0 0 0 transparent, 0 0 0 5px var(--okSoft)' }}
+      />
+      <YStack flex={1}>
+        <Text fontFamily="$heading" fontSize={28} lineHeight={32} fontWeight="500" color={tone.ink}>
+          {title}
+        </Text>
+        <Text fontSize={14} color="$colorMuted" marginTop={4}>
+          {sub}
+        </Text>
+      </YStack>
+    </XStack>
+  );
+}
+
+// ── Schedule strip (web) ─────────────────────────────────────────────────
+
+function WebScheduleStrip({
+  title,
+  stateLabels,
+  slots,
+}: {
+  title: string;
+  stateLabels: Record<ScheduleSlotState, string>;
+  slots: ScheduleSlot[];
+}): React.JSX.Element {
+  return (
+    <YStack
+      backgroundColor="$surface"
+      borderRadius="$radius.7"
+      borderWidth={0.5}
+      borderColor="$borderColor"
+      padding={20}
+    >
+      <Text
+        fontSize={11}
+        color="$colorMore"
+        textTransform="uppercase"
+        letterSpacing={0.88}
+        fontWeight="600"
+        marginBottom={12}
+      >
+        {title}
+      </Text>
+      <Stack style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
+        {slots.map((s, i) => (
+          <YStack
+            key={i}
+            padding={14}
+            backgroundColor="$surface2"
+            borderRadius={14}
+            borderWidth={0.5}
+            borderColor="$borderColor"
+            gap={8}
+          >
+            <Text
+              fontSize={11}
+              color="$colorMore"
+              textTransform="uppercase"
+              letterSpacing={0.88}
+              fontWeight="600"
+            >
+              {s.label}
+            </Text>
+            <Text
+              fontFamily="$mono"
+              fontSize={22}
+              fontWeight="500"
+              color="$color"
+              style={{ fontVariantNumeric: 'tabular-nums' }}
+            >
+              {s.time}
+            </Text>
+            <XStack alignItems="center" gap={6}>
+              <Stack
+                width={7}
+                height={7}
+                borderRadius={4}
+                backgroundColor={
+                  s.state === 'done'
+                    ? '$ok'
+                    : s.state === 'overdue' || s.state === 'missed'
+                      ? '$amber'
+                      : '$maint'
+                }
+              />
+              <Text
+                fontSize={12}
+                fontWeight="500"
+                color={
+                  s.state === 'done'
+                    ? '$okInk'
+                    : s.state === 'overdue' || s.state === 'missed'
+                      ? '$amberInk'
+                      : '$maintInk'
+                }
+              >
+                {stateLabels[s.state]}
+              </Text>
+            </XStack>
+          </YStack>
+        ))}
+      </Stack>
+    </YStack>
+  );
+}
+
+// ── Activity (web) ───────────────────────────────────────────────────────
+
+function WebActivity({
+  title,
+  historyLabel,
+  items,
+  formatBy,
+  onPressHistory,
+}: {
+  title: string;
+  historyLabel: string;
+  items: ActivityItem[];
+  formatBy: (name: string) => string;
+  onPressHistory?: (() => void) | undefined;
+}): React.JSX.Element {
+  return (
+    <YStack
+      backgroundColor="$surface"
+      borderRadius="$radius.7"
+      borderWidth={0.5}
+      borderColor="$borderColor"
+      padding={20}
+    >
+      <XStack alignItems="center" justifyContent="space-between" marginBottom={8}>
+        <Text
+          fontSize={11}
+          color="$colorMore"
+          textTransform="uppercase"
+          letterSpacing={0.88}
+          fontWeight="600"
+        >
+          {title}
+        </Text>
+        <XStack
+          alignItems="center"
+          gap={4}
+          cursor="pointer"
+          {...(onPressHistory ? { onPress: onPressHistory } : {})}
+        >
+          <Text fontSize={12} color="$maint" fontWeight="500">
+            {historyLabel}
+          </Text>
+          <Text color="$maint" display="flex" alignItems="center">
+            <ArrowRightIcon size={11} color="currentColor" />
+          </Text>
+        </XStack>
+      </XStack>
+
+      {items.map((it, i) => {
+        const isRescue = it.kind === 'rescue';
+        return (
+          <XStack
+            key={it.id}
+            alignItems="center"
+            gap={14}
+            paddingVertical={12}
+            borderTopWidth={i === 0 ? 0 : 0.5}
+            borderTopColor="$borderColor"
+          >
+            <Text
+              width={32}
+              height={32}
+              borderRadius={9}
+              backgroundColor={isRescue ? '$rescueSoft' : '$maintSoft'}
+              color={isRescue ? '$rescue' : '$maint'}
+              alignItems="center"
+              justifyContent="center"
+              flexShrink={0}
+              display="flex"
+            >
+              {isRescue ? (
+                <InhalerRescueIcon size={17} color="currentColor" />
+              ) : (
+                <InhalerMaintIcon size={17} color="currentColor" />
+              )}
+            </Text>
+            <YStack flex={1} minWidth={0}>
+              <XStack alignItems="baseline" gap={8}>
+                <Text fontSize={14} fontWeight="500" color="$color">
+                  {it.label}
+                </Text>
+                {it.cause && (
+                  <Stack
+                    paddingHorizontal={7}
+                    paddingVertical={2}
+                    borderRadius={99}
+                    backgroundColor="$rescueSoft"
+                  >
+                    <Text fontSize={11} color="$rescueInk" fontWeight="500">
+                      {it.cause}
+                    </Text>
+                  </Stack>
+                )}
+              </XStack>
+              <Text fontSize={12} color="$colorMore" marginTop={2}>
+                {formatBy(it.who)} · {it.ago}
+                {it.syncNote ? ` · sync ${it.syncNote}` : ''}
+              </Text>
+            </YStack>
+            <Text
+              fontFamily="$mono"
+              fontSize={12}
+              color="$colorMore"
+              style={{ fontVariantNumeric: 'tabular-nums' }}
+            >
+              {it.time}
+            </Text>
+          </XStack>
+        );
+      })}
+    </YStack>
+  );
+}
+
+// ── Pump rail (web — variante du Inventory mobile) ───────────────────────
+
+function WebPumpRail({
+  title,
+  inhalers,
+  formatDosesLeft,
+  formatExpiryStatus,
+  refillSoonLabel,
+}: {
+  title: string;
+  inhalers: InhalerView[];
+  formatDosesLeft: (n: number) => string;
+  formatExpiryStatus: (inh: InhalerView) => { kind: 'normal' | 'soon' | 'expired'; label: string };
+  refillSoonLabel: string;
+}): React.JSX.Element {
+  return (
+    <YStack
+      backgroundColor="$surface"
+      borderRadius="$radius.7"
+      borderWidth={0.5}
+      borderColor="$borderColor"
+      padding={20}
+    >
+      <Text
+        fontSize={11}
+        color="$colorMore"
+        textTransform="uppercase"
+        letterSpacing={0.88}
+        fontWeight="600"
+        marginBottom={12}
+      >
+        {title}
+      </Text>
+      <YStack gap={16}>
+        {inhalers.map((inh, i) => {
+          const stockPct = Math.max(0, Math.min(100, (inh.doses / Math.max(1, inh.total)) * 100));
+          const isMaint = inh.kind === 'maint';
+          const expiry = formatExpiryStatus(inh);
+          const expiryColor =
+            expiry.kind === 'expired'
+              ? '$rescueInk'
+              : expiry.kind === 'soon'
+                ? '$amberInk'
+                : '$colorMore';
+
+          return (
+            <YStack
+              key={inh.id}
+              paddingTop={i === 0 ? 0 : 16}
+              borderTopWidth={i === 0 ? 0 : 0.5}
+              borderTopColor="$borderColor"
+            >
+              <XStack gap={12}>
+                <Text
+                  width={42}
+                  height={42}
+                  borderRadius={11}
+                  backgroundColor={isMaint ? '$maintSoft' : '$rescueSoft'}
+                  color={isMaint ? '$maint' : '$rescue'}
+                  alignItems="center"
+                  justifyContent="center"
+                  flexShrink={0}
+                  display="flex"
+                >
+                  {isMaint ? (
+                    <InhalerMaintIcon size={22} color="currentColor" />
+                  ) : (
+                    <InhalerRescueIcon size={22} color="currentColor" />
+                  )}
+                </Text>
+                <YStack flex={1} minWidth={0}>
+                  <Text fontSize={14} fontWeight="500" color="$color">
+                    {inh.name}
+                  </Text>
+                  <Text fontSize={12} color="$colorMore" marginTop={1}>
+                    {inh.contextLabel}
+                  </Text>
+                </YStack>
+              </XStack>
+
+              <XStack justifyContent="space-between" alignItems="baseline" marginTop={12}>
+                <Text
+                  fontSize={11}
+                  color="$colorMore"
+                  textTransform="uppercase"
+                  letterSpacing={0.66}
+                  fontWeight="600"
+                >
+                  Stock
+                </Text>
+                <Text
+                  fontFamily="$mono"
+                  fontSize={13}
+                  color={inh.isLow ? '$amberInk' : '$color'}
+                  fontWeight="600"
+                  style={{ fontVariantNumeric: 'tabular-nums' }}
+                >
+                  {formatDosesLeft(inh.doses)}
+                </Text>
+              </XStack>
+
+              <Stack
+                marginTop={6}
+                height={6}
+                backgroundColor="$borderColor"
+                borderRadius={99}
+                overflow="hidden"
+              >
+                <Stack
+                  width={`${stockPct}%`}
+                  height="100%"
+                  borderRadius={99}
+                  backgroundColor={inh.isLow ? '$amber' : isMaint ? '$maint' : '$rescue'}
+                />
+              </Stack>
+
+              <XStack justifyContent="space-between" alignItems="center" marginTop={10}>
+                <XStack alignItems="center" gap={5}>
+                  <Text color={expiryColor} display="flex" alignItems="center">
+                    <ClockIcon size={11} color="currentColor" />
+                  </Text>
+                  <Text fontSize={11} color={expiryColor}>
+                    {expiry.label}
+                  </Text>
+                </XStack>
+                {inh.isLow && (
+                  <XStack
+                    paddingHorizontal={8}
+                    paddingVertical={2}
+                    borderRadius={99}
+                    backgroundColor="$amberSoft"
+                    alignItems="center"
+                    gap={4}
+                  >
+                    <Text color="$amberInk" display="flex" alignItems="center">
+                      <AlertIcon size={10} color="currentColor" />
+                    </Text>
+                    <Text fontSize={11} color="$amberInk" fontWeight="600">
+                      {refillSoonLabel}
+                    </Text>
+                  </XStack>
+                )}
+              </XStack>
+            </YStack>
+          );
+        })}
+      </YStack>
+    </YStack>
+  );
+}
+
+// ── Action dock (web — pill flottant centré) ──────────────────────────────
+
+function WebActionDock({
+  caption,
+  maintLabel,
+  rescueLabel,
+  onPressMaint,
+  onPressRescue,
+}: {
+  caption: string;
+  maintLabel: string;
+  rescueLabel: string;
+  onPressMaint?: (() => void) | undefined;
+  onPressRescue?: (() => void) | undefined;
+}): React.JSX.Element {
+  return (
+    <Stack
+      zIndex={10}
+      paddingHorizontal={12}
+      paddingVertical={10}
+      borderRadius={999}
+      borderWidth={0.5}
+      borderColor="$borderColor"
+      flexDirection="row"
+      alignItems="center"
+      gap={10}
+      // sticky bottom centré + glass blur via style natif (Tamagui ne
+      // supporte pas position:'sticky' + backdrop-filter en typage strict).
+      style={{
+        position: 'sticky',
+        bottom: 24,
+        marginLeft: 'auto',
+        marginRight: 'auto',
+        marginTop: -100,
+        marginBottom: 24,
+        width: 'max-content',
+        background: 'color-mix(in oklch, var(--surface) 92%, transparent)',
+        boxShadow: '0 12px 36px rgba(0,0,0,0.10), inset 0 1px 0 rgba(255,255,255,0.5)',
+        backdropFilter: 'blur(20px)',
+        WebkitBackdropFilter: 'blur(20px)',
+      }}
+    >
+      <Text
+        fontSize={11}
+        color="$colorMore"
+        textTransform="uppercase"
+        letterSpacing={0.88}
+        fontWeight="600"
+        paddingHorizontal={6}
+      >
+        {caption}
+      </Text>
+      <XStack
+        tag="button"
+        cursor="pointer"
+        backgroundColor="$maint"
+        paddingHorizontal={20}
+        paddingVertical={12}
+        borderRadius={99}
+        alignItems="center"
+        gap={10}
+        borderWidth={0}
+        {...(onPressMaint ? { onPress: onPressMaint } : {})}
+        accessibilityRole="button"
+        accessibilityLabel={maintLabel}
+        style={{ boxShadow: '0 4px 14px color-mix(in oklch, var(--maint) 35%, transparent)' }}
+      >
+        <Text
+          width={28}
+          height={28}
+          borderRadius={8}
+          alignItems="center"
+          justifyContent="center"
+          color="white"
+          display="flex"
+          style={{ background: 'rgba(255,255,255,0.18)' }}
+        >
+          <InhalerMaintIcon size={20} color="white" />
+        </Text>
+        <Text fontSize={14} fontWeight="600" color="white" fontFamily="$body">
+          {maintLabel}
+        </Text>
+      </XStack>
+      <XStack
+        tag="button"
+        cursor="pointer"
+        backgroundColor="$surface"
+        paddingHorizontal={20}
+        paddingVertical={12}
+        borderRadius={99}
+        borderWidth={1.5}
+        borderColor="$rescue"
+        alignItems="center"
+        gap={10}
+        {...(onPressRescue ? { onPress: onPressRescue } : {})}
+        accessibilityRole="button"
+        accessibilityLabel={rescueLabel}
+      >
+        <Text
+          width={28}
+          height={28}
+          borderRadius={8}
+          backgroundColor="$rescueSoft"
+          color="$rescue"
+          alignItems="center"
+          justifyContent="center"
+          display="flex"
+        >
+          <InhalerRescueIcon size={20} color="currentColor" />
+        </Text>
+        <Text fontSize={14} fontWeight="600" color="$rescue" fontFamily="$body">
+          {rescueLabel}
+        </Text>
+      </XStack>
+    </Stack>
+  );
+}

--- a/packages/ui/src/components/home/Inventory.tsx
+++ b/packages/ui/src/components/home/Inventory.tsx
@@ -1,0 +1,145 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { AlertIcon, ClockIcon, InhalerMaintIcon, InhalerRescueIcon } from '../../icons';
+import { Section } from './Section';
+import { SectionHeader } from './SectionHeader';
+import type { InhalerView } from './types';
+
+interface InventoryProps {
+  title: string;
+  inhalers: InhalerView[];
+  /** Pre-formatted strings (callers compute days-until + locale-formatted date). */
+  formatDosesLeft: (n: number) => string;
+  formatExpiryStatus: (inh: InhalerView) => { kind: 'normal' | 'soon' | 'expired'; label: string };
+  refillSoonLabel: string;
+  /** Empty state when no inhaler is registered yet. */
+  emptyState?: React.ReactNode;
+}
+
+export function Inventory({
+  title,
+  inhalers,
+  formatDosesLeft,
+  formatExpiryStatus,
+  refillSoonLabel,
+  emptyState,
+}: InventoryProps): React.JSX.Element {
+  if (inhalers.length === 0 && emptyState) {
+    return (
+      <Section>
+        <SectionHeader label={title} />
+        {emptyState}
+      </Section>
+    );
+  }
+
+  return (
+    <Section>
+      <SectionHeader label={title} />
+      <YStack gap="$3.5">
+        {inhalers.map((inh, i) => {
+          const stockPct = Math.max(0, Math.min(100, (inh.doses / Math.max(1, inh.total)) * 100));
+          const isMaint = inh.kind === 'maint';
+          const expiry = formatExpiryStatus(inh);
+          const expiryColorToken =
+            expiry.kind === 'expired'
+              ? '$rescueInk'
+              : expiry.kind === 'soon'
+                ? '$amberInk'
+                : '$colorMore';
+
+          return (
+            <XStack
+              key={inh.id}
+              gap="$3"
+              alignItems="flex-start"
+              paddingTop={i === 0 ? 0 : '$3.5'}
+              borderTopWidth={i === 0 ? 0 : 0.5}
+              borderTopColor="$borderColor"
+            >
+              <Text
+                width={40}
+                height={40}
+                borderRadius={10}
+                backgroundColor={isMaint ? '$maintSoft' : '$rescueSoft'}
+                color={isMaint ? '$maint' : '$rescue'}
+                alignItems="center"
+                justifyContent="center"
+                flexShrink={0}
+                display="flex"
+              >
+                {isMaint ? (
+                  <InhalerMaintIcon size={20} color="currentColor" />
+                ) : (
+                  <InhalerRescueIcon size={20} color="currentColor" />
+                )}
+              </Text>
+
+              <YStack flex={1} minWidth={0} gap="$1.5">
+                <XStack justifyContent="space-between" alignItems="baseline" gap="$2">
+                  <Text fontSize={14} fontWeight="500" color="$color" flex={1} numberOfLines={1}>
+                    {inh.name}
+                  </Text>
+                  <Text
+                    fontSize={12}
+                    fontWeight="500"
+                    color={inh.isLow ? '$amberInk' : '$colorMuted'}
+                    fontFamily="$mono"
+                  >
+                    {formatDosesLeft(inh.doses)}
+                  </Text>
+                </XStack>
+                <Text fontSize={11.5} color="$colorMore">
+                  {inh.contextLabel}
+                </Text>
+
+                {/* Stock bar */}
+                <Stack
+                  height={5}
+                  backgroundColor="$borderColor"
+                  borderRadius={9999}
+                  overflow="hidden"
+                  marginTop="$1"
+                >
+                  <Stack
+                    width={`${stockPct}%`}
+                    height="100%"
+                    backgroundColor={inh.isLow ? '$amber' : isMaint ? '$maint' : '$rescue'}
+                  />
+                </Stack>
+
+                <XStack
+                  justifyContent="space-between"
+                  alignItems="center"
+                  gap="$2"
+                  marginTop="$1.5"
+                  flexWrap="wrap"
+                >
+                  <XStack alignItems="center" gap="$1.5">
+                    <Text color={expiryColorToken} display="flex" alignItems="center">
+                      <ClockIcon size={11} color="currentColor" />
+                    </Text>
+                    <Text fontSize={11} color={expiryColorToken}>
+                      {expiry.label}
+                    </Text>
+                  </XStack>
+                  {inh.isLow && (
+                    <XStack alignItems="center" gap="$1">
+                      <Text color="$amberInk" display="flex" alignItems="center">
+                        <AlertIcon size={11} color="currentColor" />
+                      </Text>
+                      <Text fontSize={11} color="$amberInk" fontWeight="500">
+                        {refillSoonLabel}
+                      </Text>
+                    </XStack>
+                  )}
+                </XStack>
+              </YStack>
+            </XStack>
+          );
+        })}
+      </YStack>
+    </Section>
+  );
+}

--- a/packages/ui/src/components/home/KinhaleHeader.tsx
+++ b/packages/ui/src/components/home/KinhaleHeader.tsx
@@ -35,6 +35,9 @@ export function KinhaleHeader({
           {dateLabel}
         </Text>
         <Text
+          tag="h1"
+          margin={0}
+          fontFamily="$heading"
           fontSize={28}
           lineHeight={32}
           marginTop={4}

--- a/packages/ui/src/components/home/KinhaleHeader.tsx
+++ b/packages/ui/src/components/home/KinhaleHeader.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import type { CaregiverRole } from './types';
+
+interface KinhaleHeaderProps {
+  dateLabel: string;
+  childName: string;
+  roleLabel: string;
+  role: CaregiverRole;
+}
+
+export function KinhaleHeader({
+  dateLabel,
+  childName,
+  roleLabel,
+}: KinhaleHeaderProps): React.JSX.Element {
+  return (
+    <XStack
+      paddingHorizontal="$4"
+      paddingTop="$5"
+      paddingBottom="$3"
+      alignItems="flex-end"
+      justifyContent="space-between"
+      gap="$3"
+    >
+      <YStack flexShrink={1} minWidth={0}>
+        <Text
+          fontSize={11}
+          fontWeight="600"
+          color="$colorMore"
+          textTransform="uppercase"
+          letterSpacing="0.1em"
+        >
+          {dateLabel}
+        </Text>
+        <Text
+          fontSize={28}
+          lineHeight={32}
+          marginTop={4}
+          fontWeight="500"
+          color="$color"
+          letterSpacing="-0.02em"
+        >
+          {childName}
+        </Text>
+      </YStack>
+
+      <XStack
+        alignItems="center"
+        gap="$2"
+        paddingVertical="$1"
+        paddingHorizontal="$2.5"
+        backgroundColor="$surface2"
+        borderRadius={9999}
+        borderWidth={0.5}
+        borderColor="$borderColor"
+      >
+        <Stack
+          width={6}
+          height={6}
+          borderRadius={9999}
+          backgroundColor="$ok"
+          shadowColor="$okSoft"
+          shadowRadius={0}
+          shadowOffset={{ width: 0, height: 0 }}
+          // 3px ring around dot — emulated via wrapping ring below
+        />
+        <Text fontSize={11} color="$colorMore" fontWeight="500">
+          {roleLabel}
+        </Text>
+      </XStack>
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/home/ScheduleStrip.tsx
+++ b/packages/ui/src/components/home/ScheduleStrip.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { Section } from './Section';
+import { SectionHeader } from './SectionHeader';
+import type { ScheduleSlot, ScheduleSlotState } from './types';
+
+interface ScheduleStripProps {
+  title: string;
+  slots: ScheduleSlot[];
+  /** Localised state labels. */
+  stateLabels: Record<ScheduleSlotState, string>;
+}
+
+interface SlotPalette {
+  dot: string;
+  ring: string;
+  ink: string;
+}
+
+const palettes: Record<ScheduleSlotState, SlotPalette> = {
+  done: { dot: '$ok', ring: '$okSoft', ink: '$okInk' },
+  pending: { dot: '$maint', ring: '$maintSoft', ink: '$maintInk' },
+  overdue: { dot: '$amber', ring: '$amberSoft', ink: '$amberInk' },
+  missed: { dot: '$miss', ring: '$missSoft', ink: '$colorMore' },
+};
+
+export function ScheduleStrip({
+  title,
+  slots,
+  stateLabels,
+}: ScheduleStripProps): React.JSX.Element {
+  return (
+    <Section>
+      <SectionHeader label={title} />
+      <XStack gap="$2">
+        {slots.map((slot, i) => {
+          const palette = palettes[slot.state];
+          return (
+            <YStack
+              key={`${slot.label}-${i}`}
+              flex={1}
+              gap="$1.5"
+              padding="$2.5"
+              backgroundColor="$surface2"
+              borderRadius={10}
+              borderWidth={0.5}
+              borderColor="$borderColor"
+              minHeight={78}
+            >
+              <Text
+                fontSize={11}
+                color="$colorMore"
+                textTransform="uppercase"
+                letterSpacing="0.08em"
+                fontWeight="500"
+              >
+                {slot.label}
+              </Text>
+              <Text fontSize={16} fontWeight="500" color="$color" fontFamily="$mono">
+                {slot.time}
+              </Text>
+              <XStack alignItems="center" gap="$1.5" marginTop="auto">
+                <Stack
+                  width={12}
+                  height={12}
+                  borderRadius={9999}
+                  backgroundColor={palette.ring}
+                  alignItems="center"
+                  justifyContent="center"
+                >
+                  <Stack width={6} height={6} borderRadius={9999} backgroundColor={palette.dot} />
+                </Stack>
+                <Text fontSize={11} color={palette.ink} fontWeight="500">
+                  {stateLabels[slot.state]}
+                </Text>
+              </XStack>
+            </YStack>
+          );
+        })}
+      </XStack>
+    </Section>
+  );
+}

--- a/packages/ui/src/components/home/Section.tsx
+++ b/packages/ui/src/components/home/Section.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { YStack, type YStackProps } from 'tamagui';
+
+/** Card-style section container used across the Home dashboard. */
+export function Section(props: YStackProps): React.JSX.Element {
+  return (
+    <YStack
+      backgroundColor="$surface"
+      borderRadius={20}
+      padding="$4"
+      borderWidth={0.5}
+      borderColor="$borderColor"
+      {...props}
+    />
+  );
+}

--- a/packages/ui/src/components/home/SectionHeader.tsx
+++ b/packages/ui/src/components/home/SectionHeader.tsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { Text, XStack } from 'tamagui';
+
+interface SectionHeaderProps {
+  label: string;
+  action?: React.ReactNode;
+}
+
+export function SectionHeader({ label, action }: SectionHeaderProps): React.JSX.Element {
+  return (
+    <XStack alignItems="center" justifyContent="space-between" marginBottom="$2.5">
+      <Text
+        fontSize={11}
+        fontWeight="600"
+        color="$colorMore"
+        textTransform="uppercase"
+        letterSpacing="0.08em"
+      >
+        {label}
+      </Text>
+      {action}
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/home/SectionHeader.tsx
+++ b/packages/ui/src/components/home/SectionHeader.tsx
@@ -10,6 +10,8 @@ export function SectionHeader({ label, action }: SectionHeaderProps): React.JSX.
   return (
     <XStack alignItems="center" justifyContent="space-between" marginBottom="$2.5">
       <Text
+        tag="h2"
+        margin={0}
         fontSize={11}
         fontWeight="600"
         color="$colorMore"

--- a/packages/ui/src/components/home/StatusHero.tsx
+++ b/packages/ui/src/components/home/StatusHero.tsx
@@ -1,0 +1,78 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import type { StatusTime } from './types';
+
+type Tone = 'maint' | 'amber' | 'ok';
+
+interface StatusHeroProps {
+  time: StatusTime;
+  /** Pre-formatted localised strings. */
+  messages: {
+    onTrackTitle: string;
+    onTrackSub: string;
+    dueTitle: string;
+    dueSub: string;
+    overdueTitle: string;
+    overdueSub: string;
+  };
+}
+
+function toneFor(time: StatusTime): {
+  tone: Tone;
+  titleKey: 'onTrackTitle' | 'dueTitle' | 'overdueTitle';
+  subKey: 'onTrackSub' | 'dueSub' | 'overdueSub';
+} {
+  if (time === 'overdue') return { tone: 'amber', titleKey: 'overdueTitle', subKey: 'overdueSub' };
+  if (time === 'evening') return { tone: 'maint', titleKey: 'dueTitle', subKey: 'dueSub' };
+  return { tone: 'ok', titleKey: 'onTrackTitle', subKey: 'onTrackSub' };
+}
+
+export function StatusHero({ time, messages }: StatusHeroProps): React.JSX.Element {
+  const { tone, titleKey, subKey } = toneFor(time);
+
+  const bgToken = tone === 'amber' ? '$amberSoft' : tone === 'maint' ? '$maintSoft' : '$okSoft';
+  const dotToken = tone === 'amber' ? '$amber' : tone === 'maint' ? '$maint' : '$ok';
+  const inkToken = tone === 'amber' ? '$amberInk' : tone === 'maint' ? '$maintInk' : '$okInk';
+
+  return (
+    <XStack
+      padding="$4"
+      backgroundColor={bgToken}
+      borderRadius={20}
+      borderWidth={0.5}
+      borderColor="$borderColor"
+      gap="$3"
+      alignItems="flex-start"
+    >
+      {/* Dot with soft ring */}
+      <Stack
+        width={16}
+        height={16}
+        borderRadius={9999}
+        backgroundColor={bgToken}
+        alignItems="center"
+        justifyContent="center"
+        marginTop={6}
+        flexShrink={0}
+      >
+        <Stack width={8} height={8} borderRadius={9999} backgroundColor={dotToken} />
+      </Stack>
+
+      <YStack flex={1} minWidth={0}>
+        <Text
+          fontSize={22}
+          lineHeight={26}
+          fontWeight="500"
+          color={inkToken}
+          letterSpacing="-0.02em"
+        >
+          {messages[titleKey]}
+        </Text>
+        <Text fontSize={13} color="$colorMuted" marginTop={4}>
+          {messages[subKey]}
+        </Text>
+      </YStack>
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/home/index.ts
+++ b/packages/ui/src/components/home/index.ts
@@ -7,7 +7,7 @@ export type {
 } from './HomeDashboard';
 
 export { HomeWebDashboard } from './HomeWebDashboard';
-export type { HomeWebDashboardProps } from './HomeWebDashboard';
+export type { HomeNavItem, HomeWebDashboardProps } from './HomeWebDashboard';
 
 // Sub-components are exported for advanced consumers (Storybook, custom layouts).
 export { Activity } from './Activity';

--- a/packages/ui/src/components/home/index.ts
+++ b/packages/ui/src/components/home/index.ts
@@ -1,0 +1,32 @@
+export { HomeDashboard } from './HomeDashboard';
+export type {
+  HomeDashboardData,
+  HomeDashboardHandlers,
+  HomeDashboardMessages,
+  HomeDashboardProps,
+} from './HomeDashboard';
+
+export { HomeWebDashboard } from './HomeWebDashboard';
+export type { HomeWebDashboardProps } from './HomeWebDashboard';
+
+// Sub-components are exported for advanced consumers (Storybook, custom layouts).
+export { Activity } from './Activity';
+export { BottomActionBar } from './BottomActionBar';
+export { Caregivers } from './Caregivers';
+export { DaycareRestrictedView } from './DaycareRestrictedView';
+export { Inventory } from './Inventory';
+export { KinhaleHeader } from './KinhaleHeader';
+export { ScheduleStrip } from './ScheduleStrip';
+export { StatusHero } from './StatusHero';
+
+export type {
+  ActivityItem,
+  ActivityKind,
+  CaregiverRole,
+  CaregiverView,
+  InhalerKind,
+  InhalerView,
+  ScheduleSlot,
+  ScheduleSlotState,
+  StatusTime,
+} from './types';

--- a/packages/ui/src/components/home/types.ts
+++ b/packages/ui/src/components/home/types.ts
@@ -1,0 +1,52 @@
+// Shared types for the Home dashboard. Components are presentational :
+// they receive `messages` (already-localised strings) and `data` props.
+// The consuming page is responsible for wiring i18n + projections.
+
+export type CaregiverRole = 'admin' | 'contributor' | 'restricted';
+
+export type StatusTime = 'morning' | 'evening' | 'overdue' | 'on-track';
+
+export type ScheduleSlotState = 'done' | 'pending' | 'overdue' | 'missed';
+
+export interface ScheduleSlot {
+  label: string;
+  time: string;
+  state: ScheduleSlotState;
+  tag?: string;
+}
+
+export type InhalerKind = 'maint' | 'rescue';
+
+export interface InhalerView {
+  id: string;
+  name: string;
+  contextLabel: string;
+  kind: InhalerKind;
+  doses: number;
+  total: number;
+  expiry: string;
+  isLow?: boolean;
+}
+
+export type ActivityKind = 'maint' | 'rescue';
+
+export interface ActivityItem {
+  id: string;
+  kind: ActivityKind;
+  label: string;
+  who: string;
+  time: string;
+  ago: string;
+  cause?: string;
+  syncNote?: string;
+}
+
+export interface CaregiverView {
+  id: string;
+  name: string;
+  roleLabel: string;
+  initial: string;
+  online: boolean;
+  syncPending?: boolean;
+  accentColor: string;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,4 @@
 export * from './theme';
 export * from './icons';
 export * from './components/auth';
+export * from './components/home';


### PR DESCRIPTION
## Summary

Refonte complète de la page d'accueil `/` selon la maquette de référence `docs/design/handoffs/2026-04-26-clinical-calm/project/Kinhale Home.html` (composants `KinhaleHome` mobile et `KinhaleWeb` desktop). C'est la **PR-A** du backlog refonte design (cf. plan `.agents/current-run/02-auth-redesign-plan.md`, étendu en plan global de refonte design dans la PR #365).

**Refs:** KIN-106 — première PR de la série après les fondations PR-0 (#365).

## Apport fonctionnel

- **Composants partagés `@kinhale/ui/home`** récupérés du WIP de la branche `feature/web-home-dashboard` (stash) puis ajustés pour passer le typecheck strict :
  - `HomeDashboard` (mobile-style 1 colonne) — orchestre tout
  - `HomeWebDashboard` (**NOUVEAU**, desktop 3 colonnes) — sidebar 224 px + main + rail mes pompes + dock action sticky
  - Sous-composants : `KinhaleHeader`, `StatusHero`, `ScheduleStrip`, `Inventory`, `Activity`, `Caregivers`, `BottomActionBar`, `DaycareRestrictedView`, `Section`, `SectionHeader`
  - Types métier exposés : `ScheduleSlot`, `InhalerView`, `ActivityItem`, `CaregiverView`, `HomeDashboardData/Messages/Handlers`, `HomeNavItem`

- **Layout responsive automatique** : `apps/web/src/app/page.tsx` détecte la viewport via `matchMedia(min-width: 1024px)` et choisit `HomeWebDashboard` (≥ 1024 px) ou `HomeDashboard` (mobile-style). Hydratation correctement gérée pour ne pas rediriger vers `/auth` pendant que zustand persist hydrate localStorage.

- **i18n FR + EN** : 36 nouvelles clés `home.dashboard.*` (status on-track/due/overdue, schedule labels, inventory dosesLeft/expiry, activity, caregivers, quickActionCaption, **nav.{home,history,pumps,caregivers,reports,settings}**) avec interpolations `{{n}}`, `{{name}}`, `{{date}}`. **Aucune chaîne UI hardcodée**.

- **Module mapping** `apps/web/src/lib/home/messages.ts` : construit `HomeDashboardMessages` à partir d'un `t()` i18next courant + formatte la date longue locale (`fr-CA` / `en-CA`) + heuristique `formatExpiryStatus` (45 jours pour le seuil "soon").

- **Données mockées** dans `apps/web/src/lib/home/mock-data.ts` : 3 pompes plausibles (Fluticasone fond + Salbutamol maison low + Salbutamol garderie), 3 slots horaires, 2 entrées d'activité dont 1 rescue avec cause "Effort", 3 aidants colorés. **Temporaire** : à remplacer par les projections `@kinhale/sync` dans une PR ultérieure dédiée au wiring.

- **Variante desktop** `HomeWebDashboard` reproduit fidèlement `KinhaleWeb` de la maquette (≈ 700 lignes) :
  - Sidebar : logo œil-pompe + 6 nav items localisés + carte AIDANTS avec avatars empilés (`color-mix accent 18%`)
  - Top bar sticky avec `backdrop-filter: blur(12)` + role pill + halo OK
  - Status hero color-coded par `time` (overdue → amber, evening → maint, on-track → ok)
  - Schedule strip 3 colonnes JetBrains Mono tabular-nums
  - Activity avec icône + label + cause badge + sync note
  - Pump rail Stock + dosesLeft mono + barre 6 px + expiry icon
  - Action dock pill flottant centré, sticky bottom 24, `backdrop-filter: blur(20)`, box-shadow `color-mix accent 35%`

## Conformité workflow Kinhale (CLAUDE.md §revue assistée)

**`kz-design-review` lancé** vs `Kinhale Home.html` sur 60+ critères stricts (palette, typo, layout, dimensions exactes, états dynamiques, a11y…). Verdict initial ⚠️ écarts mineurs + **3 majeurs** — tous résolus avant push :

- ✅ **J1** — Halo dot `StatusHero` figé sur `okSoft` → calcul dynamique via `color-mix(in oklch, ${tone.dotVar} 18%, transparent)`
- ✅ **J2** — `DEFAULT_NAV_ITEMS` hardcodés en français (violation règle non-négociable #5 i18n FR+EN) → 6 clés `home.dashboard.nav.*` ajoutées + prop `navItems` requise + `apps/web/src/app/page.tsx` construit la liste via `t()` + branche les `onPress`
- ✅ **J3** — Aucun heading natif rendu (régression WCAG 2.1 AA) → `tag="h1"` sur nom enfant top bar + `KinhaleHeader` mobile, `tag="h2"` sur status hero + `SectionHeader` mobile + headers section web (Schedule, Activity, Pump rail)

Mineurs notables traités en passant : letterSpacing en px, `tag="h1"` sur header mobile.

## Décisions de scope

- **Mobile** (`apps/mobile/app/index.tsx`) reporté à **PR-A2** couplée avec **KIN-105** (parité fonts mobile / Inter Tight via expo-google-fonts) — évite de cascader Expo + Metro config dans cette PR.
- **Wiring vers `@kinhale/sync`** reporté — données mockées pour cette PR pour découpler le visuel du data-flow et limiter le blast radius en cas de revert.

## Volume

8 fichiers modifiés + 13 fichiers créés (composants + lib + mock) — ~1 783 lignes ajoutées, ~30 modifiées.

## Test plan

- [x] `pnpm format:check` — propre
- [x] `pnpm lint:root` — 0 warning
- [x] `pnpm typecheck` — 10/10 packages OK
- [x] `pnpm test` — **301/301 verts** (206 web + 95 mobile, 2 nouveaux tests Home : redirect non-auth + dashboard auth)
- [x] `kz-design-review` lancé, 3 majeurs résolus avant push, rapport interne `.agents/current-run/kz-design-review-KIN-106-PRA.md`
- [x] Vérification visuelle screenshot Playwright à 1440×900 — sidebar + main + rail conformes maquette
- [ ] **Test manuel navigateur** : http://localhost:3000/ (avec session) — vérifier responsive (resize sous/sur 1024 px) + interactions (clic Fond/Secours/Historique/sidebar)
- [ ] Test responsive < 1024 px → bascule sur layout mobile-style
- [ ] Test EN (toggle locale) — sidebar nav, role labels, dashboard textes

## Tickets de suivi (déjà ouverts ou créés)

- **PR-A2** — Refonte écran mobile Home (à brancher après KIN-105 résolu)
- **KIN-105** (issue #366) — Parité mobile clinical-calm : fonts + tokens Tamagui + bascule `@kinhale/ui` côté Expo
- Wiring `@kinhale/sync` projections (à ouvrir si pas déjà tracé)

🤖 Generated with [Claude Code](https://claude.com/claude-code)