### PR TITLE
feat(ui,web,i18n): refonte page Historique clinical-calm (KIN-111)

### DIFF
--- a/apps/web/src/app/journal/page.tsx
+++ b/apps/web/src/app/journal/page.tsx
@@ -1,35 +1,31 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import * as React from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
-import { YStack, H1, Text, Button, XStack } from 'tamagui';
-import { projectDoses, projectCaregivers, type ProjectedDose } from '@kinhale/sync';
-import { canEditDose } from '@kinhale/domain/entities';
-import type { Role } from '@kinhale/domain/entities';
+
+import { projectCaregivers, projectDoses } from '@kinhale/sync';
+import {
+  HistoryListMobile,
+  HistoryListWeb,
+  type HistoryFilter,
+  type HistoryNavItem,
+} from '@kinhale/ui/history';
+
 import { useAuthStore } from '../../stores/auth-store';
 import { useDocStore } from '../../stores/doc-store';
+import {
+  buildCalendarCells,
+  buildFeed,
+  buildHistoryListMessages,
+  buildStats,
+} from '../../lib/journal/messages';
 
-/**
- * Détermine le rôle de l'aidant courant depuis la projection des aidants
- * du foyer. Retombe sur `'contributor'` par défaut tant que l'aidant n'est
- * pas associé à un device dans la projection (cas d'amorçage).
- */
-function deriveCurrentRole(
-  caregivers: ReadonlyArray<{ caregiverId: string; role: string }>,
-  deviceId: string | null,
-): Role {
-  if (deviceId === null) return 'contributor';
-  const me = caregivers.find((c) => c.caregiverId === deviceId);
-  if (me === undefined) return 'contributor';
-  if (me.role === 'admin' || me.role === 'restricted_contributor' || me.role === 'contributor') {
-    return me.role;
-  }
-  return 'contributor';
-}
+const DESKTOP_BREAKPOINT_PX = 1024;
 
