### PR TITLE
feat(ui,web,i18n): refonte étapes Pumps + Plan + Done de l'onboarding (KIN-108)

### DIFF
--- a/apps/web/src/app/onboarding/done/page.tsx
+++ b/apps/web/src/app/onboarding/done/page.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { projectChild } from '@kinhale/sync';
+import {
+  DoneStep,
+  OnboardingAside,
+  OnboardingCTA,
+  OnboardingShell,
+  type OnboardingShellCopy,
+} from '@kinhale/ui/onboarding';
+
+import { useDocStore } from '../../../stores/doc-store';
+import { useRequireAuth } from '../../../lib/useRequireAuth';
+
+export default function OnboardingDonePage(): React.JSX.Element | null {
+  const { t } = useTranslation('common');
+  const router = useRouter();
+  const authenticated = useRequireAuth();
+  const doc = useDocStore((s) => s.doc);
+
+  // Récupère le prénom de l'enfant pour personnaliser le titre. Si
+  // l'utilisateur a sauté l'étape Welcome (pas créé d'enfant), on tombe
+  // sur un libellé générique.
+  const childName = React.useMemo(() => {
+    if (doc === null) return '';
+    return projectChild(doc)?.firstName ?? '';
+  }, [doc]);
+
+  const shellCopy: OnboardingShellCopy = {
+    skip: t('onboarding.shellSkip'),
+    back: t('onboarding.shellBack'),
+  };
+
+  const stepCopy = {
+    title: t('onboarding.done.title'),
+    sub: t('onboarding.done.sub'),
+    nextReminder: t('onboarding.done.nextReminder'),
+  };
+
+  if (!authenticated) return null;
+
+  return (
+    <OnboardingShell
+      step="done"
+      copy={shellCopy}
+      aside={
+        <OnboardingAside
+          step="done"
+          copy={{
+            eyebrow: t('onboarding.done.asideEyebrow'),
+            title: t('onboarding.done.asideTitle'),
+            body: t('onboarding.done.asideBody'),
+          }}
+        />
+      }
+      primaryCta={
+        <OnboardingCTA
+          label={t('onboarding.done.cta')}
+          onPress={() => router.push('/')}
+          testID="onboarding-done-cta"
+        />
+      }
+    >
+      <DoneStep copy={stepCopy} childName={childName} />
+    </OnboardingShell>
+  );
+}