-export default function JournalPage(): React.JSX.Element {
-  const { t } = useTranslation('common');
+export default function JournalPage(): React.JSX.Element | null {
+  const { t, i18n } = useTranslation('common');
   const router = useRouter();
   const accessToken = useAuthStore((s) => s.accessToken);
   const householdId = useAuthStore((s) => s.householdId);
@@ -37,176 +33,137 @@ export default function JournalPage(): React.JSX.Element {
   const doc = useDocStore((s) => s.doc);
   const initDoc = useDocStore((s) => s.initDoc);
 
+  const [hydrated, setHydrated] = useState(false);
+  const [isDesktop, setIsDesktop] = useState<boolean | null>(null);
+  const [filter, setFilter] = useState<HistoryFilter>('all');
+  const [reference, setReference] = useState<Date>(() => new Date());
+
   useEffect(() => {
+    setHydrated(true);
+    if (typeof window !== 'undefined') {
+      const mq = window.matchMedia(`(min-width: ${DESKTOP_BREAKPOINT_PX}px)`);
+      const update = (): void => setIsDesktop(mq.matches);
+      update();
+      mq.addEventListener('change', update);
+      return () => mq.removeEventListener('change', update);
+    }
+    return undefined;
+  }, []);
+
+  useEffect(() => {
+    if (!hydrated) return;
     if (accessToken === null) {
-      router.push('/auth');
+      router.replace('/auth');
       return;
     }
     if (householdId !== null) {
-      initDoc(householdId);
+      void initDoc(householdId);
     }
-  }, [accessToken, householdId, initDoc, router]);
+  }, [accessToken, householdId, hydrated, initDoc, router]);
 
-  const doses = doc !== null ? projectDoses(doc) : [];
-  const caregivers = doc !== null ? projectCaregivers(doc) : [];
-  const currentRole = deriveCurrentRole(caregivers, deviceId);
-  const nowMs = Date.now();
-
-  return (
-    <YStack padding="$4" gap="$4">
-      <H1>{t('journal.title')}</H1>
-      <XStack gap="$2" flexWrap="wrap" marginBottom="$3">
-        <Button size="$3" onPress={() => router.push('/onboarding/child')}>
-          {t('nav.child')}
-        </Button>
-        <Button size="$3" onPress={() => router.push('/onboarding/pump')}>
-          {t('nav.pumps')}
-        </Button>
-        <Button size="$3" onPress={() => router.push('/onboarding/plan')}>
-          {t('nav.plan')}
-        </Button>
-        <Button size="$3" onPress={() => router.push('/caregivers')}>
-          {t('nav.caregivers')}
-        </Button>
-      </XStack>
-      {doses.length === 0 && <Text color="$color10">{t('journal.empty')}</Text>}
-      {doses.map((dose) => {
-        const isVoided = dose.status === 'voided';
-        const isPendingReview = dose.status === 'pending_review';
-        const editVerdict = canEditDose({
-          dose: {
-            recordedByDeviceId: dose.deviceId,
-            administeredAtMs: dose.administeredAtMs,
-            status: dose.status,
-          },
-          currentDeviceId: deviceId ?? '',
-          currentRole,
-          nowMs,
-        });
-        return (
-          <DoseCard
-            key={dose.eventId}
-            dose={dose}
-            isVoided={isVoided}
-            isPendingReview={isPendingReview}
-            canEdit={editVerdict.allowed}
-            t={t}
-            onEdit={() => router.push(`/journal/edit/${dose.doseId}`)}
-            onVoid={() => router.push(`/journal/void/${dose.doseId}`)}
-            onResolve={() => router.push(`/journal/resolve/${dose.doseId}`)}
-          />
-        );
-      })}
-      <Button onPress={() => router.push('/journal/add')} marginTop="$2">
-        {t('journal.addDose')}
-      </Button>
-    </YStack>
+  const doses = React.useMemo(() => (doc !== null ? projectDoses(doc) : []), [doc]);
+  const caregivers = React.useMemo(
+    () =>
+      doc !== null
+        ? projectCaregivers(doc).map((c) => ({
+            caregiverId: c.caregiverId,
+            alias: c.displayName,
+          }))
+        : [],
+    [doc],
   );
-}
 
-interface DoseCardProps {
-  readonly dose: ProjectedDose;
-  readonly isVoided: boolean;
-  readonly isPendingReview: boolean;
-  readonly canEdit: boolean;
-  readonly t: (key: string) => string;
-  readonly onEdit: () => void;
-  readonly onVoid: () => void;
-  readonly onResolve: () => void;
-}
+  const locale = i18n.language === 'en' ? 'en-CA' : 'fr-CA';
+  const messages = React.useMemo(() => buildHistoryListMessages(t, reference), [t, reference]);
 
-function DoseCard({
-  dose,
-  isVoided,
-  isPendingReview,
-  canEdit,
-  t,
-  onEdit,
-  onVoid,
-  onResolve,
-}: DoseCardProps): React.JSX.Element {
-  const labelKey = dose.doseType === 'rescue' ? 'journal.rescue' : 'journal.maintenance';
-  const reasonLabel =
-    isVoided && dose.voidedReason !== undefined && dose.voidedReason === 'duplicate_resolved'
-      ? t('journal.dose.voidedReason.duplicate_resolved')
-      : (dose.voidedReason ?? '');
+  const cells = React.useMemo(
+    () => buildCalendarCells({ doses, currentDeviceId: deviceId, caregivers, reference, locale }),
+    [doses, deviceId, caregivers, reference, locale],
+  );
+  const stats = React.useMemo(
+    () => buildStats({ doses, currentDeviceId: deviceId, caregivers, reference, locale }),
+    [doses, deviceId, caregivers, reference, locale],
+  );
+  const feed = React.useMemo(
+    () => buildFeed(t, { doses, currentDeviceId: deviceId, caregivers, reference, locale }, filter),
+    [t, doses, deviceId, caregivers, reference, locale, filter],
+  );
+
+  const navItems = React.useMemo<HistoryNavItem[]>(
+    () => [
+      { key: 'home', label: t('pumps.nav.home'), onPress: () => router.push('/') },
+      { key: 'history', label: t('pumps.nav.history'), active: true },
+      {
+        key: 'pumps',
+        label: t('pumps.nav.pumps'),
+        onPress: () => router.push('/pumps'),
+      },
+      {
+        key: 'caregivers',
+        label: t('pumps.nav.caregivers'),
+        onPress: () => router.push('/caregivers'),
+      },
+      {
+        key: 'reports',
+        label: t('pumps.nav.reports'),
+        onPress: () => router.push('/reports'),
+      },
+      {
+        key: 'settings',
+        label: t('pumps.nav.settings'),
+        onPress: () => router.push('/settings/notifications'),
+      },
+    ],
+    [router, t],
+  );
+
+  if (!hydrated || accessToken === null || isDesktop === null) {
+    return null;
+  }
+
+  const handlers = {
+    onPressAdd: (): void => router.push('/journal/add'),
+    onPressExport: (): void => router.push('/reports'),
+    onPressEntry: (id: string): void => router.push(`/journal/edit/${id}`),
+    onPressPrevMonth: (): void => {
+      setReference((prev) => {
+        const next = new Date(prev);
+        next.setMonth(next.getMonth() - 1, 1);
+        return next;
+      });
+    },
+    onPressNextMonth: (): void => {
+      setReference((prev) => {
+        const next = new Date(prev);
+        next.setMonth(next.getMonth() + 1, 1);
+        return next;
+      });
+    },
+    onChangeFilter: (f: HistoryFilter): void => setFilter(f),
+  };
+
+  if (isDesktop) {
+    return (
+      <HistoryListWeb
+        messages={messages}
+        cells={cells}
+        stats={stats}
+        feed={feed}
+        activeFilter={filter}
+        navItems={navItems}
+        handlers={handlers}
+      />
+    );
+  }
+
   return (
-    <YStack
-      data-testid={`dose-card-${dose.doseId}`}
-      padding="$3"
-      borderWidth={1}
-      borderColor={isPendingReview ? '$orange8' : '$borderColor'}
-      borderRadius="$3"
-      gap="$2"
-      opacity={isVoided ? 0.55 : 1}
-      backgroundColor={isPendingReview ? '$orange3' : '$background'}
-    >
-      <XStack justifyContent="space-between" alignItems="center">
-        <Text
-          fontSize="$4"
-          fontWeight="700"
-          textDecorationLine={isVoided ? 'line-through' : 'none'}
-        >
-          {t(labelKey)}
-        </Text>
-        <Text fontSize="$2" color="$color9">
-          {new Date(dose.administeredAtMs).toLocaleString()}
-        </Text>
-      </XStack>
-
-      {isVoided && (
-        <Text fontSize="$2" color="$color10" fontWeight="600">
-          {t('journal.dose.voidedBadge')}
-          {reasonLabel.length > 0 && ` · ${t('journal.dose.voidedReason.label')} : ${reasonLabel}`}
-        </Text>
-      )}
-
-      {isPendingReview && (
-        <Text fontSize="$2" color="$orange11" fontWeight="600">
-          {t('journal.dose.pendingReviewBadge')}
-        </Text>
-      )}
-
-      {dose.symptoms.length > 0 && (
-        <Text fontSize="$3" color="$color10">
-          {dose.symptoms.map((s) => t(`journal.symptom.${s}`)).join(' · ')}
-        </Text>
-      )}
-
-      {dose.circumstances.length > 0 && (
-        <Text fontSize="$3" color="$color10">
-          {dose.circumstances.map((c) => t(`journal.circumstance.${c}`)).join(' · ')}
-        </Text>
-      )}
-
-      {dose.freeFormTag !== null && (
-        <Text fontSize="$3" color="$color9" fontStyle="italic">
-          {dose.freeFormTag}
-        </Text>
-      )}
-
-      {!isVoided && (
-        <XStack gap="$2" flexWrap="wrap" marginTop="$2">
-          {canEdit && (
-            <Button size="$2" onPress={onEdit} testID={`dose-edit-${dose.doseId}`}>
-              {t('journal.dose.actions.edit')}
-            </Button>
-          )}
-          <Button size="$2" onPress={onVoid} theme="red" testID={`dose-void-${dose.doseId}`}>
-            {t('journal.dose.actions.void')}
-          </Button>
-          {isPendingReview && (
-            <Button
-              size="$2"
-              onPress={onResolve}
-              theme="orange"
-              testID={`dose-resolve-${dose.doseId}`}
-            >
-              {t('journal.dose.actions.resolve')}
-            </Button>
-          )}
-        </XStack>
-      )}
-    </YStack>
+    <HistoryListMobile
+      messages={messages}
+      cells={cells}
+      stats={stats}
+      feed={feed}
+      activeFilter={filter}
+      handlers={handlers}
+    />
   );
 }

--- a/apps/web/src/lib/journal/messages.ts
+++ b/apps/web/src/lib/journal/messages.ts
@@ -1,0 +1,283 @@
+import type { TFunction } from 'i18next';
+
+import type {
+  CalendarCell,
+  CalendarCellState,
+  FeedDay,
+  FeedEntry,
+  FeedEntryState,
+  HistoryListMessages,
+  HistoryStats,
+} from '@kinhale/ui/history';
+import type { ProjectedDose } from '@kinhale/sync';
+
+export interface ProjectedCaregiverLite {
+  caregiverId: string;
+  /** Pseudonyme du foyer (ex. « Antoine »). Optionnel. */
+  alias?: string | null;
+}
+
+interface BuildContext {
+  /** Doses du foyer projetées depuis le doc Automerge. */
+  doses: ReadonlyArray<ProjectedDose>;
+  /** ID du device courant (pour déterminer « Vous » dans le fil). */
+  currentDeviceId: string | null;
+  /** Aidants du foyer. */
+  caregivers: ReadonlyArray<ProjectedCaregiverLite>;
+  /** Mois affiché — par défaut le mois courant. */
+  reference?: Date;
+  /** Locale BCP-47, ex. `'fr-CA'` ou `'en-CA'`. */
+  locale: string;
+}
+
+function startOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), 1, 0, 0, 0, 0);
+}
+
+function endOfMonth(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth() + 1, 0, 23, 59, 59, 999);
+}
+
+function isoDay(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function formatTime(ms: number, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  }).format(new Date(ms));
+}
+
+function slotForHour(t: TFunction<'common'>, hour: number): string {
+  if (hour < 5 || hour >= 21) return t('history.slot.night');
+  if (hour < 12) return t('history.slot.morning');
+  if (hour < 17) return t('history.slot.afternoon');
+  return t('history.slot.evening');
+}
+
+function whoFor(
+  t: TFunction<'common'>,
+  caregiverId: string,
+  caregivers: ReadonlyArray<ProjectedCaregiverLite>,
+  currentDeviceId: string | null,
+): string {
+  if (currentDeviceId !== null && caregiverId === currentDeviceId) {
+    return t('history.actor.you');
+  }
+  const found = caregivers.find((c) => c.caregiverId === caregiverId);
+  if (found?.alias !== undefined && found.alias !== null && found.alias !== '') {
+    return found.alias;
+  }
+  return t('history.actor.unknown');
+}
+
+function statusToFeedState(s: ProjectedDose['status']): FeedEntryState {
+  if (s === 'voided') return 'voided';
+  if (s === 'pending_review') return 'pendingReview';
+  return 'done';
+}
+
+function dayLabelFor(t: TFunction<'common'>, iso: string, reference: Date): string {
+  const todayIso = isoDay(reference);
+  const yesterday = new Date(reference);
+  yesterday.setDate(yesterday.getDate() - 1);
+  const yIso = isoDay(yesterday);
+  if (iso === todayIso) return t('history.today');
+  if (iso === yIso) return t('history.yesterday');
+  // « 24 avril » — mois sans année si année courante.
+  const d = new Date(`${iso}T00:00:00`);
+  const months = t('history.months', { returnObjects: true }) as string[];
+  const month = months[d.getMonth()] ?? '';
+  return `${d.getDate()} ${month}`;
+}
+
+export function buildHistoryListMessages(
+  t: TFunction<'common'>,
+  reference: Date,
+): HistoryListMessages {
+  const months = t('history.months', { returnObjects: true }) as string[];
+  const weekdays = t('history.weekdays', { returnObjects: true }) as string[];
+  const monthLabel = `${capitalize(months[reference.getMonth()] ?? '')} ${reference.getFullYear()}`;
+
+  return {
+    childName: t('home.dashboard.childName'),
+    title: t('history.title'),
+    subtitle: t('history.subtitle'),
+    filtersLabel: t('history.filtersLabel'),
+    filterAll: t('history.filterAll'),
+    filterMaint: t('history.filterMaint'),
+    filterRescue: t('history.filterRescue'),
+    exportLabel: t('history.exportLabel'),
+    addCta: t('history.addCta'),
+    statAdherenceLabel: t('history.statAdherenceLabel'),
+    statRescueLabel: t('history.statRescueLabel'),
+    statStreakLabel: t('history.statStreakLabel'),
+    daysSuffix: t('history.daysSuffix'),
+    legendDone: t('history.legendDone'),
+    legendPartial: t('history.legendPartial'),
+    legendMissed: t('history.legendMissed'),
+    legendRescue: t('history.legendRescue'),
+    legendFuture: t('history.legendFuture'),
+    monthLabel,
+    weekdays,
+    pillFond: t('history.pillFond'),
+    pillSecours: t('history.pillSecours'),
+    markerVoided: t('history.marker.voided'),
+    markerPendingReview: t('history.marker.pendingReview'),
+    markerBackfill: t('history.marker.backfill'),
+    markerMissed: t('history.marker.missed'),
+    formatBy: (who: string) => t('history.by', { who }),
+    emptyTitle: t('history.emptyTitle'),
+    emptySub: t('history.emptySub'),
+    notMedical: t('history.notMedical'),
+  };
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+export function buildCalendarCells(ctx: BuildContext): CalendarCell[] {
+  const ref = ctx.reference ?? new Date();
+  const monthStart = startOfMonth(ref);
+  const monthEnd = endOfMonth(ref);
+  const todayIso = isoDay(new Date());
+
+  // Index des doses par jour ISO (uniquement le mois courant).
+  const byDay = new Map<string, ProjectedDose[]>();
+  for (const dose of ctx.doses) {
+    const d = new Date(dose.administeredAtMs);
+    if (d < monthStart || d > monthEnd) continue;
+    const key = isoDay(d);
+    const arr = byDay.get(key) ?? [];
+    arr.push(dose);
+    byDay.set(key, arr);
+  }
+
+  // Padding début (lundi = 0).
+  const cells: CalendarCell[] = [];
+  const firstDayOfWeek = (monthStart.getDay() + 6) % 7;
+  for (let i = 0; i < firstDayOfWeek; i++) {
+    cells.push({ day: null, state: 'future' });
+  }
+  for (let day = 1; day <= monthEnd.getDate(); day++) {
+    const iso = isoDay(new Date(ref.getFullYear(), ref.getMonth(), day));
+    const dayDoses = byDay.get(iso) ?? [];
+    const visibleDoses = dayDoses.filter((d) => d.status !== 'voided');
+    const isPast = iso < todayIso;
+    const isToday = iso === todayIso;
+
+    let state: CalendarCellState;
+    if (iso > todayIso) {
+      state = 'future';
+    } else if (isToday) {
+      state = visibleDoses.length === 0 ? 'todayPending' : 'done';
+    } else if (visibleDoses.length === 0 && isPast) {
+      state = 'missed';
+    } else if (visibleDoses.some((d) => d.doseType === 'rescue')) {
+      state = 'rescue';
+    } else {
+      state = 'done';
+    }
+    cells.push({ day, state, iso });
+  }
+  return cells;
+}
+
+export function buildStats(ctx: BuildContext): HistoryStats {
+  const ref = ctx.reference ?? new Date();
+  const monthStart = startOfMonth(ref);
+  const monthEnd = endOfMonth(ref);
+  const today = new Date();
+  const dayCount = Math.min(
+    today < monthEnd ? today.getDate() : monthEnd.getDate(),
+    monthEnd.getDate(),
+  );
+
+  // Doses du mois (non voidées).
+  const monthDoses = ctx.doses.filter((d) => {
+    const t = new Date(d.administeredAtMs);
+    return t >= monthStart && t <= monthEnd && d.status !== 'voided';
+  });
+
+  // Adhérence : % de jours écoulés du mois avec au moins 1 dose maint.
+  const daysWithMaint = new Set<string>();
+  for (const d of monthDoses) {
+    if (d.doseType === 'maintenance') {
+      daysWithMaint.add(isoDay(new Date(d.administeredAtMs)));
+    }
+  }
+  const adherencePct = dayCount > 0 ? Math.round((daysWithMaint.size / dayCount) * 100) : 0;
+
+  // Prises de secours du mois.
+  const rescueCount = monthDoses.filter((d) => d.doseType === 'rescue').length;
+
+  // Plus longue série consécutive de jours « avec maint ».
+  let longestStreakDays = 0;
+  let current = 0;
+  for (let day = 1; day <= dayCount; day++) {
+    const iso = isoDay(new Date(ref.getFullYear(), ref.getMonth(), day));
+    if (daysWithMaint.has(iso)) {
+      current += 1;
+      if (current > longestStreakDays) longestStreakDays = current;
+    } else {
+      current = 0;
+    }
+  }
+
+  return { adherencePct, rescueCount, longestStreakDays };
+}
+
+export function buildFeed(
+  t: TFunction<'common'>,
+  ctx: BuildContext,
+  filter: 'all' | 'maint' | 'rescue',
+): FeedDay[] {
+  const ref = ctx.reference ?? new Date();
+  const monthStart = startOfMonth(ref);
+
+  const filtered = ctx.doses.filter((d) => {
+    const time = new Date(d.administeredAtMs);
+    if (time < monthStart) return false;
+    if (filter === 'maint') return d.doseType === 'maintenance';
+    if (filter === 'rescue') return d.doseType === 'rescue';
+    return true;
+  });
+
+  // Tri décroissant pour avoir aujourd'hui d'abord.
+  const sorted = [...filtered].sort((a, b) => b.administeredAtMs - a.administeredAtMs);
+
+  const byDay = new Map<string, FeedEntry[]>();
+  for (const dose of sorted) {
+    const date = new Date(dose.administeredAtMs);
+    const iso = isoDay(date);
+    const slotLabel = slotForHour(t, date.getHours());
+    const time = formatTime(dose.administeredAtMs, ctx.locale);
+    const entry: FeedEntry = {
+      id: dose.doseId,
+      kind: dose.doseType === 'maintenance' ? 'maint' : 'rescue',
+      slot: slotLabel,
+      time: dose.status === 'voided' ? '—' : time,
+      who: whoFor(t, dose.caregiverId, ctx.caregivers, ctx.currentDeviceId),
+      state: statusToFeedState(dose.status),
+      ...(dose.doseType === 'rescue' && dose.circumstances.length > 0
+        ? { cause: dose.circumstances[0] }
+        : {}),
+      ...(dose.freeFormTag !== null && dose.freeFormTag !== '' ? { note: dose.freeFormTag } : {}),
+    };
+    const arr = byDay.get(iso) ?? [];
+    arr.push(entry);
+    byDay.set(iso, arr);
+  }
+
+  const days: FeedDay[] = [];
+  for (const [iso, entries] of byDay.entries()) {
+    days.push({ label: dayLabelFor(t, iso, ref), entries });
+  }
+  return days;
+}

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -762,5 +762,68 @@
       "metadataFailed": "Could not retrieve metadata from the server. Check your connection.",
       "generationFailed": "Could not generate the archive. Please try again."
     }