--- a/apps/web/src/app/onboarding/plan/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/plan/__tests__/page.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { screen, fireEvent, act } from '@testing-library/react';
+import { fireEvent, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import OnboardingPlanPage from '../page';
 import { renderWithProviders } from '../../../../test-utils/render';
 
@@ -8,7 +9,7 @@ jest.setTimeout(15000);
 const mockProjectPumps = jest.fn((_doc: unknown) => [
   {
     pumpId: 'pump-1',
-    name: 'Ventolin',
+    name: 'Fluticasone',
     pumpType: 'maintenance',
     totalDoses: 200,
     expiresAtMs: null,
@@ -40,26 +41,7 @@ jest.mock('../../../../stores/auth-store', () => ({
 }));
 
 const mockAppendPlan = jest.fn().mockResolvedValue([new Uint8Array([1])]);
-const mockDoc = {
-  householdId: 'hh-1',
-  events: [
-    {
-      id: 'e1',
-      type: 'PumpReplaced',
-      payloadJson: JSON.stringify({
-        pumpId: 'pump-1',
-        name: 'Ventolin',
-        pumpType: 'maintenance',
-        totalDoses: 200,
-        expiresAtMs: null,
-      }),
-      signerPublicKeyHex: 'a'.repeat(64),
-      signatureHex: 'b'.repeat(128),
-      deviceId: 'dev-1',
-      occurredAtMs: 1000,
-    },
-  ],
-};
+const mockDoc = { householdId: 'hh-1', events: [] };
 jest.mock('../../../../stores/doc-store', () => ({
   useDocStore: jest.fn((selector: (s: { appendPlan: jest.Mock; doc: typeof mockDoc }) => unknown) =>
     selector({ appendPlan: mockAppendPlan, doc: mockDoc }),
@@ -75,8 +57,6 @@ jest.mock('../../../../lib/device', () => ({
   getOrCreateDevice: (...args: unknown[]) => mockGetOrCreateDevice(...args),
 }));
 
-// Statut sync — mutable pour que les tests du guard E7-S08 puissent le
-// basculer. Par défaut : en ligne.
 let mockConnected = true;
 jest.mock('../../../../stores/sync-status-store', () => ({
   useSyncStatusStore: jest.fn(
@@ -84,6 +64,14 @@ jest.mock('../../../../stores/sync-status-store', () => ({
       selector({ connected: mockConnected, pulling: false }),
   ),
 }));
+
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 6; i += 1) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+};
 
 describe('OnboardingPlanPage', () => {
   beforeEach(() => {
@@ -94,7 +82,7 @@ describe('OnboardingPlanPage', () => {
     mockProjectPumps.mockReturnValue([
       {
         pumpId: 'pump-1',
-        name: 'Ventolin',
+        name: 'Fluticasone',
         pumpType: 'maintenance',
         totalDoses: 200,
         expiresAtMs: null,
@@ -108,12 +96,7 @@ describe('OnboardingPlanPage', () => {
     jest.useFakeTimers();
     try {
       renderWithProviders(<OnboardingPlanPage />);
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flush();
       expect(mockReplace).toHaveBeenCalledWith('/auth');
     } finally {
       jest.clearAllTimers();
@@ -121,56 +104,49 @@ describe('OnboardingPlanPage', () => {
     }
   });
 
-  it('affiche le formulaire quand une pompe de fond est disponible', () => {
-    renderWithProviders(<OnboardingPlanPage />);
-    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
-    // Avec une seule pompe, le sélecteur est masqué (auto-sélection) et le champ heures est affiché
-    expect(screen.getByPlaceholderText(/8.*20|ex.*8/i)).toBeInTheDocument();
-  });
-
-  it('navigue vers /journal après sauvegarde réussie', async () => {
+  it('affiche le titre du step Plan + horaires par défaut 8h/20h', async () => {
     jest.useFakeTimers();
     try {
       renderWithProviders(<OnboardingPlanPage />);
-      fireEvent.change(screen.getByPlaceholderText(/8.*20|ex.*8/i), {
-        target: { value: '8, 20' },
-      });
-      fireEvent.click(screen.getByText(/enregistrer|save/i));
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-      expect(mockAppendPlan).toHaveBeenCalledWith(
-        expect.objectContaining({ pumpId: 'pump-1', scheduledHoursUtc: [8, 20] }),
-        'dev-1',
-        expect.any(Uint8Array),
-      );
-      expect(mockPush).toHaveBeenCalledWith('/journal');
+      await flush();
+      // KIN-108 : refonte clinical-calm — titre étape 3 « À quels moments
+      // de la journée ? » / « When during the day? ».
+      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
     } finally {
       jest.clearAllTimers();
       jest.useRealTimers();
     }
   });
 
-  it('affiche le CTA "Ajouter une pompe" quand aucune pompe de fond n\'est enregistrée', async () => {
-    mockProjectPumps.mockReturnValue([]);
-    renderWithProviders(<OnboardingPlanPage />);
-    expect(
-      screen.getByText(/ajoute d'abord une pompe|add a maintenance pump/i),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/ajouter une pompe|add a pump/i)).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText(/8.*20|ex.*8/i)).toBeNull();
+  it('crée un plan avec [8, 20] sur la pompe maintenance puis redirige', async () => {
+    jest.useFakeTimers();
+    try {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      renderWithProviders(<OnboardingPlanPage />);
+      await flush();
+      await user.click(screen.getByTestId('onboarding-plan-cta'));
+      await flush();
+      expect(mockAppendPlan).toHaveBeenCalledWith(
+        expect.objectContaining({ pumpId: 'pump-1', scheduledHoursUtc: [8, 20] }),
+        'dev-1',
+        expect.any(Uint8Array),
+      );
+      expect(mockPush).toHaveBeenCalledWith('/onboarding/done');
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
   });
 
-  it('navigue vers /onboarding/pump en cliquant sur le CTA quand aucune pompe', async () => {
+  it('affiche un message si aucune pompe maintenance et désactive le CTA', async () => {
     mockProjectPumps.mockReturnValue([]);
     jest.useFakeTimers();
     try {
       renderWithProviders(<OnboardingPlanPage />);
-      fireEvent.click(screen.getByText(/ajouter une pompe|add a pump/i));
-      expect(mockPush).toHaveBeenCalledWith('/onboarding/pump');
+      await flush();
+      // Le CTA est désactivé quand pas de pompe maintenance.
+      const cta = screen.getByTestId('onboarding-plan-cta');
+      expect(cta).toBeDisabled();
     } finally {
       jest.clearAllTimers();
       jest.useRealTimers();
@@ -178,29 +154,16 @@ describe('OnboardingPlanPage', () => {
   });
 
   it('hors-ligne : affiche le message du guard et ne déclenche pas appendPlan', async () => {
+    mockConnected = false;
     jest.useFakeTimers();
     try {
-      mockConnected = false;
       renderWithProviders(<OnboardingPlanPage />);
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
-
+      await flush();
       expect(screen.getByTestId('offline-guard-message')).toBeTruthy();
-
-      // Tenter de cliquer malgré le disabled : le handler `if (!online) return`
-      // doit empêcher appendPlan d'être appelé.
-      const saveBtn = screen.getByText(/enregistrer|save/i);
-      fireEvent.click(saveBtn);
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      // Bouton désactivé → fireEvent court-circuite pointer-events: none
+      // pour vérifier que le handler `if (!online) return` bloque.
+      fireEvent.click(screen.getByTestId('onboarding-plan-cta'));
+      await flush();
       expect(mockAppendPlan).not.toHaveBeenCalled();
     } finally {
       jest.clearAllTimers();

--- a/apps/web/src/app/onboarding/plan/page.tsx
+++ b/apps/web/src/app/onboarding/plan/page.tsx
@@ -3,14 +3,33 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
-import { YStack, H1, Button, Text, Input, XStack, Card } from 'tamagui';
+import { Stack, Text } from 'tamagui';
+import {
+  OnboardingAside,
+  OnboardingCTA,
+  OnboardingShell,
+  PlanStep,
+  type OnboardingShellCopy,
+  type PlanStepValue,
+} from '@kinhale/ui/onboarding';
 import { projectPumps } from '@kinhale/sync';
+
 import { useAuthStore } from '../../../stores/auth-store';
 import { useDocStore } from '../../../stores/doc-store';
 import { getOrCreateDevice } from '../../../lib/device';
 import { useRequireAuth } from '../../../lib/useRequireAuth';
 import { useOnlineGuard } from '../../../hooks/useOnlineGuard';
-import { DisclaimerFooter } from '../../../components/DisclaimerFooter';
+
+// Conversion "HH:MM" → heure UTC entière (les minutes ne sont pas gérées
+// par le format actuel `scheduledHoursUtc: number[]` ; KIN-038 prévoit
+// un format plus précis post-v1.0).
+function parseHour(time: string): number | null {
+  const match = /^(\d{2}):(\d{2})$/.exec(time);
+  if (!match) return null;
+  const hour = parseInt(match[1] ?? '', 10);
+  if (Number.isNaN(hour) || hour < 0 || hour > 23) return null;
+  return hour;
+}
 
 export default function OnboardingPlanPage(): React.JSX.Element | null {
   const { t } = useTranslation('common');
@@ -21,30 +40,49 @@ export default function OnboardingPlanPage(): React.JSX.Element | null {
   const appendPlan = useDocStore((s) => s.appendPlan);
   const doc = useDocStore((s) => s.doc);
 
+  const [value, setValue] = useState<PlanStepValue>({
+    morningTime: '08:00',
+    eveningTime: '20:00',
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   const maintenancePumps =
     doc !== null
       ? projectPumps(doc).filter((p) => p.pumpType === 'maintenance' && !p.isExpired)
       : [];
+  const targetPumpId = maintenancePumps[0]?.pumpId ?? null;
 
-  const [selectedPumpId, setSelectedPumpId] = useState<string | null>(
-    maintenancePumps.length === 1 ? (maintenancePumps[0]?.pumpId ?? null) : null,
-  );
-  const [hoursStr, setHoursStr] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const shellCopy: OnboardingShellCopy = {
+    skip: t('onboarding.shellSkip'),
+    back: t('onboarding.shellBack'),
+  };
 
-  const handleSave = async (): Promise<void> => {
-    // Défense en profondeur : cf. kz-securite-075-078 §m1.
+  const stepCopy = {
+    title: t('onboarding.plan.stepTitle'),
+    sub: t('onboarding.plan.stepSub'),
+    morningLabel: t('onboarding.plan.morningLabel'),
+    eveningLabel: t('onboarding.plan.eveningLabel'),
+    plansTitle: t('onboarding.plan.plansTitle'),
+    plansSub: t('onboarding.plan.plansSub'),
+    greenLabel: t('onboarding.plan.greenLabel'),
+    greenSub: t('onboarding.plan.greenSub'),
+    yellowLabel: t('onboarding.plan.yellowLabel'),
+    yellowSub: t('onboarding.plan.yellowSub'),
+    redLabel: t('onboarding.plan.redLabel'),
+    redSub: t('onboarding.plan.redSub'),
+  };
+
+  const handleContinue = async (): Promise<void> => {
     if (!online) return;
     setError(null);
-    if (selectedPumpId === null) {
-      setError(t('onboarding.plan.saveError'));
+    if (targetPumpId === null) {
+      setError(t('onboarding.plan.noMaintenance'));
       return;
     }
-    const scheduledHoursUtc = hoursStr
-      .split(',')
-      .map((h) => parseInt(h.trim(), 10))
-      .filter((h) => !isNaN(h));
+    const morningHour = parseHour(value.morningTime);
+    const eveningHour = parseHour(value.eveningTime);
+    const scheduledHoursUtc = [morningHour, eveningHour].filter((h): h is number => h !== null);
     if (scheduledHoursUtc.length === 0) {
       setError(t('onboarding.plan.saveError'));
       return;
@@ -56,7 +94,7 @@ export default function OnboardingPlanPage(): React.JSX.Element | null {
       await appendPlan(
         {
           planId: crypto.randomUUID(),
-          pumpId: selectedPumpId,
+          pumpId: targetPumpId,
           scheduledHoursUtc,
           startAtMs: Date.now(),
           endAtMs: null,
@@ -64,7 +102,7 @@ export default function OnboardingPlanPage(): React.JSX.Element | null {
         deviceId,
         kp.secretKey,
       );
-      router.push('/journal');
+      router.push('/onboarding/done');
     } catch {
       setError(t('onboarding.plan.saveError'));
     } finally {
@@ -74,80 +112,60 @@ export default function OnboardingPlanPage(): React.JSX.Element | null {
 
   if (!authenticated) return null;
 
-  if (maintenancePumps.length === 0) {
-    return (
-      <YStack padding="$4" gap="$4">
-        <H1>{t('onboarding.plan.title')}</H1>
-        <Card padding="$4" gap="$3">
-          <Text fontWeight="bold" fontSize="$5">
-            {t('onboarding.plan.noMaintenancePumpTitle')}
-          </Text>
-          <Text>{t('onboarding.plan.noMaintenancePumpBody')}</Text>
-          <Button
-            onPress={() => router.push('/onboarding/pump')}
-            backgroundColor="$blue9"
-            color="white"
-            borderColor="$blue10"
-            borderWidth={2}
-            accessibilityLabel={t('onboarding.plan.goToPumpCta')}
-          >
-            {t('onboarding.plan.goToPumpCta')}
-          </Button>
-        </Card>
-        {/* Pied E10 : disclaimer discret omniprésent (RM27). */}
-        <DisclaimerFooter />
-      </YStack>
-    );
-  }
-
   return (
-    <YStack padding="$4" gap="$4">
-      <H1>{t('onboarding.plan.title')}</H1>
-
-      {maintenancePumps.length > 1 && (
-        <>
-          <Text fontWeight="600">{t('onboarding.plan.pumpSelectLabel')}</Text>
-          <XStack flexWrap="wrap" gap="$2">
-            {maintenancePumps.map((p) => (
-              <Button
-                key={p.pumpId}
-                onPress={() => setSelectedPumpId(p.pumpId)}
-                backgroundColor={selectedPumpId === p.pumpId ? '$blue9' : '$backgroundStrong'}
-                color={selectedPumpId === p.pumpId ? 'white' : '$color'}
-                borderColor={selectedPumpId === p.pumpId ? '$blue10' : '$borderColor'}
-                borderWidth={2}
-              >
-                {p.name}
-              </Button>
-            ))}
-          </XStack>
-        </>
-      )}
-
-      <Text fontWeight="600">{t('onboarding.plan.hoursLabel')}</Text>
-      <Input
-        value={hoursStr}
-        onChangeText={setHoursStr}
-        placeholder={t('onboarding.plan.hoursPlaceholder')}
-      />
+    <OnboardingShell
+      step="plan"
+      copy={shellCopy}
+      onBack={() => router.push('/onboarding/pump')}
+      onSkip={() => router.push('/')}
+      aside={
+        <OnboardingAside
+          step="plan"
+          copy={{
+            eyebrow: t('onboarding.plan.asideEyebrow'),
+            title: t('onboarding.plan.asideTitle'),
+            body: t('onboarding.plan.asideBody'),
+          }}
+        />
+      }
+      primaryCta={
+        <OnboardingCTA
+          label={t('onboarding.plan.stepCta')}
+          loading={loading}
+          loadingLabel={t('onboarding.plan.saving')}
+          disabled={targetPumpId === null || !online}
+          onPress={() => void handleContinue()}
+          testID="onboarding-plan-cta"
+        />
+      }
+    >
+      <PlanStep copy={stepCopy} value={value} onChange={setValue} />
 
       {error !== null && (
-        <Text role="alert" color="$red10">
+        <Text color="$amberInk" fontSize={12} marginTop={12} role="alert">
           {error}
         </Text>
       )}
 
-      {!online ? (
-        <Text color="$orange10" testID="offline-guard-message" role="status">
-          {t('offlineGuard.message')}
+      {targetPumpId === null && (
+        <Text color="$colorMore" fontSize={12} marginTop={12} fontStyle="italic">
+          {t('onboarding.plan.noMaintenance')}
         </Text>
-      ) : null}
+      )}
 
-      <Button onPress={() => void handleSave()} disabled={loading || !online} marginTop="$2">
-        {loading ? t('onboarding.plan.saving') : t('onboarding.plan.save')}
-      </Button>
-      {/* Pied E10 : disclaimer discret omniprésent (RM27). */}
-      <DisclaimerFooter />
-    </YStack>
+      {!online && (
+        <Stack
+          marginTop={12}
+          paddingHorizontal={14}
+          paddingVertical={10}
+          borderRadius={10}
+          backgroundColor="$amberSoft"
+        >
+          <Text color="$amberInk" fontSize={12} testID="offline-guard-message" role="status">
+            {t('offlineGuard.message')}
+          </Text>
+        </Stack>
+      )}
+    </OnboardingShell>
   );
 }

--- a/apps/web/src/app/onboarding/pump/__tests__/page.test.tsx
+++ b/apps/web/src/app/onboarding/pump/__tests__/page.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { screen, fireEvent, act } from '@testing-library/react';
+import { screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import OnboardingPumpPage from '../page';
 import { renderWithProviders } from '../../../../test-utils/render';
 
@@ -40,16 +41,42 @@ jest.mock('../../../../lib/device', () => ({
   getOrCreateDevice: (...args: unknown[]) => mockGetOrCreateDevice(...args),
 }));
 
+let mockConnected = true;
+jest.mock('../../../../stores/sync-status-store', () => ({
+  useSyncStatusStore: jest.fn(
+    (selector: (s: { connected: boolean; pulling: boolean }) => unknown) =>
+      selector({ connected: mockConnected, pulling: false }),
+  ),
+}));
+
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 6; i += 1) {
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+};
+
 describe('OnboardingPumpPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockAccessToken = 'tok-1';
+    mockConnected = true;
     mockAppendPump.mockResolvedValue([new Uint8Array([1])]);
   });
 
-  it('affiche le formulaire', () => {
-    renderWithProviders(<OnboardingPumpPage />);
-    expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+  it('affiche le titre du step Pumps', async () => {
+    jest.useFakeTimers();
+    try {
+      renderWithProviders(<OnboardingPumpPage />);
+      await flush();
+      // KIN-108 : refonte clinical-calm — titre étape 2 « Quelles sont
+      // ses pompes ? » / « What inhalers do they use? ».
+      expect(screen.getByRole('heading', { level: 1 })).toBeInTheDocument();
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
   });
 
   it('redirige vers /auth si non authentifié (#181)', async () => {
@@ -57,12 +84,7 @@ describe('OnboardingPumpPage', () => {
     jest.useFakeTimers();
     try {
       renderWithProviders(<OnboardingPumpPage />);
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flush();
       expect(mockReplace).toHaveBeenCalledWith('/auth');
     } finally {
       jest.clearAllTimers();
@@ -70,23 +92,23 @@ describe('OnboardingPumpPage', () => {
     }
   });
 
-  it('navigue vers /onboarding/plan après sauvegarde réussie', async () => {
+  it('crée une pompe maintenance + une pompe rescue par défaut puis redirige', async () => {
     jest.useFakeTimers();
     try {
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       renderWithProviders(<OnboardingPumpPage />);
-      fireEvent.change(screen.getByPlaceholderText(/ventolin|ventolin/i), {
-        target: { value: 'Ventolin' },
-      });
-      fireEvent.change(screen.getByPlaceholderText(/200/i), { target: { value: '200' } });
-      fireEvent.click(screen.getByText(/enregistrer|save/i));
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flush();
+      // Les deux toggles sont actifs par défaut → un clic sur le CTA suffit.
+      await user.click(screen.getByTestId('onboarding-pumps-cta'));
+      await flush();
+      expect(mockAppendPump).toHaveBeenCalledTimes(2);
       expect(mockAppendPump).toHaveBeenCalledWith(
-        expect.objectContaining({ name: 'Ventolin', totalDoses: 200 }),
+        expect.objectContaining({ name: 'Fluticasone', pumpType: 'maintenance', totalDoses: 200 }),
+        'dev-1',
+        expect.any(Uint8Array),
+      );
+      expect(mockAppendPump).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Salbutamol', pumpType: 'rescue', totalDoses: 200 }),
         'dev-1',
         expect.any(Uint8Array),
       );
@@ -101,18 +123,11 @@ describe('OnboardingPumpPage', () => {
     jest.useFakeTimers();
     try {
       mockAppendPump.mockRejectedValueOnce(new Error('network'));
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
       renderWithProviders(<OnboardingPumpPage />);
-      fireEvent.change(screen.getByPlaceholderText(/ventolin|ventolin/i), {
-        target: { value: 'Ventolin' },
-      });
-      fireEvent.change(screen.getByPlaceholderText(/200/i), { target: { value: '200' } });
-      fireEvent.click(screen.getByText(/enregistrer|save/i));
-      await act(async () => {
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-        await Promise.resolve();
-      });
+      await flush();
+      await user.click(screen.getByTestId('onboarding-pumps-cta'));
+      await flush();
       expect(screen.getByRole('alert')).toBeTruthy();
       expect(mockPush).not.toHaveBeenCalled();
     } finally {

--- a/apps/web/src/app/onboarding/pump/page.tsx
+++ b/apps/web/src/app/onboarding/pump/page.tsx
@@ -3,44 +3,90 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
-import { YStack, H1, Button, Text, Input, XStack } from 'tamagui';
+import { Stack, Text } from 'tamagui';
+import {
+  OnboardingAside,
+  OnboardingCTA,
+  OnboardingShell,
+  PumpsStep,
+  type OnboardingShellCopy,
+  type PumpsStepValue,
+} from '@kinhale/ui/onboarding';
+
 import { useAuthStore } from '../../../stores/auth-store';
 import { useDocStore } from '../../../stores/doc-store';
 import { getOrCreateDevice } from '../../../lib/device';
 import { useRequireAuth } from '../../../lib/useRequireAuth';
-import { DisclaimerFooter } from '../../../components/DisclaimerFooter';
+import { useOnlineGuard } from '../../../hooks/useOnlineGuard';
+
+// Valeurs par défaut métier — la maquette ne demande qu'un toggle
+// fond/secours, pas le détail des pompes. On crée des pompes initiales
+// avec des valeurs raisonnables que l'utilisateur pourra ajuster plus
+// tard via la page « Mes pompes » (à créer en PR-C).
+const DEFAULT_TOTAL_DOSES = 200;
+const DEFAULT_EXPIRY_OFFSET_MS = 365 * 24 * 60 * 60 * 1000; // 12 mois
 
 export default function OnboardingPumpPage(): React.JSX.Element | null {
   const { t } = useTranslation('common');
   const router = useRouter();
   const authenticated = useRequireAuth();
+  const { online } = useOnlineGuard();
   const deviceId = useAuthStore((s) => s.deviceId) ?? '';
   const appendPump = useDocStore((s) => s.appendPump);
 
-  const [name, setName] = useState('');
-  const [pumpType, setPumpType] = useState<'maintenance' | 'rescue'>('maintenance');
-  const [totalDosesStr, setTotalDosesStr] = useState('');
-  const [expiresAtStr, setExpiresAtStr] = useState('');
+  const [pumps, setPumps] = useState<PumpsStepValue>({ maint: true, rescue: true });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const handleSave = async (): Promise<void> => {
-    setError(null);
-    const totalDoses = parseInt(totalDosesStr, 10);
-    if (name.trim() === '' || isNaN(totalDoses) || totalDoses <= 0) {
-      setError(t('onboarding.pump.saveError'));
-      return;
-    }
-    const expiresAtMs = expiresAtStr.trim() !== '' ? new Date(expiresAtStr.trim()).getTime() : null;
+  const shellCopy: OnboardingShellCopy = {
+    skip: t('onboarding.shellSkip'),
+    back: t('onboarding.shellBack'),
+  };
 
+  const stepCopy = {
+    title: t('onboarding.pumps.title'),
+    sub: t('onboarding.pumps.sub'),
+    maintLabel: t('onboarding.pumps.maintLabel'),
+    maintSub: t('onboarding.pumps.maintSub'),
+    rescueLabel: t('onboarding.pumps.rescueLabel'),
+    rescueSub: t('onboarding.pumps.rescueSub'),
+  };
+
+  const validSelection = pumps.maint || pumps.rescue;
+
+  const handleContinue = async (): Promise<void> => {
+    if (!online || !validSelection) return;
+    setError(null);
     setLoading(true);
     try {
       const kp = await getOrCreateDevice();
-      await appendPump(
-        { pumpId: crypto.randomUUID(), name: name.trim(), pumpType, totalDoses, expiresAtMs },
-        deviceId,
-        kp.secretKey,
-      );
+      const expiresAtMs = Date.now() + DEFAULT_EXPIRY_OFFSET_MS;
+      if (pumps.maint) {
+        await appendPump(
+          {
+            pumpId: crypto.randomUUID(),
+            name: 'Fluticasone',
+            pumpType: 'maintenance',
+            totalDoses: DEFAULT_TOTAL_DOSES,
+            expiresAtMs,
+          },
+          deviceId,
+          kp.secretKey,
+        );
+      }
+      if (pumps.rescue) {
+        await appendPump(
+          {
+            pumpId: crypto.randomUUID(),
+            name: 'Salbutamol',
+            pumpType: 'rescue',
+            totalDoses: DEFAULT_TOTAL_DOSES,
+            expiresAtMs,
+          },
+          deviceId,
+          kp.secretKey,
+        );
+      }
       router.push('/onboarding/plan');
     } catch {
       setError(t('onboarding.pump.saveError'));
@@ -49,68 +95,58 @@ export default function OnboardingPumpPage(): React.JSX.Element | null {
     }
   };
 
+  const errorMessage = !validSelection ? t('onboarding.pumps.atLeastOne') : error;
+
   if (!authenticated) return null;
 
   return (
-    <YStack padding="$4" gap="$4">
-      <H1>{t('onboarding.pump.title')}</H1>
+    <OnboardingShell
+      step="pumps"
+      copy={shellCopy}
+      onBack={() => router.push('/onboarding/child')}
+      onSkip={() => router.push('/')}
+      aside={
+        <OnboardingAside
+          step="pumps"
+          copy={{
+            eyebrow: t('onboarding.pumps.asideEyebrow'),
+            title: t('onboarding.pumps.asideTitle'),
+            body: t('onboarding.pumps.asideBody'),
+          }}
+        />
+      }
+      primaryCta={
+        <OnboardingCTA
+          label={t('onboarding.pumps.cta')}
+          loading={loading}
+          loadingLabel={t('onboarding.pump.saving')}
+          disabled={!validSelection || !online}
+          onPress={() => void handleContinue()}
+          testID="onboarding-pumps-cta"
+        />
+      }
+    >
+      <PumpsStep copy={stepCopy} value={pumps} onChange={setPumps} />
 
-      <Text fontWeight="600">{t('onboarding.pump.nameLabel')}</Text>
-      <Input
-        value={name}
-        onChangeText={setName}
-        placeholder={t('onboarding.pump.namePlaceholder')}
-      />
-
-      <Text fontWeight="600">{t('onboarding.pump.typeLabel')}</Text>
-      <XStack gap="$3">
-        <Button
-          flex={1}
-          onPress={() => setPumpType('maintenance')}
-          backgroundColor={pumpType === 'maintenance' ? '$blue9' : '$backgroundStrong'}
-          color={pumpType === 'maintenance' ? 'white' : '$color'}
-          borderColor={pumpType === 'maintenance' ? '$blue10' : '$borderColor'}
-          borderWidth={2}
-        >
-          {t('onboarding.pump.typeMaintenance')}
-        </Button>
-        <Button
-          flex={1}
-          onPress={() => setPumpType('rescue')}
-          backgroundColor={pumpType === 'rescue' ? '$blue9' : '$backgroundStrong'}
-          color={pumpType === 'rescue' ? 'white' : '$color'}
-          borderColor={pumpType === 'rescue' ? '$blue10' : '$borderColor'}
-          borderWidth={2}
-        >
-          {t('onboarding.pump.typeRescue')}
-        </Button>
-      </XStack>
-
-      <Text fontWeight="600">{t('onboarding.pump.totalDosesLabel')}</Text>
-      <Input
-        value={totalDosesStr}
-        onChangeText={setTotalDosesStr}
-        placeholder={t('onboarding.pump.totalDosesPlaceholder')}
-      />
-
-      <Text fontWeight="600">{t('onboarding.pump.expiresAtLabel')}</Text>
-      <Input
-        value={expiresAtStr}
-        onChangeText={setExpiresAtStr}
-        placeholder={t('onboarding.pump.expiresAtPlaceholder')}
-      />
-
-      {error !== null && (
-        <Text role="alert" color="$red10">
-          {error}
+      {errorMessage !== null && (
+        <Text color="$amberInk" fontSize={12} marginTop={12} role="alert">
+          {errorMessage}
         </Text>
       )}
 
-      <Button onPress={() => void handleSave()} disabled={loading} marginTop="$2">
-        {loading ? t('onboarding.pump.saving') : t('onboarding.pump.save')}
-      </Button>
-      {/* Pied E10 : disclaimer discret omniprésent (RM27). */}
-      <DisclaimerFooter />
-    </YStack>
+      {!online && (
+        <Stack
+          marginTop={12}
+          paddingHorizontal={14}
+          paddingVertical={10}
+          borderRadius={10}
+          backgroundColor="$amberSoft"
+        >
+          <Text color="$amberInk" fontSize={12} testID="offline-guard-message" role="status">
+            {t('offlineGuard.message')}
+          </Text>
+        </Stack>
+      )}
+    </OnboardingShell>
   );
 }

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -217,11 +217,46 @@
       "asideTitle": "Welcome to Kinhale",
       "asideBody": "We will set up your child's tracking in under 3 minutes. No jargon, no busywork."
     },
+    "pumps": {
+      "title": "What inhalers do they use?",
+      "sub": "Let's set up the routine. We can adjust anything later.",
+      "maintLabel": "Maintenance (morning + evening)",
+      "maintSub": "Fluticasone, Budesonide…",
+      "rescueLabel": "Rescue (as needed)",
+      "rescueSub": "Salbutamol (Ventolin)…",
+      "cta": "Continue",
+      "atLeastOne": "Select at least one type of inhaler to continue.",
+      "asideEyebrow": "Step 2 · 6",
+      "asideTitle": "Your inhalers",
+      "asideBody": "A maintenance inhaler, a rescue inhaler, or both. Tracking adapts to what your child uses."
+    },
+    "plan": {
+      "stepTitle": "When during the day?",
+      "stepSub": "We'll send a gentle reminder. Never guilt.",
+      "morningLabel": "Morning",
+      "eveningLabel": "Evening",
+      "plansTitle": "The action plan",
+      "plansSub": "Like a traffic light. Green, yellow, red.",
+      "greenLabel": "Green zone",
+      "greenSub": "No symptoms · maintenance only",
+      "yellowLabel": "Yellow zone",
+      "yellowSub": "Cough, wheeze · add rescue puffs",
+      "redLabel": "Red zone",
+      "redSub": "Distress · 4 rescue puffs and call 911",
+      "stepCta": "Got it",
+      "noMaintenance": "No maintenance inhaler registered. Enable it in the previous step to set reminders.",
+      "asideEyebrow": "Step 3 · 6",
+      "asideTitle": "When?",
+      "asideBody": "Pick reminders that match real life. You can change them later."
+    },
     "done": {
       "title": "Well done {{name}} !",
       "sub": "First details saved. Routine activated.",
       "nextReminder": "Next reminder · tonight 8:00 PM",
-      "cta": "Go to home"
+      "cta": "Go to home",
+      "asideEyebrow": "",
+      "asideTitle": "You are set",
+      "asideBody": "The journal is live and reminders are active."
     },
     "errors": {
       "nameRequired": "Your child's first name is required."

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -217,11 +217,46 @@
       "asideTitle": "Bienvenue chez Kinhale",
       "asideBody": "On va créer le suivi de votre enfant en moins de 3 minutes. Pas de jargon, pas de questions inutiles."
     },
+    "pumps": {
+      "title": "Quelles sont ses pompes ?",
+      "sub": "Configurons d'abord la routine. On ajustera tout plus tard.",
+      "maintLabel": "Pompe de fond (matin et soir)",
+      "maintSub": "Fluticasone, Budesonide…",
+      "rescueLabel": "Pompe de secours (au besoin)",
+      "rescueSub": "Salbutamol (Ventolin)…",
+      "cta": "Continuer",
+      "atLeastOne": "Sélectionnez au moins un type de pompe pour continuer.",
+      "asideEyebrow": "Étape 2 · 6",
+      "asideTitle": "Vos pompes",
+      "asideBody": "Une pompe de fond, une pompe de secours, ou les deux. Le suivi s'adapte à ce que votre enfant utilise."
+    },
+    "plan": {
+      "stepTitle": "À quels moments de la journée ?",
+      "stepSub": "On enverra un rappel discret. Pas culpabilisant.",
+      "morningLabel": "Matin",
+      "eveningLabel": "Soir",
+      "plansTitle": "Le plan d'action",
+      "plansSub": "Comme un feu de circulation. Vert, jaune, rouge.",
+      "greenLabel": "Zone verte",
+      "greenSub": "Pas de symptômes · routine de fond seulement",
+      "yellowLabel": "Zone jaune",
+      "yellowSub": "Toux, sifflement · ajouter pompe de secours",
+      "redLabel": "Zone rouge",
+      "redSub": "Détresse · 4 bouffées secours et appelez le 911",
+      "stepCta": "C'est compris",
+      "noMaintenance": "Aucune pompe de fond enregistrée. Activez-la à l'étape précédente pour configurer le rappel.",
+      "asideEyebrow": "Étape 3 · 6",
+      "asideTitle": "Quand ?",
+      "asideBody": "Choisissez les rappels qui collent à la vraie vie. Vous pourrez les modifier plus tard."
+    },
     "done": {
       "title": "Bravo {{name}} !",
       "sub": "Premières informations enregistrées. Routine activée.",
       "nextReminder": "Prochain rappel · ce soir 20:00",
-      "cta": "Aller à l'accueil"
+      "cta": "Aller à l'accueil",
+      "asideEyebrow": "",
+      "asideTitle": "Prêt",
+      "asideBody": "Vous y êtes. Le journal est ouvert, les rappels sont actifs."
     },
     "errors": {
       "nameRequired": "Le prénom de votre enfant est obligatoire."

--- a/packages/ui/src/components/onboarding/PlanStep.tsx
+++ b/packages/ui/src/components/onboarding/PlanStep.tsx
@@ -1,0 +1,190 @@
+import * as React from 'react';
+import { Input, Stack, Text, XStack, YStack } from 'tamagui';
+
+export interface PlanStepValue {
+  morningTime: string;
+  eveningTime: string;
+}
+
+interface PlanStepProps {
+  copy: {
+    title: string;
+    sub: string;
+    morningLabel: string;
+    eveningLabel: string;
+    plansTitle: string;
+    plansSub: string;
+    greenLabel: string;
+    greenSub: string;
+    yellowLabel: string;
+    yellowSub: string;
+    redLabel: string;
+    redSub: string;
+  };
+  value: PlanStepValue;
+  onChange: (next: PlanStepValue) => void;
+}
+
+// Step 2+3 fusionnés (maquette `Kinhale Onboarding.html` lignes 3429+3479).
+// Deux blocs :
+//   1. Horaires : 2 TimeRow matin (08:00) + soir (20:00) en JetBrains Mono
+//   2. Plan d'action : 3 ZoneCard vert (zone OK) / jaune (alerte) / rouge
+//      (urgence). Affichage informatif, pas d'édition à ce stade.
+export function PlanStep({ copy, value, onChange }: PlanStepProps): React.JSX.Element {
+  return (
+    <YStack paddingTop={8} gap={6}>
+      <Text
+        tag="h1"
+        margin={0}
+        fontFamily="$heading"
+        fontSize={22}
+        fontWeight="500"
+        letterSpacing={-0.44}
+        color="$color"
+      >
+        {copy.title}
+      </Text>
+      <Text fontSize={13.5} color="$colorMore" lineHeight={20} marginTop={6}>
+        {copy.sub}
+      </Text>
+
+      <YStack marginTop={22} gap={10}>
+        <TimeRow
+          icon="☀"
+          iconColor="oklch(60% 0.10 75)"
+          label={copy.morningLabel}
+          value={value.morningTime}
+          onChange={(time): void => onChange({ ...value, morningTime: time })}
+        />
+        <TimeRow
+          icon="☾"
+          iconColor="oklch(50% 0.08 250)"
+          label={copy.eveningLabel}
+          value={value.eveningTime}
+          onChange={(time): void => onChange({ ...value, eveningTime: time })}
+        />
+      </YStack>
+
+      <YStack marginTop={28} gap={6}>
+        <Text
+          tag="h2"
+          margin={0}
+          fontFamily="$heading"
+          fontSize={18}
+          fontWeight="500"
+          letterSpacing={-0.36}
+          color="$color"
+        >
+          {copy.plansTitle}
+        </Text>
+        <Text fontSize={13.5} color="$colorMore" lineHeight={20} marginTop={4}>
+          {copy.plansSub}
+        </Text>
+      </YStack>
+
+      <YStack marginTop={14} gap={10}>
+        <ZoneCard color="oklch(65% 0.14 145)" label={copy.greenLabel} sub={copy.greenSub} />
+        <ZoneCard color="oklch(78% 0.14 80)" label={copy.yellowLabel} sub={copy.yellowSub} />
+        <ZoneCard color="oklch(60% 0.18 25)" label={copy.redLabel} sub={copy.redSub} />
+      </YStack>
+    </YStack>
+  );
+}
+
+interface TimeRowProps {
+  icon: string;
+  iconColor: string;
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+}
+
+function TimeRow({ icon, iconColor, label, value, onChange }: TimeRowProps): React.JSX.Element {
+  return (
+    <XStack
+      paddingHorizontal={16}
+      paddingVertical={14}
+      gap={14}
+      alignItems="center"
+      backgroundColor="$surface"
+      borderWidth={0.5}
+      borderColor="$borderColor"
+      borderRadius={14}
+    >
+      <Stack
+        width={36}
+        height={36}
+        borderRadius={10}
+        backgroundColor="$surface2"
+        alignItems="center"
+        justifyContent="center"
+        flexShrink={0}
+      >
+        <Text fontSize={18} style={{ color: iconColor }}>
+          {icon}
+        </Text>
+      </Stack>
+      <Text fontSize={13} fontWeight="500" color="$colorMore" flex={1}>
+        {label}
+      </Text>
+      <Input
+        unstyled
+        value={value}
+        onChangeText={onChange}
+        keyboardType="numbers-and-punctuation"
+        // type="time" en HTML pur — Tamagui Input est mappé à un input web.
+        // Côté mobile, fallback texte (acceptable pour cette PR).
+        {...({ type: 'time' } as object)}
+        backgroundColor="transparent"
+        borderWidth={0}
+        fontFamily="$mono"
+        fontSize={18}
+        fontWeight="600"
+        color="$color"
+        textAlign="right"
+        style={{ fontVariantNumeric: 'tabular-nums' } as object}
+        aria-label={label}
+      />
+    </XStack>
+  );
+}
+
+interface ZoneCardProps {
+  color: string;
+  label: string;
+  sub: string;
+}
+
+function ZoneCard({ color, label, sub }: ZoneCardProps): React.JSX.Element {
+  return (
+    <XStack
+      gap={14}
+      paddingHorizontal={16}
+      paddingVertical={14}
+      backgroundColor="$surface"
+      borderRadius={14}
+      borderWidth={0.5}
+      borderColor="$borderColor"
+    >
+      <Stack
+        width={36}
+        height={36}
+        borderRadius={18}
+        flexShrink={0}
+        // Halo doux 4 px teinté de la couleur de la zone — calque exact maquette.
+        style={{
+          background: color,
+          boxShadow: `0 0 0 4px color-mix(in oklch, ${color} 18%, transparent)`,
+        }}
+      />
+      <YStack flex={1} minWidth={0}>
+        <Text fontSize={14} fontWeight="600" color="$color">
+          {label}
+        </Text>
+        <Text fontSize={12.5} color="$colorMore" marginTop={3} lineHeight={20}>
+          {sub}
+        </Text>
+      </YStack>
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/onboarding/PumpsStep.tsx
+++ b/packages/ui/src/components/onboarding/PumpsStep.tsx
@@ -1,0 +1,138 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { CheckSmallIcon } from '../auth/icons';
+import { InhalerMaintIcon, InhalerRescueIcon } from '../../icons';
+
+export interface PumpsStepValue {
+  maint: boolean;
+  rescue: boolean;
+}
+
+interface PumpsStepProps {
+  copy: {
+    title: string;
+    sub: string;
+    maintLabel: string;
+    maintSub: string;
+    rescueLabel: string;
+    rescueSub: string;
+  };
+  value: PumpsStepValue;
+  onChange: (next: PumpsStepValue) => void;
+}
+
+// Step 1 de l'onboarding (maquette `Kinhale Onboarding.html` ligne 3373).
+// Liste verticale de 2 `CheckTile` : fond (controller) + secours (rescue).
+// L'utilisateur peut activer un, l'autre, ou les deux.
+export function PumpsStep({ copy, value, onChange }: PumpsStepProps): React.JSX.Element {
+  return (
+    <YStack paddingTop={8} gap={6}>
+      <Text
+        tag="h1"
+        margin={0}
+        fontFamily="$heading"
+        fontSize={22}
+        fontWeight="500"
+        letterSpacing={-0.44}
+        color="$color"
+      >
+        {copy.title}
+      </Text>
+      <Text fontSize={13.5} color="$colorMore" lineHeight={20} marginTop={6}>
+        {copy.sub}
+      </Text>
+      <YStack marginTop={22} gap={10}>
+        <CheckTile
+          checked={value.maint}
+          onChange={(next): void => onChange({ ...value, maint: next })}
+          kind="maint"
+          title={copy.maintLabel}
+          sub={copy.maintSub}
+        />
+        <CheckTile
+          checked={value.rescue}
+          onChange={(next): void => onChange({ ...value, rescue: next })}
+          kind="rescue"
+          title={copy.rescueLabel}
+          sub={copy.rescueSub}
+        />
+      </YStack>
+    </YStack>
+  );
+}
+
+interface CheckTileProps {
+  checked: boolean;
+  onChange: (next: boolean) => void;
+  kind: 'maint' | 'rescue';
+  title: string;
+  sub: string;
+}
+
+// CheckTile interne au step Pumps — on le garde local plutôt que de
+// l'exposer publiquement tant qu'aucun autre écran n'en a l'usage.
+function CheckTile({ checked, onChange, kind, title, sub }: CheckTileProps): React.JSX.Element {
+  return (
+    <XStack
+      tag="button"
+      cursor="pointer"
+      onPress={() => onChange(!checked)}
+      width="100%"
+      paddingHorizontal={16}
+      paddingVertical={14}
+      alignItems="center"
+      gap={14}
+      backgroundColor={checked ? '$maintSoft' : '$surface'}
+      borderWidth={1.5}
+      borderColor={checked ? '$maint' : '$borderColor'}
+      borderRadius={14}
+      animation="quick"
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked }}
+      accessibilityLabel={title}
+      // Backgroundcolor utilise color-mix pour matcher exactement la maquette
+      // quand checked (8% de l'accent vs surface).
+      style={{
+        background: checked ? 'color-mix(in oklch, var(--maint) 8%, var(--surface))' : undefined,
+      }}
+    >
+      <Stack
+        width={48}
+        height={48}
+        borderRadius={12}
+        backgroundColor={kind === 'maint' ? '$maint' : '$rescue'}
+        alignItems="center"
+        justifyContent="center"
+        flexShrink={0}
+      >
+        {kind === 'maint' ? (
+          <InhalerMaintIcon size={24} color="#ffffff" />
+        ) : (
+          <InhalerRescueIcon size={24} color="#ffffff" />
+        )}
+      </Stack>
+      <YStack flex={1} minWidth={0}>
+        <Text fontSize={14} fontWeight="600" color="$color">
+          {title}
+        </Text>
+        <Text fontSize={12} color="$colorMore" marginTop={2}>
+          {sub}
+        </Text>
+      </YStack>
+      <Stack
+        width={22}
+        height={22}
+        borderRadius={11}
+        flexShrink={0}
+        backgroundColor={checked ? '$maint' : 'transparent'}
+        borderWidth={checked ? 0 : 1.5}
+        borderColor="$borderColorStrong"
+        alignItems="center"
+        justifyContent="center"
+      >
+        {checked && <CheckSmallIcon size={12} color="#ffffff" />}
+      </Stack>
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/onboarding/index.ts
+++ b/packages/ui/src/components/onboarding/index.ts
@@ -3,7 +3,12 @@ export { OnboardingAside } from './OnboardingAside';
 export { OnboardingCTA } from './OnboardingCTA';
 export { ProgressDots } from './ProgressDots';
 export { WelcomeStep } from './WelcomeStep';
+export { PumpsStep } from './PumpsStep';
+export { PlanStep } from './PlanStep';
 export { DoneStep } from './DoneStep';
+
+export type { PumpsStepValue } from './PumpsStep';
+export type { PlanStepValue } from './PlanStep';
 
 export { ONBOARDING_STEPS } from './types';
 export type { OnboardingShellCopy, OnboardingStep } from './types';


### PR DESCRIPTION
## Summary

Suite de la refonte clinical-calm de l'onboarding. La PR #368 (KIN-107) avait livré l'étape **Welcome**. Cette PR complète le flow avec les **3 étapes restantes** alignées sur la maquette `docs/design/handoffs/2026-04-26-clinical-calm/project/Kinhale Onboarding.html` :

- Étape 2 — **Pompes** (toggle fond/secours)
- Étape 3 — **Plan** (horaires matin/soir + zones vert/jaune/rouge informatives)
- Étape finale — **Done** (validation + redirect vers le dashboard)

**Refs:** KIN-108 — PR-B2 du backlog refonte design.

## Apport

### Composants partagés `@kinhale/ui/onboarding`

- **`PumpsStep`** : titre Inter Tight 22 + sub 13.5 + 2 toggle-tiles via composant interne `CheckTile` (icône 48×48 accentée, indicateur rond 22×22, état checked = `color-mix(maint 8%, surface)` + bordure accent 1.5 px).
- **`PlanStep`** : combine
  - 2 `TimeRow` matin/soir avec icône soleil/lune, input time JetBrains Mono `fontVariantNumeric: tabular-nums`
  - 3 `ZoneCard` plan d'action : cercle 36×36 + halo `color-mix 18%` aux couleurs vert / jaune / rouge (alignées maquette)
- **`DoneStep`** finalisé : coche XL OK 104×104 + halo okSoft 12 px + titre interpolé `{name}` + récap rappel mono.

### Routes web refondues

- **`/onboarding/pump`** : shell dual-pane + `PumpsStep`. Sur Continuer, crée 1 pompe maintenance (Fluticasone, 200 doses, 12 mois) et/ou rescue (Salbutamol) selon les toggles. Détails personnalisables plus tard via « Mes pompes » (PR-C).
- **`/onboarding/plan`** : shell dual-pane + `PlanStep`. Horaires par défaut 08:00 / 20:00 → `scheduledHoursUtc: [8, 20]` lors du `appendPlan`.
- **`/onboarding/done`** (NOUVEAU) : récupère le prénom de l'enfant via `projectChild` pour personnaliser le titre. CTA « Aller à l'accueil » → `router.push('/')`.

### i18n

30 nouvelles clés `onboarding.{pumps,plan,done}.*` (FR + EN) incluant les variantes aside (eyebrow / title / body) pour le panneau gauche desktop.

## Test plan

- [x] `pnpm format:check` — propre
- [x] `pnpm lint:root` — 0 warning
- [x] `pnpm typecheck` — 10/10 packages OK
- [x] `pnpm test` — **300/300 verts** (205 web + 95 mobile, tests onboarding adaptés)
- [ ] **Test manuel navigateur** : http://localhost:3000/onboarding/child → cliquer Continuer
  → /onboarding/pump (shell dual-pane + 2 toggles fond/secours)
  → /onboarding/plan (shell dual-pane + horaires + zones vert/jaune/rouge)
  → /onboarding/done (coche verte XL + bouton "Aller à l'accueil")
  → / (dashboard)
- [ ] Test EN (toggle locale) sur les 4 étapes
- [ ] Test responsive (sous 1024 px → bascule sur layout mobile-empilé)

## Périmètre — qu'est-ce qui n'est PAS dans cette PR

- **Étape 4 « Première dose guidée »** (s5 maquette : 4 sous-étapes shake/insert/breathe/rinse) — c'est plus un tutoriel qu'une saisie. Repoussée vers une PR ultérieure si besoin product. Le flow saute directement de Plan → Done.
- **Visuels SVG personnalisés par étape** dans `OnboardingAside` — actuellement toutes les étapes utilisent le même breath orb. Les variantes spécifiques (2 inhalateurs FOND/SOS, horloge, etc. de la maquette `OnbAside.Visuals[step]`) seront ajoutées en peaufinage si la fidélité visuelle l'exige. Le contenu textuel (eyebrow / title / body) du panneau est déjà différencié par étape.

## Tickets de suivi

- **PR-A2 / KIN-105** — Parité mobile clinical-calm (toujours en attente)
- **PR-C** — Mes pompes + Détail + Ajouter pompe (récupère le contrôle des champs détaillés que cette PR-B2 a simplifié à des valeurs par défaut)
- **PR-F** — Page Plan d'action éditable (zones vert/jaune/rouge personnalisables, signature pédiatre)

🤖 Generated with [Claude Code](https://claude.com/claude-code)