+  },
+  "history": {
+    "title": "History",
+    "subtitle": "All logged doses",
+    "filtersLabel": "Filters",
+    "filterAll": "All",
+    "filterMaint": "Maintenance only",
+    "filterRescue": "Rescue only",
+    "exportLabel": "Export",
+    "addCta": "Add a dose",
+    "statAdherenceLabel": "Adherence this month",
+    "statRescueLabel": "Rescue doses",
+    "statStreakLabel": "Best streak",
+    "daysSuffix": "d",
+    "legendDone": "Given",
+    "legendPartial": "Partial",
+    "legendMissed": "Missed",
+    "legendRescue": "Rescue",
+    "legendFuture": "Upcoming",
+    "weekdays": ["M", "T", "W", "T", "F", "S", "S"],
+    "monthFormat": "{{month}} {{year}}",
+    "months": [
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December"
+    ],
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "pillFond": "Maintenance",
+    "pillSecours": "Rescue",
+    "slot": {
+      "morning": "Morning",
+      "afternoon": "Afternoon",
+      "evening": "Evening",
+      "night": "Bedtime",
+      "asNeeded": "As needed"
+    },
+    "marker": {
+      "voided": "Voided",
+      "pendingReview": "Pending review",
+      "backfill": "Backfill",
+      "missed": "Missed"
+    },
+    "by": "by {{who}}",
+    "actor": {
+      "you": "You",
+      "coparent": "Co-parent",
+      "daycare": "Daycare",
+      "grandparent": "Grandma",
+      "unknown": "Caregiver"
+    },
+    "emptyTitle": "No doses logged yet",
+    "emptySub": "Logged doses will appear here, day by day.",
+    "notMedical": "Tracking tool · not medical advice."
   }
 }

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -762,5 +762,68 @@
       "metadataFailed": "Impossible de récupérer les métadonnées du serveur. Vérifiez votre connexion.",
       "generationFailed": "Impossible de générer l'archive. Réessayez."
     }
+  },
+  "history": {
+    "title": "Historique",
+    "subtitle": "Toutes les prises consignées",
+    "filtersLabel": "Filtres",
+    "filterAll": "Tout",
+    "filterMaint": "Fond seulement",
+    "filterRescue": "Secours seulement",
+    "exportLabel": "Exporter",
+    "addCta": "Ajouter une prise",
+    "statAdherenceLabel": "Adhérence ce mois",
+    "statRescueLabel": "Prises de secours",
+    "statStreakLabel": "Meilleure série",
+    "daysSuffix": "j",
+    "legendDone": "Donnée",
+    "legendPartial": "Partielle",
+    "legendMissed": "Manquée",
+    "legendRescue": "Secours",
+    "legendFuture": "À venir",
+    "weekdays": ["L", "M", "M", "J", "V", "S", "D"],
+    "monthFormat": "{{month}} {{year}}",
+    "months": [
+      "janvier",
+      "février",
+      "mars",
+      "avril",
+      "mai",
+      "juin",
+      "juillet",
+      "août",
+      "septembre",
+      "octobre",
+      "novembre",
+      "décembre"
+    ],
+    "today": "Aujourd'hui",
+    "yesterday": "Hier",
+    "pillFond": "Fond",
+    "pillSecours": "Secours",
+    "slot": {
+      "morning": "Matin",
+      "afternoon": "Après-midi",
+      "evening": "Soir",
+      "night": "Coucher",
+      "asNeeded": "Au besoin"
+    },
+    "marker": {
+      "voided": "Annulée",
+      "pendingReview": "À vérifier",
+      "backfill": "Rattrapage",
+      "missed": "Manquée"
+    },
+    "by": "par {{who}}",
+    "actor": {
+      "you": "Vous",
+      "coparent": "Co-parent",
+      "daycare": "Garderie",
+      "grandparent": "Mamie",
+      "unknown": "Aidant"
+    },
+    "emptyTitle": "Aucune prise enregistrée",
+    "emptySub": "Les prises consignées apparaîtront ici, jour par jour.",
+    "notMedical": "Outil de suivi · ne remplace pas un avis médical."
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -14,6 +14,7 @@
     "./home": "./src/components/home/index.ts",
     "./onboarding": "./src/components/onboarding/index.ts",
     "./pumps": "./src/components/pumps/index.ts",
+    "./history": "./src/components/history/index.ts",
     "./icons": "./src/icons/index.ts"
   },
   "scripts": {

--- a/packages/ui/src/components/history/CalendarGrid.tsx
+++ b/packages/ui/src/components/history/CalendarGrid.tsx
@@ -1,0 +1,137 @@
+import * as React from 'react';
+import { Stack, Text } from 'tamagui';
+
+import type { CalendarCell, CalendarCellState } from './types';
+
+interface ToneTokens {
+  bg: string;
+  fg: string;
+  dot: string | null;
+  ring?: boolean;
+  strike?: boolean;
+}
+
+function toneFor(state: CalendarCellState): ToneTokens {
+  switch (state) {
+    case 'done':
+      return { bg: '$okSoft', fg: '$ok', dot: '$ok' };
+    case 'partial':
+      return { bg: '$amberSoft', fg: '$amberInk', dot: '$amber' };
+    case 'missed':
+      return { bg: '$missSoft', fg: '$colorMore', dot: '$miss', strike: true };
+    case 'rescue':
+      return { bg: '$rescueSoft', fg: '$rescue', dot: '$rescue' };
+    case 'todayPending':
+      return { bg: 'transparent', fg: '$color', dot: '$maint', ring: true };
+    case 'future':
+    default:
+      return { bg: 'transparent', fg: '$colorFaint', dot: null };
+  }
+}
+
+export interface CalendarGridProps {
+  /** Tableau des libellés courts des 7 jours (déjà localisés). */
+  weekdays: ReadonlyArray<string>;
+  /** Cases du mois (avec padding début de semaine). */
+  cells: ReadonlyArray<CalendarCell>;
+  /** `true` => format dense pour mobile. */
+  compact?: boolean;
+  onPressDay?: ((iso: string) => void) | undefined;
+}
+
+export function CalendarGrid({
+  weekdays,
+  cells,
+  compact = false,
+  onPressDay,
+}: CalendarGridProps): React.JSX.Element {
+  return (
+    <Stack>
+      {/* Weekday headers */}
+      <Stack
+        marginBottom={8}
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(7, 1fr)',
+          gap: 4,
+        }}
+      >
+        {weekdays.map((w, i) => (
+          <Text
+            key={i}
+            textAlign="center"
+            fontSize={10}
+            color="$colorMore"
+            textTransform="uppercase"
+            letterSpacing={0.6}
+            fontWeight="600"
+          >
+            {w}
+          </Text>
+        ))}
+      </Stack>
+
+      {/* Cells */}
+      <Stack
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(7, 1fr)',
+          gap: 4,
+        }}
+      >
+        {cells.map((c, i) => {
+          if (c.day === null) return <Stack key={i} />;
+          const tone = toneFor(c.state);
+          const cellMin = compact ? 36 : 48;
+          const isPressable = onPressDay !== undefined && c.iso !== undefined;
+          return (
+            <Stack
+              key={i}
+              tag={isPressable ? 'button' : 'div'}
+              borderRadius={10}
+              backgroundColor={tone.bg as never}
+              borderWidth={tone.ring ? 1.5 : 0.5}
+              borderColor={tone.ring ? '$maint' : '$borderColor'}
+              alignItems="center"
+              justifyContent="center"
+              gap={3}
+              position="relative"
+              cursor={isPressable ? 'pointer' : 'default'}
+              {...(isPressable && c.iso ? { onPress: () => onPressDay(c.iso ?? '') } : {})}
+              accessibilityRole={isPressable ? 'button' : undefined}
+              accessibilityLabel={c.iso ?? `day-${c.day}`}
+              style={{ aspectRatio: '1', minHeight: cellMin }}
+            >
+              <Text
+                fontSize={compact ? 11 : 12}
+                color={tone.fg as never}
+                fontWeight={c.state === 'todayPending' ? '700' : '500'}
+                style={{
+                  fontVariantNumeric: 'tabular-nums',
+                  textDecoration: tone.strike ? 'line-through' : 'none',
+                }}
+              >
+                {c.day}
+              </Text>
+              {tone.dot !== null && (
+                <Stack width={4} height={4} borderRadius={2} backgroundColor={tone.dot as never} />
+              )}
+              {c.state === 'rescue' && (
+                <Stack
+                  position="absolute"
+                  top={4}
+                  right={4}
+                  width={6}
+                  height={6}
+                  borderRadius={3}
+                  backgroundColor="$rescue"
+                  style={{ boxShadow: '0 0 0 2px var(--background)' }}
+                />
+              )}
+            </Stack>
+          );
+        })}
+      </Stack>
+    </Stack>
+  );
+}

--- a/packages/ui/src/components/history/CalendarLegend.tsx
+++ b/packages/ui/src/components/history/CalendarLegend.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import { Stack, Text, XStack } from 'tamagui';
+
+import type { HistoryListMessages } from './types';
+
+export interface CalendarLegendProps {
+  messages: Pick<
+    HistoryListMessages,
+    'legendDone' | 'legendPartial' | 'legendMissed' | 'legendRescue'
+  >;
+  /**
+   * Si vrai, supprime le `marginTop:12` (utile quand la légende est
+   * placée à côté du `MonthHeader` côté web — le parent gère
+   * l'alignement vertical lui-même).
+   */
+  inline?: boolean;
+}
+
+export function CalendarLegend({
+  messages,
+  inline = false,
+}: CalendarLegendProps): React.JSX.Element {
+  const items: ReadonlyArray<{ label: string; tone: string }> = [
+    { label: messages.legendDone, tone: '$ok' },
+    { label: messages.legendPartial, tone: '$amber' },
+    { label: messages.legendMissed, tone: '$miss' },
+    { label: messages.legendRescue, tone: '$rescue' },
+  ];
+  return (
+    <XStack gap={14} flexWrap="wrap" {...(inline ? {} : { marginTop: 12 })}>
+      {items.map((it) => (
+        <XStack key={it.label} alignItems="center" gap={6}>
+          <Stack width={8} height={8} borderRadius={4} backgroundColor={it.tone as never} />
+          <Text fontSize={11} color="$colorMore">
+            {it.label}
+          </Text>
+        </XStack>
+      ))}
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/history/FeedDay.tsx
+++ b/packages/ui/src/components/history/FeedDay.tsx
@@ -1,0 +1,225 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { InhalerMaintIcon, InhalerRescueIcon } from '../../icons';
+import type { FeedDay as FeedDayData, FeedEntry, FeedEntryState } from './types';
+
+interface MarkerLabels {
+  voided: string;
+  pendingReview: string;
+  backfill: string;
+  missed: string;
+}
+
+interface BadgeTone {
+  bg: string;
+  fg: string;
+}
+
+const MARKER_TONE: Record<FeedEntryState, BadgeTone | null> = {
+  done: null,
+  missed: { bg: '$missSoft', fg: '$colorMore' },
+  voided: { bg: '$missSoft', fg: '$colorMore' },
+  pendingReview: { bg: '$amberSoft', fg: '$amberInk' },
+  backfill: { bg: '$maintSoft', fg: '$maintInk' },
+};
+
+function markerLabel(state: FeedEntryState, labels: MarkerLabels): string | null {
+  switch (state) {
+    case 'done':
+      return null;
+    case 'missed':
+      return labels.missed;
+    case 'voided':
+      return labels.voided;
+    case 'pendingReview':
+      return labels.pendingReview;
+    case 'backfill':
+      return labels.backfill;
+  }
+}
+
+export interface FeedDayCardProps {
+  data: FeedDayData;
+  pillFond: string;
+  pillSecours: string;
+  formatBy: (who: string) => string;
+  markers: MarkerLabels;
+  onPressEntry?: ((id: string) => void) | undefined;
+}
+
+export function FeedDayCard({
+  data,
+  pillFond,
+  pillSecours,
+  formatBy,
+  markers,
+  onPressEntry,
+}: FeedDayCardProps): React.JSX.Element {
+  return (
+    <YStack marginBottom={18}>
+      <Text
+        tag="h3"
+        margin={0}
+        fontSize={11}
+        color="$colorMore"
+        textTransform="uppercase"
+        letterSpacing={0.88}
+        fontWeight="600"
+        marginBottom={6}
+      >
+        {data.label}
+      </Text>
+      <YStack
+        backgroundColor="$surface"
+        borderRadius={14}
+        borderWidth={0.5}
+        borderColor="$borderColor"
+        overflow="hidden"
+      >
+        {data.entries.map((entry, i) => (
+          <FeedEntryRow
+            key={entry.id}
+            entry={entry}
+            isFirst={i === 0}
+            pillFond={pillFond}
+            pillSecours={pillSecours}
+            formatBy={formatBy}
+            markers={markers}
+            {...(onPressEntry ? { onPress: () => onPressEntry(entry.id) } : {})}
+          />
+        ))}
+      </YStack>
+    </YStack>
+  );
+}
+
+interface FeedEntryRowProps {
+  entry: FeedEntry;
+  isFirst: boolean;
+  pillFond: string;
+  pillSecours: string;
+  formatBy: (who: string) => string;
+  markers: MarkerLabels;
+  onPress?: (() => void) | undefined;
+}
+
+function FeedEntryRow({
+  entry,
+  isFirst,
+  pillFond,
+  pillSecours,
+  formatBy,
+  markers,
+  onPress,
+}: FeedEntryRowProps): React.JSX.Element {
+  const isRescue = entry.kind === 'rescue';
+  const isStruck = entry.state === 'voided' || entry.state === 'missed';
+  const opacity = isStruck ? 0.6 : 1;
+  const tone = MARKER_TONE[entry.state];
+  const marker = markerLabel(entry.state, markers);
+
+  return (
+    <XStack
+      tag={onPress ? 'button' : 'div'}
+      cursor={onPress ? 'pointer' : 'default'}
+      borderWidth={0}
+      backgroundColor="transparent"
+      alignItems="center"
+      gap={12}
+      paddingHorizontal={14}
+      paddingVertical={12}
+      borderTopWidth={isFirst ? 0 : 0.5}
+      borderTopColor="$borderColor"
+      opacity={opacity}
+      {...(onPress ? { onPress } : {})}
+      {...(onPress ? { hoverStyle: { backgroundColor: '$surface2' } } : {})}
+      accessibilityRole={onPress ? 'button' : undefined}
+    >
+      <Text
+        width={32}
+        height={32}
+        borderRadius={9}
+        backgroundColor={isRescue ? '$rescueSoft' : '$maintSoft'}
+        color={isRescue ? '$rescue' : '$maint'}
+        alignItems="center"
+        justifyContent="center"
+        flexShrink={0}
+        display="flex"
+      >
+        {isRescue ? (
+          <InhalerRescueIcon size={17} color="currentColor" />
+        ) : (
+          <InhalerMaintIcon size={17} color="currentColor" />
+        )}
+      </Text>
+      <YStack flex={1} minWidth={0}>
+        <XStack alignItems="baseline" gap={8} flexWrap="wrap">
+          <Text
+            fontSize={13.5}
+            fontWeight="500"
+            color="$color"
+            style={{
+              textDecoration: isStruck ? 'line-through' : 'none',
+            }}
+          >
+            {isRescue ? pillSecours : pillFond} · {entry.slot}
+          </Text>
+          {entry.cause !== undefined && entry.cause !== '' && (
+            <Stack
+              paddingHorizontal={7}
+              paddingVertical={2}
+              backgroundColor="$rescueSoft"
+              borderRadius={99}
+            >
+              <Text
+                fontSize={10}
+                fontWeight="600"
+                color="$rescueInk"
+                textTransform="uppercase"
+                letterSpacing={0.4}
+              >
+                {entry.cause}
+              </Text>
+            </Stack>
+          )}
+          {marker !== null && tone !== null && (
+            <Stack
+              paddingHorizontal={7}
+              paddingVertical={2}
+              backgroundColor={tone.bg as never}
+              borderRadius={99}
+            >
+              <Text
+                fontSize={10}
+                fontWeight="600"
+                color={tone.fg as never}
+                textTransform="uppercase"
+                letterSpacing={0.4}
+              >
+                {marker}
+              </Text>
+            </Stack>
+          )}
+        </XStack>
+        <Text fontSize={11.5} color="$colorMore" marginTop={2}>
+          {formatBy(entry.who)}
+          {entry.note !== undefined && entry.note !== '' && (
+            <Text fontStyle="italic" color="$colorMore">
+              {' · '}
+              {entry.note}
+            </Text>
+          )}
+        </Text>
+      </YStack>
+      <Text
+        fontFamily="$mono"
+        fontSize={12}
+        color="$colorMore"
+        style={{ fontVariantNumeric: 'tabular-nums' }}
+      >
+        {entry.time}
+      </Text>
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/history/FilterPills.tsx
+++ b/packages/ui/src/components/history/FilterPills.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react';
+import { Stack, Text, XStack } from 'tamagui';
+
+import type { HistoryFilter } from './types';
+
+export interface FilterPillsProps {
+  active: HistoryFilter;
+  labelAll: string;
+  labelMaint: string;
+  labelRescue: string;
+  /** Si vrai, occupe toute la largeur (mobile) ; sinon `width: fit-content` (desktop). */
+  fullWidth?: boolean;
+  onChange?: ((f: HistoryFilter) => void) | undefined;
+}
+
+export function FilterPills({
+  active,
+  labelAll,
+  labelMaint,
+  labelRescue,
+  fullWidth = false,
+  onChange,
+}: FilterPillsProps): React.JSX.Element {
+  const items: ReadonlyArray<{ value: HistoryFilter; label: string }> = [
+    { value: 'all', label: labelAll },
+    { value: 'maint', label: labelMaint },
+    { value: 'rescue', label: labelRescue },
+  ];
+  return (
+    <XStack
+      gap={6}
+      padding={4}
+      backgroundColor="$surface2"
+      borderRadius={99}
+      width={fullWidth ? '100%' : 'fit-content'}
+      role="radiogroup"
+    >
+      {items.map((it) => {
+        const isActive = it.value === active;
+        return (
+          <Stack
+            key={it.value}
+            tag="button"
+            cursor="pointer"
+            paddingHorizontal={fullWidth ? 10 : 14}
+            paddingVertical={fullWidth ? 8 : 7}
+            borderRadius={99}
+            borderWidth={0}
+            backgroundColor={isActive ? '$surface' : 'transparent'}
+            flex={fullWidth ? 1 : 0}
+            alignItems="center"
+            justifyContent="center"
+            accessibilityRole="radio"
+            accessibilityState={{ checked: isActive }}
+            accessibilityLabel={it.label}
+            {...(onChange ? { onPress: () => onChange(it.value) } : {})}
+            style={isActive ? { boxShadow: '0 1px 2px rgba(0,0,0,0.06)' } : undefined}
+          >
+            <Text
+              fontSize={fullWidth ? 12 : 12.5}
+              fontWeight={isActive ? '600' : '500'}
+              color={isActive ? '$color' : '$colorMore'}
+            >
+              {it.label}
+            </Text>
+          </Stack>
+        );
+      })}
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/history/HistoryListMobile.tsx
+++ b/packages/ui/src/components/history/HistoryListMobile.tsx
@@ -1,0 +1,239 @@
+import * as React from 'react';
+import { Stack, Text, Theme, XStack, YStack } from 'tamagui';
+
+import { CalendarGrid } from './CalendarGrid';
+import { CalendarLegend } from './CalendarLegend';
+import { FeedDayCard } from './FeedDay';
+import { FilterPills } from './FilterPills';
+import { DownloadIcon, PlusIconSm } from './icons';
+import { MonthHeader } from './MonthHeader';
+import { StatTile } from './StatTile';
+import type {
+  CalendarCell,
+  FeedDay,
+  HistoryFilter,
+  HistoryListHandlers,
+  HistoryListMessages,
+  HistoryStats,
+} from './types';
+
+export interface HistoryListMobileProps {
+  messages: HistoryListMessages;
+  cells: ReadonlyArray<CalendarCell>;
+  stats: HistoryStats;
+  feed: ReadonlyArray<FeedDay>;
+  activeFilter: HistoryFilter;
+  handlers?: HistoryListHandlers | undefined;
+  theme?: 'kinhale_light' | 'kinhale_dark';
+}
+
+export function HistoryListMobile({
+  messages,
+  cells,
+  stats,
+  feed,
+  activeFilter,
+  handlers,
+  theme = 'kinhale_light',
+}: HistoryListMobileProps): React.JSX.Element {
+  const hasEntries = feed.some((d) => d.entries.length > 0);
+
+  return (
+    <Theme name={theme}>
+      <YStack height="100%" backgroundColor="$background">
+        {/* Header */}
+        <XStack
+          tag="header"
+          paddingHorizontal={20}
+          paddingTop={8}
+          paddingBottom={16}
+          alignItems="center"
+          justifyContent="space-between"
+          borderBottomWidth={0.5}
+          borderBottomColor="$borderColor"
+        >
+          <YStack>
+            <Text
+              tag="h1"
+              margin={0}
+              fontFamily="$heading"
+              fontSize={24}
+              fontWeight="500"
+              letterSpacing={-0.48}
+              color="$color"
+            >
+              {messages.title}
+            </Text>
+            <Text fontSize={12} color="$colorMore" marginTop={2}>
+              {messages.subtitle}
+            </Text>
+          </YStack>
+          <XStack
+            tag="button"
+            cursor="pointer"
+            backgroundColor="$surface"
+            borderWidth={0.5}
+            borderColor="$borderColorStrong"
+            paddingHorizontal={12}
+            paddingVertical={8}
+            borderRadius={99}
+            alignItems="center"
+            gap={6}
+            accessibilityRole="button"
+            accessibilityLabel={messages.exportLabel}
+            {...(handlers?.onPressExport ? { onPress: handlers.onPressExport } : {})}
+          >
+            <Text color="$colorMuted" display="flex">
+              <DownloadIcon size={13} color="currentColor" />
+            </Text>
+            <Text fontSize={12} fontWeight="500" color="$colorMuted">
+              {messages.exportLabel}
+            </Text>
+          </XStack>
+        </XStack>
+
+        <Stack
+          flex={1}
+          paddingHorizontal={16}
+          paddingTop={16}
+          paddingBottom={80}
+          style={{ overflow: 'auto' }}
+        >
+          {/* Calendrier mensuel */}
+          <YStack
+            backgroundColor="$surface"
+            borderRadius={18}
+            padding={18}
+            borderWidth={0.5}
+            borderColor="$borderColor"
+            marginBottom={14}
+          >
+            <MonthHeader
+              monthLabel={messages.monthLabel}
+              size="sm"
+              {...(handlers?.onPressPrevMonth ? { onPressPrev: handlers.onPressPrevMonth } : {})}
+              {...(handlers?.onPressNextMonth ? { onPressNext: handlers.onPressNextMonth } : {})}
+            />
+            <CalendarGrid
+              weekdays={messages.weekdays}
+              cells={cells}
+              compact
+              {...(handlers?.onPressDay ? { onPressDay: handlers.onPressDay } : {})}
+            />
+            <CalendarLegend messages={messages} />
+          </YStack>
+
+          {/* Statistiques mensuelles */}
+          <XStack gap={8} marginBottom={18}>
+            <StatTile
+              label={messages.statAdherenceLabel}
+              value={String(stats.adherencePct)}
+              suffix="%"
+              tone="ok"
+            />
+            <StatTile
+              label={messages.statRescueLabel}
+              value={String(stats.rescueCount)}
+              tone="rescue"
+            />
+            <StatTile
+              label={messages.statStreakLabel}
+              value={String(stats.longestStreakDays)}
+              suffix={messages.daysSuffix}
+              tone="maint"
+            />
+          </XStack>
+
+          {/* Filtres */}
+          <Stack marginBottom={16}>
+            <FilterPills
+              active={activeFilter}
+              labelAll={messages.filterAll}
+              labelMaint={messages.filterMaint}
+              labelRescue={messages.filterRescue}
+              fullWidth
+              {...(handlers?.onChangeFilter ? { onChange: handlers.onChangeFilter } : {})}
+            />
+          </Stack>
+
+          {/* Fil d'activité */}
+          {hasEntries ? (
+            feed
+              .filter((d) => d.entries.length > 0)
+              .map((day, i) => (
+                <FeedDayCard
+                  key={`${day.label}-${i}`}
+                  data={day}
+                  pillFond={messages.pillFond}
+                  pillSecours={messages.pillSecours}
+                  formatBy={messages.formatBy}
+                  markers={{
+                    voided: messages.markerVoided,
+                    pendingReview: messages.markerPendingReview,
+                    backfill: messages.markerBackfill,
+                    missed: messages.markerMissed,
+                  }}
+                  {...(handlers?.onPressEntry ? { onPressEntry: handlers.onPressEntry } : {})}
+                />
+              ))
+          ) : (
+            <YStack
+              padding={24}
+              backgroundColor="$surface"
+              borderRadius={14}
+              borderWidth={0.5}
+              borderColor="$borderColor"
+              alignItems="center"
+              gap={6}
+            >
+              <Text fontFamily="$heading" fontSize={16} fontWeight="500" color="$color">
+                {messages.emptyTitle}
+              </Text>
+              <Text fontSize={12.5} color="$colorMore" textAlign="center">
+                {messages.emptySub}
+              </Text>
+            </YStack>
+          )}
+
+          <Text
+            fontSize={11}
+            color="$colorFaint"
+            textAlign="center"
+            marginTop={20}
+            fontStyle="italic"
+          >
+            {messages.notMedical}
+          </Text>
+        </Stack>
+
+        {/* FAB add */}
+        {handlers?.onPressAdd && (
+          <Stack
+            tag="button"
+            cursor="pointer"
+            position="absolute"
+            bottom={20}
+            right={20}
+            width={56}
+            height={56}
+            borderRadius={28}
+            backgroundColor="$maint"
+            borderWidth={0}
+            alignItems="center"
+            justifyContent="center"
+            accessibilityRole="button"
+            accessibilityLabel={messages.addCta}
+            onPress={handlers.onPressAdd}
+            style={{
+              boxShadow: '0 6px 18px color-mix(in oklch, var(--maint) 32%, transparent)',
+            }}
+          >
+            <Text color="white" display="flex">
+              <PlusIconSm size={20} color="white" />
+            </Text>
+          </Stack>
+        )}
+      </YStack>
+    </Theme>
+  );
+}

--- a/packages/ui/src/components/history/HistoryListWeb.tsx
+++ b/packages/ui/src/components/history/HistoryListWeb.tsx
@@ -1,0 +1,272 @@
+import * as React from 'react';
+import { Stack, Text, Theme, XStack, YStack } from 'tamagui';
+
+import { CalendarGrid } from './CalendarGrid';
+import { CalendarLegend } from './CalendarLegend';
+import { FeedDayCard } from './FeedDay';
+import { FilterPills } from './FilterPills';
+import { HistorySidebar } from './HistorySidebar';
+import { DownloadIcon, FilterIcon } from './icons';
+import { MonthHeader } from './MonthHeader';
+import { StatTile } from './StatTile';
+import type {
+  CalendarCell,
+  FeedDay,
+  HistoryFilter,
+  HistoryListHandlers,
+  HistoryListMessages,
+  HistoryNavItem,
+  HistoryStats,
+} from './types';
+
+export interface HistoryListWebProps {
+  messages: HistoryListMessages;
+  cells: ReadonlyArray<CalendarCell>;
+  stats: HistoryStats;
+  feed: ReadonlyArray<FeedDay>;
+  activeFilter: HistoryFilter;
+  navItems: ReadonlyArray<HistoryNavItem>;
+  handlers?: HistoryListHandlers | undefined;
+  theme?: 'kinhale_light' | 'kinhale_dark';
+}
+
+export function HistoryListWeb({
+  messages,
+  cells,
+  stats,
+  feed,
+  activeFilter,
+  navItems,
+  handlers,
+  theme = 'kinhale_light',
+}: HistoryListWebProps): React.JSX.Element {
+  const hasEntries = feed.some((d) => d.entries.length > 0);
+
+  return (
+    <Theme name={theme}>
+      <Stack
+        position="absolute"
+        top={0}
+        right={0}
+        bottom={0}
+        left={0}
+        backgroundColor="$background"
+        overflow="hidden"
+        style={{ display: 'grid', gridTemplateColumns: '224px 1fr' }}
+      >
+        <HistorySidebar navItems={navItems} />
+
+        <YStack tag="main" minHeight={0} style={{ overflow: 'auto' }}>
+          {/* Header sticky */}
+          <XStack
+            paddingHorizontal={32}
+            paddingVertical={20}
+            alignItems="flex-end"
+            justifyContent="space-between"
+            borderBottomWidth={0.5}
+            borderBottomColor="$borderColor"
+            zIndex={5}
+            style={{
+              position: 'sticky',
+              top: 0,
+              background: 'color-mix(in oklch, var(--background) 90%, transparent)',
+              backdropFilter: 'blur(12px)',
+              WebkitBackdropFilter: 'blur(12px)',
+            }}
+          >
+            <YStack>
+              <Text
+                fontSize={11}
+                color="$colorMore"
+                textTransform="uppercase"
+                letterSpacing={1.1}
+                fontWeight="600"
+              >
+                {messages.childName}
+              </Text>
+              <Text
+                tag="h1"
+                margin={0}
+                fontFamily="$heading"
+                fontSize={28}
+                fontWeight="500"
+                letterSpacing={-0.56}
+                color="$color"
+                marginTop={2}
+              >
+                {messages.title}
+              </Text>
+            </YStack>
+
+            <XStack gap={10}>
+              <XStack
+                tag="button"
+                cursor="pointer"
+                backgroundColor="$surface"
+                borderWidth={0.5}
+                borderColor="$borderColorStrong"
+                paddingHorizontal={14}
+                paddingVertical={8}
+                borderRadius={10}
+                alignItems="center"
+                gap={6}
+                accessibilityRole="button"
+                accessibilityLabel={messages.filtersLabel}
+              >
+                <Text color="$colorMuted" display="flex">
+                  <FilterIcon size={13} color="currentColor" />
+                </Text>
+                <Text fontSize={13} fontWeight="500" color="$colorMuted">
+                  {messages.filtersLabel}
+                </Text>
+              </XStack>
+              <XStack
+                tag="button"
+                cursor="pointer"
+                backgroundColor="$maint"
+                borderWidth={0}
+                paddingHorizontal={14}
+                paddingVertical={8}
+                borderRadius={10}
+                alignItems="center"
+                gap={6}
+                accessibilityRole="button"
+                accessibilityLabel={messages.exportLabel}
+                {...(handlers?.onPressExport ? { onPress: handlers.onPressExport } : {})}
+                style={{
+                  boxShadow: '0 2px 8px color-mix(in oklch, var(--maint) 28%, transparent)',
+                }}
+              >
+                <Text color="white" display="flex">
+                  <DownloadIcon size={13} color="white" />
+                </Text>
+                <Text fontSize={13} fontWeight="600" color="white">
+                  {messages.exportLabel}
+                </Text>
+              </XStack>
+            </XStack>
+          </XStack>
+
+          {/* Content grid : calendrier + stats à gauche / fil à droite */}
+          <Stack
+            paddingHorizontal={32}
+            paddingTop={24}
+            paddingBottom={48}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'minmax(0, 1.4fr) minmax(0, 1fr)',
+              gap: 24,
+            }}
+          >
+            {/* Left col */}
+            <YStack gap={16} minWidth={0}>
+              <YStack
+                backgroundColor="$surface"
+                borderRadius={18}
+                padding={22}
+                borderWidth={0.5}
+                borderColor="$borderColor"
+              >
+                <MonthHeader
+                  monthLabel={messages.monthLabel}
+                  labelMinWidth={130}
+                  {...(handlers?.onPressPrevMonth
+                    ? { onPressPrev: handlers.onPressPrevMonth }
+                    : {})}
+                  {...(handlers?.onPressNextMonth
+                    ? { onPressNext: handlers.onPressNextMonth }
+                    : {})}
+                  trailing={<CalendarLegend messages={messages} inline />}
+                />
+                <CalendarGrid
+                  weekdays={messages.weekdays}
+                  cells={cells}
+                  {...(handlers?.onPressDay ? { onPressDay: handlers.onPressDay } : {})}
+                />
+              </YStack>
+
+              <XStack gap={10}>
+                <StatTile
+                  label={messages.statAdherenceLabel}
+                  value={String(stats.adherencePct)}
+                  suffix="%"
+                  tone="ok"
+                />
+                <StatTile
+                  label={messages.statRescueLabel}
+                  value={String(stats.rescueCount)}
+                  tone="rescue"
+                />
+                <StatTile
+                  label={messages.statStreakLabel}
+                  value={String(stats.longestStreakDays)}
+                  suffix={messages.daysSuffix}
+                  tone="maint"
+                />
+              </XStack>
+            </YStack>
+
+            {/* Right col : fil */}
+            <YStack minWidth={0}>
+              <Stack marginBottom={14}>
+                <FilterPills
+                  active={activeFilter}
+                  labelAll={messages.filterAll}
+                  labelMaint={messages.filterMaint}
+                  labelRescue={messages.filterRescue}
+                  {...(handlers?.onChangeFilter ? { onChange: handlers.onChangeFilter } : {})}
+                />
+              </Stack>
+              {hasEntries ? (
+                feed
+                  .filter((d) => d.entries.length > 0)
+                  .map((day, i) => (
+                    <FeedDayCard
+                      key={`${day.label}-${i}`}
+                      data={day}
+                      pillFond={messages.pillFond}
+                      pillSecours={messages.pillSecours}
+                      formatBy={messages.formatBy}
+                      markers={{
+                        voided: messages.markerVoided,
+                        pendingReview: messages.markerPendingReview,
+                        backfill: messages.markerBackfill,
+                        missed: messages.markerMissed,
+                      }}
+                      {...(handlers?.onPressEntry ? { onPressEntry: handlers.onPressEntry } : {})}
+                    />
+                  ))
+              ) : (
+                <YStack
+                  padding={24}
+                  backgroundColor="$surface"
+                  borderRadius={14}
+                  borderWidth={0.5}
+                  borderColor="$borderColor"
+                  alignItems="center"
+                  gap={6}
+                >
+                  <Text fontFamily="$heading" fontSize={16} fontWeight="500" color="$color">
+                    {messages.emptyTitle}
+                  </Text>
+                  <Text fontSize={12.5} color="$colorMore" textAlign="center">
+                    {messages.emptySub}
+                  </Text>
+                </YStack>
+              )}
+              <Text
+                fontSize={11}
+                color="$colorFaint"
+                textAlign="center"
+                marginTop={20}
+                fontStyle="italic"
+              >
+                {messages.notMedical}
+              </Text>
+            </YStack>
+          </Stack>
+        </YStack>
+      </Stack>
+    </Theme>
+  );
+}

--- a/packages/ui/src/components/history/HistorySidebar.tsx
+++ b/packages/ui/src/components/history/HistorySidebar.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { BrandIcon } from '../auth/icons';
+import type { HistoryNavItem } from './types';
+
+export interface HistorySidebarProps {
+  navItems: ReadonlyArray<HistoryNavItem>;
+  brandLabel?: string;
+}
+
+/**
+ * Sidebar 224 px de la page Historique. Pattern identique à
+ * `PumpsSidebar` ; on duplique pour rester strictement présentationnel
+ * sans dépendance croisée entre modules `pumps` ↔ `history`.
+ */
+export function HistorySidebar({
+  navItems,
+  brandLabel = 'Kinhale',
+}: HistorySidebarProps): React.JSX.Element {
+  return (
+    <YStack
+      tag="aside"
+      borderRightWidth={0.5}
+      borderRightColor="$borderColor"
+      paddingHorizontal={14}
+      paddingVertical={20}
+      gap={4}
+      backgroundColor="$surface"
+      style={{ overflow: 'auto' }}
+    >
+      <XStack alignItems="center" gap={10} paddingHorizontal={8} paddingTop={4} paddingBottom={18}>
+        <Stack
+          width={28}
+          height={28}
+          borderRadius={8}
+          backgroundColor="$maint"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <BrandIcon size={15} color="#ffffff" />
+        </Stack>
+        <Text
+          fontFamily="$heading"
+          fontSize={17}
+          fontWeight="600"
+          letterSpacing={-0.17}
+          color="$color"
+        >
+          {brandLabel}
+        </Text>
+      </XStack>
+
+      {navItems.map((item) => (
+        <XStack
+          key={item.key}
+          tag="button"
+          paddingHorizontal={10}
+          paddingVertical={9}
+          borderRadius={8}
+          backgroundColor={item.active ? '$surface2' : 'transparent'}
+          cursor="pointer"
+          alignItems="center"
+          gap={10}
+          borderWidth={0}
+          hoverStyle={{ backgroundColor: '$surface2' }}
+          {...(item.onPress ? { onPress: item.onPress } : {})}
+          accessibilityRole="link"
+          accessibilityLabel={item.label}
+        >
+          <Stack
+            width={6}
+            height={6}
+            borderRadius={3}
+            backgroundColor={item.active ? '$maint' : '$borderColorStrong'}
+          />
+          <Text
+            fontSize={13.5}
+            fontWeight={item.active ? '600' : '500'}
+            color={item.active ? '$color' : '$colorMuted'}
+            fontFamily="$body"
+          >
+            {item.label}
+          </Text>
+        </XStack>
+      ))}
+    </YStack>
+  );
+}

--- a/packages/ui/src/components/history/MonthHeader.tsx
+++ b/packages/ui/src/components/history/MonthHeader.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import { Stack, Text, XStack } from 'tamagui';
+
+import { ChevronLeftIcon, ChevronRightIcon } from './icons';
+
+export interface MonthHeaderProps {
+  /** Libellé du mois courant (ex. « Avril 2026 »). */
+  monthLabel: string;
+  /** Largeur min du label en px (utile pour éviter les jumps). */
+  labelMinWidth?: number;
+  /** Taille du label : `sm` (16 px) pour mobile, `md` (18 px) pour web. */
+  size?: 'sm' | 'md';
+  /** Libellés a11y des boutons précédent / suivant (déjà localisés). */
+  prevLabel?: string;
+  nextLabel?: string;
+  onPressPrev?: (() => void) | undefined;
+  onPressNext?: (() => void) | undefined;
+  /** Optionnel : enfants affichés à droite (ex. Légende sur web). */
+  trailing?: React.ReactNode;
+}
+
+export function MonthHeader({
+  monthLabel,
+  labelMinWidth = 0,
+  size = 'md',
+  prevLabel = 'prev-month',
+  nextLabel = 'next-month',
+  onPressPrev,
+  onPressNext,
+  trailing,
+}: MonthHeaderProps): React.JSX.Element {
+  const fontSize = size === 'sm' ? 16 : 18;
+  return (
+    <XStack justifyContent="space-between" alignItems="center" marginBottom={14}>
+      <XStack alignItems="center" gap={8}>
+        <NavButton onPress={onPressPrev} ariaLabel={prevLabel}>
+          <ChevronLeftIcon size={14} color="currentColor" />
+        </NavButton>
+        <Text
+          fontFamily="$heading"
+          fontSize={fontSize}
+          fontWeight="500"
+          letterSpacing={-0.18}
+          color="$color"
+          textAlign="center"
+          {...(labelMinWidth > 0 ? { minWidth: labelMinWidth } : {})}
+        >
+          {monthLabel}
+        </Text>
+        <NavButton onPress={onPressNext} ariaLabel={nextLabel}>
+          <ChevronRightIcon size={14} color="currentColor" />
+        </NavButton>
+      </XStack>
+      {trailing !== undefined && trailing !== null ? <>{trailing}</> : null}
+    </XStack>
+  );
+}
+
+interface NavButtonProps {
+  ariaLabel: string;
+  children: React.ReactNode;
+  onPress?: (() => void) | undefined;
+}
+
+function NavButton({ ariaLabel, children, onPress }: NavButtonProps): React.JSX.Element {
+  return (
+    <Stack
+      tag="button"
+      cursor={onPress ? 'pointer' : 'default'}
+      width={30}
+      height={30}
+      borderRadius={15}
+      borderWidth={0}
+      backgroundColor="$surface2"
+      alignItems="center"
+      justifyContent="center"
+      accessibilityRole="button"
+      accessibilityLabel={ariaLabel}
+      {...(onPress ? { onPress } : {})}
+      hoverStyle={{ backgroundColor: '$borderColor' }}
+    >
+      <Text color="$colorMuted" display="flex">
+        {children}
+      </Text>
+    </Stack>
+  );
+}

--- a/packages/ui/src/components/history/StatTile.tsx
+++ b/packages/ui/src/components/history/StatTile.tsx
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { Stack, Text, YStack } from 'tamagui';
+
+export type StatTone = 'maint' | 'ok' | 'rescue';
+
+export interface StatTileProps {
+  label: string;
+  /** Valeur principale, déjà formatée (ex. `"91"`). */
+  value: string;
+  /** Suffixe court (ex. `"%"`, `"j"`). */
+  suffix?: string;
+  tone?: StatTone;
+}
+
+const TONE: Record<StatTone, { bg: string; fg: string }> = {
+  maint: { bg: '$maintSoft', fg: '$maintInk' },
+  ok: { bg: '$okSoft', fg: '$okInk' },
+  rescue: { bg: '$rescueSoft', fg: '$rescueInk' },
+};
+
+export function StatTile({
+  label,
+  value,
+  suffix,
+  tone = 'maint',
+}: StatTileProps): React.JSX.Element {
+  const tk = TONE[tone];
+  return (
+    <YStack
+      flex={1}
+      padding={14}
+      borderRadius={14}
+      backgroundColor={tk.bg as never}
+      borderWidth={0.5}
+      borderColor="$borderColor"
+    >
+      <Text
+        fontSize={10}
+        color={tk.fg as never}
+        textTransform="uppercase"
+        letterSpacing={0.8}
+        fontWeight="600"
+        opacity={0.8}
+      >
+        {label}
+      </Text>
+      <Stack flexDirection="row" alignItems="baseline" marginTop={4}>
+        <Text
+          fontFamily="$heading"
+          fontSize={26}
+          fontWeight="500"
+          color={tk.fg as never}
+          letterSpacing={-0.52}
+          style={{ fontVariantNumeric: 'tabular-nums' }}
+        >
+          {value}
+        </Text>
+        {suffix !== undefined && suffix !== '' && (
+          <Text fontSize={14} marginLeft={4} color={tk.fg as never} opacity={0.7}>
+            {suffix}
+          </Text>
+        )}
+      </Stack>
+    </YStack>
+  );
+}

--- a/packages/ui/src/components/history/icons.tsx
+++ b/packages/ui/src/components/history/icons.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react';
+
+interface IconProps {
+  size?: number;
+  color?: string;
+}
+
+const baseStroke = {
+  fill: 'none' as const,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+};
+
+export function FilterIcon({ size = 14, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.5"
+    >
+      <path d="M2 4h10M4 7h6M5.5 10h3" />
+    </svg>
+  );
+}
+
+export function DownloadIcon({ size = 14, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.5"
+    >
+      <path d="M7 2v7M4 6.5l3 3 3-3M2.5 11.5h9" />
+    </svg>
+  );
+}
+
+export function ChevronLeftIcon({
+  size = 14,
+  color = 'currentColor',
+}: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.6"
+    >
+      <path d="M9 3L5 7l4 4" />
+    </svg>
+  );
+}
+
+export function ChevronRightIcon({
+  size = 14,
+  color = 'currentColor',
+}: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.6"
+    >
+      <path d="M5 3l4 4-4 4" />
+    </svg>
+  );
+}
+
+export function PlusIconSm({ size = 14, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.8"
+    >
+      <path d="M7 2v10M2 7h10" />
+    </svg>
+  );
+}

--- a/packages/ui/src/components/history/index.ts
+++ b/packages/ui/src/components/history/index.ts
@@ -1,0 +1,40 @@
+export { CalendarGrid } from './CalendarGrid';
+export type { CalendarGridProps } from './CalendarGrid';
+
+export { CalendarLegend } from './CalendarLegend';
+export type { CalendarLegendProps } from './CalendarLegend';
+
+export { FeedDayCard } from './FeedDay';
+export type { FeedDayCardProps } from './FeedDay';
+
+export { FilterPills } from './FilterPills';
+export type { FilterPillsProps } from './FilterPills';
+
+export { HistoryListMobile } from './HistoryListMobile';
+export type { HistoryListMobileProps } from './HistoryListMobile';
+
+export { HistoryListWeb } from './HistoryListWeb';
+export type { HistoryListWebProps } from './HistoryListWeb';
+
+export { HistorySidebar } from './HistorySidebar';
+export type { HistorySidebarProps } from './HistorySidebar';
+
+export { MonthHeader } from './MonthHeader';
+export type { MonthHeaderProps } from './MonthHeader';
+
+export { StatTile } from './StatTile';
+export type { StatTileProps, StatTone } from './StatTile';
+
+export type {
+  CalendarCell,
+  CalendarCellState,
+  FeedDay,
+  FeedEntry,
+  FeedEntryState,
+  HistoryDoseKind,
+  HistoryFilter,
+  HistoryListHandlers,
+  HistoryListMessages,
+  HistoryNavItem,
+  HistoryStats,
+} from './types';

--- a/packages/ui/src/components/history/types.ts
+++ b/packages/ui/src/components/history/types.ts
@@ -1,0 +1,129 @@
+// Types présentationnels pour les composants Historique. L'app appelante
+// mappe ses projections (`@kinhale/sync` + calculs domain) vers ces
+// types pure-presentational.
+
+export type HistoryDoseKind = 'maint' | 'rescue';
+
+/** État visuel d'une journée dans le calendrier. */
+export type CalendarCellState =
+  | 'done' // toutes les prises prévues ont été données
+  | 'partial' // au moins une dose manquée ou rattrapée
+  | 'missed' // aucune prise enregistrée
+  | 'rescue' // au moins une prise de secours
+  | 'todayPending' // jour courant — décompte en cours
+  | 'future'; // après aujourd'hui — placeholder
+
+export interface CalendarCell {
+  /** Numéro du jour (1-31). `null` pour les cases de padding début de mois. */
+  day: number | null;
+  state: CalendarCellState;
+  /** Identifiant ISO YYYY-MM-DD (utile pour le clic / navigation). */
+  iso?: string | undefined;
+}
+
+/** État d'une prise dans le fil d'activité. */
+export type FeedEntryState =
+  | 'done'
+  | 'missed'
+  | 'voided'
+  | 'pendingReview' // RM6 — double saisie en attente d'arbitrage
+  | 'backfill'; // RM18 — saisie en rattrapage
+
+export interface FeedEntry {
+  id: string;
+  kind: HistoryDoseKind;
+  /** Libellé du moment (« Matin », « Soir », « Midi », etc.) — déjà localisé. */
+  slot: string;
+  /** Heure HH:mm ou « — » si missed. */
+  time: string;
+  /** Nom de l'aidant, déjà localisé. */
+  who: string;
+  state: FeedEntryState;
+  /** Cause d'une prise de secours (ex. « Effort »). Optionnel. */
+  cause?: string | undefined;
+  /** Note optionnelle, plain text. */
+  note?: string | undefined;
+}
+
+export interface FeedDay {
+  /** Libellé localisé : « Aujourd'hui », « Hier », ou « 24 avril ». */
+  label: string;
+  entries: ReadonlyArray<FeedEntry>;
+}
+
+export interface HistoryStats {
+  /** Adhérence du mois en pourcentage (0-100). */
+  adherencePct: number;
+  /** Nombre de prises de secours ce mois. */
+  rescueCount: number;
+  /** Plus longue série de jours consécutifs « done ». */
+  longestStreakDays: number;
+}
+
+export type HistoryFilter = 'all' | 'maint' | 'rescue';
+
+// ── Sidebar dashboard (réutilisé) ────────────────────────────────────────
+
+export interface HistoryNavItem {
+  key: string;
+  label: string;
+  active?: boolean;
+  onPress?: (() => void) | undefined;
+}
+
+// ── Messages localisés ──────────────────────────────────────────────────
+
+export interface HistoryListMessages {
+  /** Eyebrow desktop (prénom enfant en uppercase). */
+  childName: string;
+  title: string;
+  subtitle: string;
+  filtersLabel: string;
+  filterAll: string;
+  filterMaint: string;
+  filterRescue: string;
+  exportLabel: string;
+  /** « Adhérence ce mois », etc. */
+  statAdherenceLabel: string;
+  statRescueLabel: string;
+  statStreakLabel: string;
+  /** Suffixe pour les jours, ex. « j » ou « d ». */
+  daysSuffix: string;
+  /** Légende calendrier (5 entrées, déjà localisées). */
+  legendDone: string;
+  legendPartial: string;
+  legendMissed: string;
+  legendRescue: string;
+  legendFuture: string;
+  /** Mois affiché (ex. « Avril 2026 »). */
+  monthLabel: string;
+  /** Tableau des 7 jours (« L M M J V S D »). */
+  weekdays: ReadonlyArray<string>;
+  /** Pill localisée pour le fond / secours. */
+  pillFond: string;
+  pillSecours: string;
+  /** Marqueurs de statut. */
+  markerVoided: string;
+  markerPendingReview: string;
+  markerBackfill: string;
+  markerMissed: string;
+  /** « par {who} ». L'app fournit la fonction de format. */
+  formatBy: (who: string) => string;
+  /** État vide (aucune prise). */
+  emptyTitle: string;
+  emptySub: string;
+  /** Disclaimer Kinhale. */
+  notMedical: string;
+  /** Bouton Ajouter (FAB / header — usage clavier + accessibilité). */
+  addCta: string;
+}
+
+export interface HistoryListHandlers {
+  onPressAdd?: (() => void) | undefined;
+  onPressExport?: (() => void) | undefined;
+  onPressEntry?: ((id: string) => void) | undefined;
+  onPressDay?: ((iso: string) => void) | undefined;
+  onPressPrevMonth?: (() => void) | undefined;
+  onPressNextMonth?: (() => void) | undefined;
+  onChangeFilter?: ((f: HistoryFilter) => void) | undefined;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,3 +4,4 @@ export * from './components/auth';
 export * from './components/home';
 export * from './components/onboarding';
 export * from './components/pumps';
+export * from './components/history';


### PR DESCRIPTION
## Summary

Refonte complète de la page **Journal/Historique** pour matcher la maquette clinical-calm (`docs/design/handoffs/2026-04-26-pumps-v2/project/Kinhale Historique.html`).

### Layout web
- Sidebar 224 px + header sticky avec eyebrow LÉA + h1 28 px + boutons **Filtres** + **Exporter**
- Grid 2 colonnes : **calendrier mensuel + 3 stat tiles** à gauche, **fil d'activité avec filtres** à droite

### Layout mobile
- Header h1 + bouton Exporter pill, calendrier compact, 3 stats côte à côte, filtres pleine largeur, fil d'activité, **FAB +** en bas-droite

### Calendrier mensuel
- 6 états visuels : `done` / `partial` / `missed` / `rescue` / `todayPending` (ring maint) / `future`
- Marqueur dot rescue en top-right pour les jours avec prise de secours
- Navigation mois ← → ; cells cliquables (drill-in jour, futur ticket)

### Stats mensuelles
- **Adhérence** (% jours avec maint, ton ok)
- **Prises de secours** (count, ton rescue)
- **Meilleure série** (jours consécutifs avec maint, ton maint)

Calculées à la volée à partir de `projectDoses` non-voidées du mois.

### Fil d'activité
- Groupé par jour avec header h3 « Aujourd'hui / Hier / 24 avril »
- Marqueurs pastilles : `Annulée`, `À vérifier`, `Rattrapage`, `Manquée`
- Cause RM5 affichée en pastille rescue uppercase
- Note libre en italique sous l'aidant
- Entries cliquables → `/journal/edit/{id}` (édition existante préservée)
- Heure mono à droite, line-through si voided/missed

## Architecture

- 9 composants exposés via `@kinhale/ui/history` : `HistoryListWeb/Mobile`, `CalendarGrid`, `CalendarLegend`, `FeedDayCard`, `FilterPills`, `StatTile`, `MonthHeader`, `HistorySidebar`
- Composants **100 % présentationnels** — l'app mappe les projections vers les types `FeedDay`, `CalendarCell`, `HistoryStats`
- Helpers `apps/web/src/lib/journal/messages.ts` : `buildHistoryListMessages`, `buildCalendarCells`, `buildStats`, `buildFeed`
- Refactor `apps/web/src/app/journal/page.tsx` : utilise `projectDoses` + `projectCaregivers` réels pour piloter les 3 panneaux

## Conformité

- ✅ **WCAG 2.1 AA** : `<h1>` + `<h3>` natifs, `accessibilityRole="radio"` + `accessibilityState` sur pills filtre, `accessibilityLabel` partout, FAB 56×56
- ✅ **TypeScript strict** : aucun `any`, `exactOptionalPropertyTypes` via spreads conditionnels
- ✅ **Tokens design system** : `$ok/$amber/$rescue/$miss/$maint` + variantes Soft/Ink, aucun hex hardcodé
- ✅ **i18n FR + EN** : section `history.*` complète, aucune chaîne hardcodée
- ✅ **Pas de donnée santé en log/payload** ; `projectCaregivers` ne fuit pas d'identité au relais
- ✅ **Tests préservés** : 4 tests JournalPage continuent de passer (209 tests web + 95 mobile)

**Design review automatique** : verdict **GO avec corrections mineures**. Les 4 écarts majeurs ont été corrigés :
- Suppression du subtitle web (absent maquette)
- Suppression du bouton « Ajouter » dans le header web (FAB mobile suffit)
- Prop `inline` sur `CalendarLegend` (suppression du `marginTop` quand en trailing)
- Prop `size: 'sm' | 'md'` sur `MonthHeader` (16 px mobile / 18 px web)

## Test plan

- [ ] `pnpm typecheck` ✓ (10/10 packages)
- [ ] `pnpm lint` ✓ (10/10 packages)
- [ ] `pnpm format:check` ✓
- [ ] `pnpm test` ✓ (209 web + 95 mobile)
- [ ] Vérification visuelle desktop : `/journal` affiche sidebar + header + calendrier + stats + fil
- [ ] Mobile : layout vertical, FAB + en bas-droite cliquable
- [ ] Cliquer sur une entrée du fil → navigue vers `/journal/edit/{id}`
- [ ] Cliquer sur une cellule du calendrier (jour passé) → drill-in (route à venir)
- [ ] Filtres Tout / Fond / Secours filtrent correctement le fil
- [ ] Navigation mois ← → met à jour calendrier + stats + fil
- [ ] Cliquer Exporter → navigue vers `/reports`
- [ ] FR ↔ EN : changer la langue traduit toutes les chaînes (sidebar + filtres + légende + stats + marqueurs + slots)

## Hors scope (KIN-112 à venir)

- **Détail épisode** `/journal/[id]` avec timeline minute-par-minute — la maquette inclut météo/pollen/qualité air qui sortent du modèle E2EE Kinhale, décision séparée nécessaire avant implémentation
- **État `backfill`** dans le fil — pas encore généré par `projectDoses`, à relier à RM18 dans une PR ultérieure

🤖 Generated with [Claude Code](https://claude.com/claude-code)