### PR TITLE
feat(ui,web,i18n): refonte Aidants + Inviter aidant clinical-calm (KIN-113)

### DIFF
--- a/apps/web/src/app/caregivers/__tests__/page.test.tsx
+++ b/apps/web/src/app/caregivers/__tests__/page.test.tsx
@@ -108,7 +108,9 @@ describe('CaregiversPage', () => {
 
       expect(screen.getByText('Maman')).toBeTruthy();
 
-      fireEvent.click(screen.getByText(/révoquer|revoke/i));
+      // v2 : « Retirer » / « Withdraw » remplace l'ancien « Révoquer ».
+      // Le bouton « Renvoyer » apparaît avant — on cible « Retirer » exactement.
+      fireEvent.click(screen.getByText(/^(retirer|withdraw)$/i));
       await act(async () => {
         await Promise.resolve(); // revokeInvitation résout
         await Promise.resolve(); // refresh → listInvitations résout
@@ -134,7 +136,9 @@ describe('CaregiversPage', () => {
         await Promise.resolve();
       });
 
-      fireEvent.click(screen.getByText(/inviter un aidant|invite a caregiver/i));
+      // v2 : sur mobile (jsdom matchMedia=false), le bouton header
+      // utilise `inviteShort` = « Inviter » / « Invite ».
+      fireEvent.click(screen.getByTestId('caregivers-invite-cta'));
       expect(mockPush).toHaveBeenCalledWith('/caregivers/invite');
     } finally {
       jest.clearAllTimers();

--- a/apps/web/src/app/caregivers/invite/__tests__/page.test.tsx
+++ b/apps/web/src/app/caregivers/invite/__tests__/page.test.tsx
@@ -68,14 +68,14 @@ describe('InviteCaregiverPage', () => {
         await Promise.resolve();
         await Promise.resolve();
       });
-      // Titre du formulaire
-      expect(screen.getByText(/nouvelle invitation|new invitation/i)).toBeTruthy();
-      // Les deux boutons de rôle
-      expect(screen.getByText(/aidant complet|full caregiver/i)).toBeTruthy();
-      expect(screen.getByText(/aidant restreint|restricted caregiver/i)).toBeTruthy();
-      // Bouton générer désactivé quand displayName vide
-      const generateBtn = screen.getByText(/générer|generate/i);
-      expect(generateBtn).toBeTruthy();
+      // v2 : titre du formulaire « Inviter un aidant » via h2 natif.
+      expect(screen.getByRole('heading', { level: 2 })).toBeInTheDocument();
+      // Rôles v2 : « Co-parent » + « Garderie · grand-parent ».
+      expect(screen.getByText(/co-parent/i)).toBeTruthy();
+      expect(screen.getByText(/garderie|daycare/i)).toBeTruthy();
+      // CTA v2 : « Envoyer l'invitation » / « Send invitation ».
+      const sendBtn = screen.getByText(/envoyer.*invitation|send invitation/i);
+      expect(sendBtn).toBeTruthy();
     } finally {
       jest.clearAllTimers();
       jest.useRealTimers();
@@ -94,11 +94,11 @@ describe('InviteCaregiverPage', () => {
       });
 
       // Saisir un nom
-      const input = screen.getByPlaceholderText(/maman|mom|garderie|daycare/i);
+      const input = document.getElementById('invite-name') as HTMLInputElement;
       fireEvent.change(input, { target: { value: 'Maman' } });
 
       // Cliquer sur Générer
-      fireEvent.click(screen.getByText(/générer|generate/i));
+      fireEvent.click(screen.getByText(/envoyer.*invitation|send invitation/i));
       await act(async () => {
         await Promise.resolve(); // createInvitation résout
         await Promise.resolve(); // setCreated
@@ -106,8 +106,11 @@ describe('InviteCaregiverPage', () => {
         await Promise.resolve(); // setQrDataUrl + setState timer
       });
 
+      // v2 : le rôle par défaut est `contributor` (Co-parent), conforme
+      // à la maquette. L'utilisateur peut sélectionner restreint
+      // explicitement avant de soumettre — testé séparément.
       expect(mockCreateInvitation).toHaveBeenCalledWith({
-        targetRole: 'restricted_contributor',
+        targetRole: 'contributor',
         displayName: 'Maman',
       });
       // Le PIN doit apparaître
@@ -147,8 +150,8 @@ describe('InviteCaregiverPage', () => {
         await Promise.resolve();
       });
       // Les deux boutons doivent être présents
-      const contributorBtn = screen.getByText(/aidant complet|full caregiver/i);
-      const restrictedBtn = screen.getByText(/aidant restreint|restricted caregiver/i);
+      const contributorBtn = screen.getByText(/co-parent/i);
+      const restrictedBtn = screen.getByText(/garderie.*grand-parent|daycare.*grandparent/i);
       expect(contributorBtn).toBeTruthy();
       expect(restrictedBtn).toBeTruthy();
     } finally {
@@ -170,10 +173,10 @@ describe('InviteCaregiverPage', () => {
         await Promise.resolve();
       });
 
-      const input = screen.getByPlaceholderText(/maman|mom|garderie|daycare/i);
+      const input = document.getElementById('invite-name') as HTMLInputElement;
       fireEvent.change(input, { target: { value: 'Papie' } });
 
-      fireEvent.click(screen.getByText(/générer|generate/i));
+      fireEvent.click(screen.getByText(/envoyer.*invitation|send invitation/i));
       await act(async () => {
         await Promise.resolve(); // createInvitation rejette
         await Promise.resolve(); // catch → setError
@@ -207,9 +210,9 @@ describe('InviteCaregiverPage', () => {
       // Même si l'utilisateur réussissait à cliquer (ex. réactivation DOM),
       // le handler est protégé par `if (!online) return;` — createInvitation
       // ne doit pas être appelé.
-      const input = screen.getByPlaceholderText(/maman|mom|garderie|daycare/i);
+      const input = document.getElementById('invite-name') as HTMLInputElement;
       fireEvent.change(input, { target: { value: 'Maman' } });
-      fireEvent.click(screen.getByText(/générer|generate/i));
+      fireEvent.click(screen.getByText(/envoyer.*invitation|send invitation/i));
       await act(async () => {
         await Promise.resolve();
         await Promise.resolve();

--- a/apps/web/src/app/caregivers/invite/page.tsx
+++ b/apps/web/src/app/caregivers/invite/page.tsx
@@ -1,27 +1,50 @@
 'use client';
 
-import React from 'react';
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import QRCode from 'qrcode';
-import { YStack, XStack, Text, Button, Input } from 'tamagui';
+
+import { Theme } from 'tamagui';
+import { InviteForm, type InviteFormState } from '@kinhale/ui/caregivers';
+import type { CaregiverRole as PresentationCaregiverRole } from '@kinhale/ui/home';
+
 import { createInvitation, type CreatedInvitation } from '../../../lib/invitations/client';
 import { useRequireAuth } from '../../../lib/useRequireAuth';
 import { useOnlineGuard } from '../../../hooks/useOnlineGuard';
-
-type TargetRole = 'contributor' | 'restricted_contributor';
+import { buildInviteFormMessages, inviteRoleToInternal } from '../../../lib/caregivers/messages';
 
 export default function InviteCaregiverPage(): React.JSX.Element | null {
   const { t } = useTranslation('common');
+  const router = useRouter();
   const authenticated = useRequireAuth();
   const { online } = useOnlineGuard();
-  const [role, setRole] = React.useState<TargetRole>('restricted_contributor');
-  const [displayName, setDisplayName] = React.useState('');
-  const [created, setCreated] = React.useState<CreatedInvitation | null>(null);
-  const [qrDataUrl, setQrDataUrl] = React.useState<string | null>(null);
-  const [error, setError] = React.useState<string | null>(null);
-  const [remainingMs, setRemainingMs] = React.useState<number>(0);
 
-  React.useEffect(() => {
+  const [state, setState] = useState<InviteFormState>({
+    name: '',
+    email: '',
+    role: 'contributor',
+  });
+  const [created, setCreated] = useState<CreatedInvitation | null>(null);
+  const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [remainingMs, setRemainingMs] = useState<number>(0);
+
+  // Pré-remplissage depuis les query params (lien depuis /caregivers).
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    const name = params.get('name');
+    const role = params.get('role');
+    setState((s) => ({
+      ...s,
+      ...(name !== null && name !== '' ? { name } : {}),
+      ...(role === 'restricted_contributor' ? { role: 'restricted' as const } : {}),
+    }));
+  }, []);
+
+  useEffect(() => {
     if (created === null) return undefined;
     const payload = `${window.location.origin}/accept-invitation/${created.token}?pin=${created.pin}`;
     void QRCode.toDataURL(payload).then((url) => setQrDataUrl(url));
@@ -31,14 +54,17 @@ export default function InviteCaregiverPage(): React.JSX.Element | null {
     return () => clearInterval(id);
   }, [created]);
 
-  const handleSubmit = async (): Promise<void> => {
-    // Défense en profondeur : même si le bouton est `disabled` quand !online,
-    // un utilisateur qui réactiverait le DOM via DevTools ne doit pas réussir
-    // à déclencher un appel réseau voué à l'échec. Refs: kz-securite-075-078 §m1.
+  const messages = React.useMemo(() => buildInviteFormMessages(t), [t]);
+
+  const handleSubmit = async (s: InviteFormState): Promise<void> => {
     if (!online) return;
+    if (s.name.trim().length === 0) return;
     setError(null);
     try {
-      const result = await createInvitation({ targetRole: role, displayName });
+      const result = await createInvitation({
+        targetRole: inviteRoleToInternal(s.role),
+        displayName: s.name.trim(),
+      });
       setCreated(result);
     } catch (e) {
       const code = (e as Error).message;
@@ -57,96 +83,197 @@ export default function InviteCaregiverPage(): React.JSX.Element | null {
 
   if (!authenticated) return null;
 
+  // Mode 2 : QR code après création (même flux que v1, juste reskiné).
   if (created !== null) {
     const minutes = Math.max(0, Math.floor(remainingMs / 60_000));
     return (
-      <YStack padding="$4" gap="$3">
-        <Text fontSize="$6" fontWeight="bold">
-          {t('invitation.qrTitle')}
-        </Text>
-        <Text>{t('invitation.qrInstruction')}</Text>
-        {qrDataUrl !== null ? <img src={qrDataUrl} alt="QR" width={240} height={240} /> : null}
-        <Text fontSize="$5">
-          {t('invitation.pinLabel')}:{' '}
-          <Text fontWeight="bold" testID="pin-value">
-            {created.pin}
-          </Text>
-        </Text>
-        <Text>{t('invitation.expiresIn', { minutes })}</Text>
-        <Button onPress={handleCopy} accessibilityLabel={t('invitation.copyLink')}>
-          {t('invitation.copyLink')}
-        </Button>
-      </YStack>
+      <Theme name="kinhale_light">
+        <main
+          style={{
+            position: 'fixed',
+            inset: 0,
+            background: 'var(--background)',
+            overflow: 'auto',
+          }}
+        >
+          <div
+            style={{
+              maxWidth: 520,
+              margin: '40px auto',
+              padding: '0 24px 48px',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 20,
+              color: 'var(--color)',
+              fontFamily: 'var(--font-body, "Inter", system-ui, sans-serif)',
+            }}
+          >
+            <h1
+              style={{
+                fontFamily: 'var(--font-display, "Inter Tight", "Inter", system-ui, sans-serif)',
+                fontSize: 28,
+                fontWeight: 500,
+                letterSpacing: '-0.56px',
+                margin: 0,
+              }}
+            >
+              {t('invitation.qrTitle')}
+            </h1>
+            <p style={{ fontSize: 14, color: 'var(--colorMuted)', margin: 0, lineHeight: 1.5 }}>
+              {t('invitation.qrInstruction')}
+            </p>
+            {qrDataUrl !== null && (
+              <div
+                style={{
+                  alignSelf: 'center',
+                  background: 'var(--surface)',
+                  borderRadius: 18,
+                  padding: 20,
+                  border: '0.5px solid var(--borderColor)',
+                }}
+              >
+                <img src={qrDataUrl} alt="QR" width={240} height={240} />
+              </div>
+            )}
+            <div
+              style={{
+                background: 'var(--surface)',
+                borderRadius: 14,
+                border: '0.5px solid var(--borderColor)',
+                padding: '14px 18px',
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
+                gap: 16,
+              }}
+            >
+              <span style={{ fontSize: 13, color: 'var(--colorMore)' }}>
+                {t('invitation.pinLabel')}
+              </span>
+              <span
+                data-testid="pin-value"
+                style={{
+                  fontFamily: 'var(--font-mono, ui-monospace, monospace)',
+                  fontSize: 20,
+                  fontWeight: 600,
+                  letterSpacing: '0.1em',
+                  color: 'var(--color)',
+                }}
+              >
+                {created.pin}
+              </span>
+            </div>
+            <p style={{ fontSize: 12.5, color: 'var(--colorMore)', margin: 0 }}>
+              {t('invitation.expiresIn', { minutes })}
+            </p>
+            <button
+              onClick={handleCopy}
+              aria-label={t('invitation.copyLink')}
+              style={{
+                appearance: 'none',
+                cursor: 'pointer',
+                background: 'var(--maint)',
+                color: '#fff',
+                padding: '12px 16px',
+                borderRadius: 12,
+                border: 'none',
+                fontSize: 14,
+                fontWeight: 600,
+                fontFamily: 'inherit',
+              }}
+            >
+              {t('invitation.copyLink')}
+            </button>
+            <button
+              onClick={() => router.push('/caregivers')}
+              style={{
+                appearance: 'none',
+                cursor: 'pointer',
+                background: 'transparent',
+                color: 'var(--colorMuted)',
+                padding: '10px 16px',
+                borderRadius: 12,
+                border: '0.5px solid var(--borderColorStrong)',
+                fontSize: 14,
+                fontWeight: 500,
+                fontFamily: 'inherit',
+              }}
+            >
+              {t('invitation.cancelCta')}
+            </button>
+          </div>
+        </main>
+      </Theme>
     );
   }
 
+  // Mode 1 : formulaire d'invitation (clinical-calm v2).
   return (
-    <YStack padding="$4" gap="$3">
-      <Text fontSize="$6" fontWeight="bold">
-        {t('invitation.createTitle')}
-      </Text>
-
-      <YStack gap="$2">
-        <Text>{t('invitation.roleLabel')}</Text>
-        <XStack gap="$2">
-          <Button
-            onPress={() => setRole('contributor')}
-            backgroundColor={role === 'contributor' ? '$blue9' : '$backgroundStrong'}
-            color={role === 'contributor' ? 'white' : '$color'}
-            borderWidth={2}
-            borderColor={role === 'contributor' ? '$blue10' : '$borderColor'}
-            flex={1}
-            accessibilityRole="radio"
-            accessibilityState={{ checked: role === 'contributor' }}
-            accessibilityLabel={t('invitation.roleContributor')}
-          >
-            {t('invitation.roleContributor')}
-          </Button>
-          <Button
-            onPress={() => setRole('restricted_contributor')}
-            backgroundColor={role === 'restricted_contributor' ? '$blue9' : '$backgroundStrong'}
-            color={role === 'restricted_contributor' ? 'white' : '$color'}
-            borderWidth={2}
-            borderColor={role === 'restricted_contributor' ? '$blue10' : '$borderColor'}
-            flex={1}
-            accessibilityRole="radio"
-            accessibilityState={{ checked: role === 'restricted_contributor' }}
-            accessibilityLabel={t('invitation.roleRestricted')}
-          >
-            {t('invitation.roleRestricted')}
-          </Button>
-        </XStack>
-      </YStack>
-
-      <YStack gap="$2">
-        <Text>{t('invitation.displayNameLabel')}</Text>
-        <Input
-          value={displayName}
-          onChangeText={setDisplayName}
-          placeholder={t('invitation.displayNamePlaceholder')}
-          accessibilityLabel={t('invitation.displayNameLabel')}
-        />
-      </YStack>
-
-      <Button
-        onPress={() => void handleSubmit()}
-        disabled={displayName.trim().length === 0 || !online}
-        backgroundColor="$blue9"
-        color="white"
-        borderColor="$blue10"
-        borderWidth={2}
-        accessibilityLabel={t('invitation.generateCta')}
+    <Theme name="kinhale_light">
+      <main
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'var(--background)',
+          overflow: 'auto',
+        }}
       >
-        {t('invitation.generateCta')}
-      </Button>
-
-      {!online ? (
-        <Text color="$orange10" testID="offline-guard-message" role="status">
-          {t('offlineGuard.message')}
-        </Text>
-      ) : null}
-
-      {error !== null ? <Text color="$red10">{error}</Text> : null}
-    </YStack>
+        <div
+          style={{
+            maxWidth: 560,
+            margin: '40px auto',
+            padding: '0 24px 48px',
+          }}
+        >
+          <InviteForm
+            messages={messages}
+            state={state}
+            onChange={(patch) => setState((s) => ({ ...s, ...patch }))}
+            submitDisabled={!online || state.name.trim().length === 0}
+            mode="web"
+            handlers={{
+              onCancel: () => router.push('/caregivers'),
+              onSubmit: (s) => {
+                void handleSubmit(s);
+              },
+            }}
+            availableRoles={
+              ['contributor', 'restricted'] as ReadonlyArray<PresentationCaregiverRole>
+            }
+          />
+          {!online && (
+            <p
+              data-testid="offline-guard-message"
+              role="status"
+              style={{
+                marginTop: 14,
+                padding: '10px 14px',
+                background: 'var(--amberSoft)',
+                color: 'var(--amberInk)',
+                borderRadius: 10,
+                fontSize: 13,
+              }}
+            >
+              {t('offlineGuard.message')}
+            </p>
+          )}
+          {error !== null && (
+            <p
+              role="status"
+              style={{
+                marginTop: 14,
+                padding: '10px 14px',
+                background: 'var(--rescueSoft)',
+                color: 'var(--rescueInk)',
+                borderRadius: 10,
+                fontSize: 13,
+              }}
+            >
+              {error}
+            </p>
+          )}
+        </div>
+      </main>
+    </Theme>
   );
 }

--- a/apps/web/src/app/caregivers/page.tsx
+++ b/apps/web/src/app/caregivers/page.tsx
@@ -1,11 +1,21 @@
 'use client';
 
-import React from 'react';
-import { useTranslation } from 'react-i18next';
+import * as React from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { YStack, XStack, Text, Button, Card } from 'tamagui';
+import { useTranslation } from 'react-i18next';
+
 import { projectCaregivers } from '@kinhale/sync';
 import { fromHex, sealedBoxEncrypt, toHex } from '@kinhale/crypto';
+import {
+  CaregiversListMobile,
+  CaregiversListWeb,
+  type CaregiverProfileView,
+  type CaregiversNavItem,
+  type InviteFormState,
+  type PendingInvitationView,
+} from '@kinhale/ui/caregivers';
+
 import { useDocStore } from '../../stores/doc-store';
 import { useAuthStore } from '../../stores/auth-store';
 import {
@@ -16,21 +26,44 @@ import {
 } from '../../lib/invitations/client';
 import { getGroupKey } from '../../lib/device';
 import { useRequireAuth } from '../../lib/useRequireAuth';
+import {
+  buildCaregiversListMessages,
+  buildInviteFormMessages,
+  buildPendingPrimaryCta,
+  buildStageLabel,
+  invitationToPendingView,
+  projectedCaregiverToView,
+} from '../../lib/caregivers/messages';
+
+const DESKTOP_BREAKPOINT_PX = 1024;
 
 export default function CaregiversPage(): React.JSX.Element | null {
-  const { t } = useTranslation('common');
+  const { t, i18n } = useTranslation('common');
   const router = useRouter();
   const authenticated = useRequireAuth();
   const accessToken = useAuthStore((s) => s.accessToken);
   const householdId = useAuthStore((s) => s.householdId);
+  const deviceId = useAuthStore((s) => s.deviceId);
   const doc = useDocStore((s) => s.doc);
-  const caregivers = doc !== null ? projectCaregivers(doc) : [];
-  const [invitations, setInvitations] = React.useState<InvitationSummary[]>([]);
-  const [error, setError] = React.useState<string | null>(null);
-  const [sealingToken, setSealingToken] = React.useState<string | null>(null);
+
+  const [invitations, setInvitations] = useState<InvitationSummary[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [sealingToken, setSealingToken] = useState<string | null>(null);
+
+  const [isDesktop, setIsDesktop] = useState<boolean | null>(null);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const mq = window.matchMedia(`(min-width: ${DESKTOP_BREAKPOINT_PX}px)`);
+      const update = (): void => setIsDesktop(mq.matches);
+      update();
+      mq.addEventListener('change', update);
+      return () => mq.removeEventListener('change', update);
+    }
+    return undefined;
+  }, []);
 
   const refresh = React.useCallback(async () => {
-    if (!accessToken) return;
+    if (accessToken === null || accessToken === '') return;
     try {
       setInvitations(await listInvitations());
       setError(null);
@@ -39,7 +72,7 @@ export default function CaregiversPage(): React.JSX.Element | null {
     }
   }, [accessToken, t]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     void refresh();
   }, [refresh]);
 
@@ -52,7 +85,13 @@ export default function CaregiversPage(): React.JSX.Element | null {
     }
   };
 
-  const handleSeal = async (inv: InvitationSummary): Promise<void> => {
+  // Logique X25519 sealing — INCHANGÉE depuis l'implémentation v1
+  // (KIN-096). Critique sécurité — toute modification doit passer par
+  // kz-securite + tests vectors. La couche présentationnelle a changé,
+  // pas la cryptographie.
+  const handleSeal = async (token: string): Promise<void> => {
+    const inv = invitations.find((i) => i.token === token);
+    if (inv === undefined) return;
     if (sealingToken !== null) return;
     if (typeof householdId !== 'string' || householdId.length === 0) {
       setError(t('invitation.errorSealMissingGroupKey'));
@@ -62,32 +101,15 @@ export default function CaregiversPage(): React.JSX.Element | null {
     setError(null);
     try {
       const groupKey = await getGroupKey(householdId);
-      // KIN-096 — clé publique X25519 fournie par l'invité, lue côté backend
-      // via /invitations endpoint. On la récupère via la liste détaillée :
-      // on appelle directement listInvitations qui ne renvoie que des flags
-      // booléens. Pour récupérer la clé publique, on utilise un GET dédié
-      // qui n'expose pas la sealed (cf. /invitations/:token/recipient-key).
-      // Pour rester KISS sur cette PR, on fait un seul GET — sealed-group-key
-      // ne peut être lu sans token, donc on a besoin d'un endpoint admin
-      // dédié. Approche retenue : la liste est étendue côté backend pour
-      // exposer recipientPublicKeyHex aux admins (déjà fait dans le record).
-      // Toutefois la liste actuelle ne renvoie que les flags booléens. On
-      // utilise donc fetch direct vers GET /invitations/:token/sealed-group-key
-      // qui renvoie aussi la clé publique. Le sealed n'existe pas encore →
-      // 404. On utilise donc un appel détaillé via l'endpoint de récupération
-      // adminée. SIMPLIFICATION : on récupère la clé publique dans le payload
-      // de la liste admin (champ `recipientPublicKeyHex`).
-      const detail = invitations.find((i) => i.token === inv.token);
       if (
-        detail === undefined ||
-        detail.hasRecipientPublicKey !== true ||
-        typeof detail.recipientPublicKeyHex !== 'string' ||
-        detail.recipientPublicKeyHex.length !== 64
+        inv.hasRecipientPublicKey !== true ||
+        typeof inv.recipientPublicKeyHex !== 'string' ||
+        inv.recipientPublicKeyHex.length !== 64
       ) {
         setError(t('invitation.errorSealNoPubkey'));
         return;
       }
-      const recipientPublicKey = fromHex(detail.recipientPublicKeyHex);
+      const recipientPublicKey = fromHex(inv.recipientPublicKeyHex);
       const sealed = await sealedBoxEncrypt(groupKey, recipientPublicKey);
       await sealInvitation(inv.token, toHex(sealed));
       await refresh();
@@ -98,138 +120,174 @@ export default function CaregiversPage(): React.JSX.Element | null {
     }
   };
 
-  if (!authenticated) return null;
+  // Mapping vers les types présentationnels.
+  const caregivers = React.useMemo<CaregiverProfileView[]>(() => {
+    const projected = doc !== null ? projectCaregivers(doc) : [];
+    return projected.map((c) =>
+      projectedCaregiverToView(c, { currentDeviceId: deviceId, locale: 'fr-CA' }),
+    );
+  }, [doc, deviceId]);
 
-  // Trois groupes : aidants déjà installés (sync doc) ; invitations
-  // « en attente d'acceptation » (recipientPublicKey absent) ; invitations
-  // « en attente de finalisation » (pubkey présente, sealed absent).
-  const pendingSealing = invitations.filter(
-    (inv) => inv.hasRecipientPublicKey === true && inv.hasSealedGroupKey !== true,
+  const locale = i18n.language === 'en' ? 'en-CA' : 'fr-CA';
+  const pending = React.useMemo<PendingInvitationView[]>(
+    () =>
+      invitations.map((inv) => invitationToPendingView(inv, { currentDeviceId: deviceId, locale })),
+    [invitations, deviceId, locale],
   );
-  const pendingAcceptance = invitations.filter((inv) => inv.hasRecipientPublicKey !== true);
-  const sealedAndWaiting = invitations.filter(
-    (inv) => inv.hasRecipientPublicKey === true && inv.hasSealedGroupKey === true,
+
+  const totalCount = caregivers.length + pending.length;
+  const messages = React.useMemo(() => buildCaregiversListMessages(t, totalCount), [t, totalCount]);
+  const inviteMessages = React.useMemo(() => buildInviteFormMessages(t), [t]);
+  const primaryCta = React.useMemo(() => buildPendingPrimaryCta(t), [t]);
+
+  const stageLabels = React.useMemo<Record<string, string>>(() => {
+    const map: Record<string, string> = {};
+    for (const p of pending) {
+      map[p.stage] = buildStageLabel(t, p.stage, p.sentLabel);
+    }
+    return map;
+  }, [t, pending]);
+
+  // Form d'invitation (desktop uniquement — sur mobile on route vers
+  // /caregivers/invite qui contient le QR code complet).
+  const [inviteState, setInviteState] = useState<InviteFormState>({
+    name: '',
+    email: '',
+    role: 'contributor',
+  });
+  const handleInviteChange = (patch: Partial<InviteFormState>): void => {
+    setInviteState((s) => ({ ...s, ...patch }));
+  };
+
+  const navItems = React.useMemo<CaregiversNavItem[]>(
+    () => [
+      { key: 'home', label: t('pumps.nav.home'), onPress: () => router.push('/') },
+      {
+        key: 'history',
+        label: t('pumps.nav.history'),
+        onPress: () => router.push('/journal'),
+      },
+      { key: 'pumps', label: t('pumps.nav.pumps'), onPress: () => router.push('/pumps') },
+      { key: 'caregivers', label: t('pumps.nav.caregivers'), active: true },
+      {
+        key: 'reports',
+        label: t('pumps.nav.reports'),
+        onPress: () => router.push('/reports'),
+      },
+      {
+        key: 'settings',
+        label: t('pumps.nav.settings'),
+        onPress: () => router.push('/settings/notifications'),
+      },
+    ],
+    [router, t],
   );
+
+  if (!authenticated || isDesktop === null) {
+    return null;
+  }
+
+  const handlers = {
+    onPressInvite: (): void => router.push('/caregivers/invite'),
+    onPressResend: (token: string): void => router.push(`/caregivers/invite?resend=${token}`),
+    onPressWithdraw: (token: string): void => {
+      void handleRevoke(token);
+    },
+    onPressSeal: (token: string): void => {
+      void handleSeal(token);
+    },
+  };
+
+  // L'envoi du form sur la colonne droite (desktop) renvoie vers
+  // /caregivers/invite qui gère le QR code + flux complet — l'utilisateur
+  // peut pré-remplir ici puis confirmer là-bas.
+  const inviteHandlers = {
+    onCancel: () => {
+      setInviteState({ name: '', email: '', role: 'contributor' });
+    },
+    onSubmit: () => {
+      router.push(
+        `/caregivers/invite?name=${encodeURIComponent(inviteState.name)}&role=${
+          inviteState.role === 'restricted' ? 'restricted_contributor' : 'contributor'
+        }`,
+      );
+    },
+  };
+
+  if (isDesktop) {
+    return (
+      <>
+        <CaregiversListWeb
+          messages={messages}
+          inviteMessages={inviteMessages}
+          caregivers={caregivers}
+          pending={pending}
+          pendingStageLabels={stageLabels}
+          pendingPrimaryCta={primaryCta}
+          navItems={navItems}
+          inviteState={inviteState}
+          onInviteChange={handleInviteChange}
+          inviteSubmitDisabled={
+            inviteState.name.trim().length === 0 || inviteState.email.trim().length === 0
+          }
+          inviteHandlers={inviteHandlers}
+          handlers={handlers}
+        />
+        {error !== null && (
+          <div
+            role="status"
+            data-testid="caregivers-error"
+            style={{
+              position: 'fixed',
+              bottom: 24,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              background: 'var(--rescueSoft)',
+              color: 'var(--rescueInk)',
+              padding: '10px 14px',
+              borderRadius: 10,
+              fontSize: 13,
+              zIndex: 100,
+            }}
+          >
+            {error}
+          </div>
+        )}
+      </>
+    );
+  }
 
   return (
-    <YStack padding="$4" gap="$3">
-      <Text fontSize="$6" fontWeight="bold">
-        {t('invitation.listTitle')}
-      </Text>
-
-      {caregivers.length === 0 && invitations.length === 0 ? (
-        <Text>{t('invitation.listEmpty')}</Text>
-      ) : null}
-
-      {caregivers.map((c) => (
-        <Card key={c.caregiverId} padding="$3">
-          <Text fontWeight="bold">{c.displayName}</Text>
-          <Text>
-            {c.role === 'contributor'
-              ? t('invitation.roleContributor')
-              : t('invitation.roleRestricted')}
-          </Text>
-        </Card>
-      ))}
-
-      {pendingSealing.length > 0 ? (
-        <YStack gap="$2">
-          <Text fontSize="$5" fontWeight="bold" testID="pending-seal-section">
-            {t('invitation.pendingSealTitle')}
-          </Text>
-          <Text>{t('invitation.pendingSealHint')}</Text>
-          {pendingSealing.map((inv) => (
-            <Card key={inv.token} padding="$3" testID={`pending-seal-card-${inv.token}`}>
-              <XStack justifyContent="space-between" alignItems="center" gap="$2">
-                <YStack flex={1}>
-                  <Text fontWeight="bold">{inv.displayName}</Text>
-                  <Text>
-                    {inv.targetRole === 'contributor'
-                      ? t('invitation.roleContributor')
-                      : t('invitation.roleRestricted')}
-                  </Text>
-                </YStack>
-                <Button
-                  onPress={() => void handleSeal(inv)}
-                  disabled={sealingToken !== null}
-                  backgroundColor="$blue9"
-                  color="white"
-                  borderColor="$blue10"
-                  borderWidth={2}
-                  accessibilityLabel={t('invitation.sealCta')}
-                  testID={`seal-button-${inv.token}`}
-                >
-                  {sealingToken === inv.token
-                    ? t('invitation.sealInProgress')
-                    : t('invitation.sealCta')}
-                </Button>
-              </XStack>
-            </Card>
-          ))}
-        </YStack>
-      ) : null}
-
-      {pendingAcceptance.map((inv) => (
-        <Card key={inv.token} padding="$3">
-          <XStack justifyContent="space-between" alignItems="center">
-            <YStack>
-              <Text fontWeight="bold">{inv.displayName}</Text>
-              <Text>
-                {inv.targetRole === 'contributor'
-                  ? t('invitation.roleContributor')
-                  : t('invitation.roleRestricted')}
-              </Text>
-            </YStack>
-            <Button
-              onPress={() => void handleRevoke(inv.token)}
-              accessibilityLabel={t('invitation.revokeCta')}
-            >
-              {t('invitation.revokeCta')}
-            </Button>
-          </XStack>
-        </Card>
-      ))}
-
-      {sealedAndWaiting.map((inv) => (
-        <Card key={inv.token} padding="$3">
-          <XStack justifyContent="space-between" alignItems="center">
-            <YStack>
-              <Text fontWeight="bold">{inv.displayName}</Text>
-              <Text color="$gray10">{t('invitation.sealedAndWaiting')}</Text>
-            </YStack>
-            <Button
-              onPress={() => void handleRevoke(inv.token)}
-              accessibilityLabel={t('invitation.revokeCta')}
-            >
-              {t('invitation.revokeCta')}
-            </Button>
-          </XStack>
-        </Card>
-      ))}
-
-      <Button
-        onPress={() => router.push('/caregivers/invite')}
-        backgroundColor="$blue9"
-        color="white"
-        borderColor="$blue10"
-        borderWidth={2}
-        accessibilityLabel={t('invitation.createCta')}
-      >
-        {t('invitation.createCta')}
-      </Button>
-
-      <Button
-        onPress={() => router.push('/caregivers/scan')}
-        backgroundColor="$backgroundStrong"
-        color="$color"
-        borderColor="$borderColor"
-        borderWidth={2}
-        accessibilityLabel={t('invitation.scanCta')}
-      >
-        {t('invitation.scanCta')}
-      </Button>
-
-      {error !== null ? <Text color="$red10">{error}</Text> : null}
-    </YStack>
+    <>
+      <CaregiversListMobile
+        messages={messages}
+        caregivers={caregivers}
+        pending={pending}
+        pendingStageLabels={stageLabels}
+        pendingPrimaryCta={primaryCta}
+        handlers={handlers}
+      />
+      {error !== null && (
+        <div
+          role="status"
+          data-testid="caregivers-error"
+          style={{
+            position: 'fixed',
+            bottom: 80,
+            left: 16,
+            right: 16,
+            background: 'var(--rescueSoft)',
+            color: 'var(--rescueInk)',
+            padding: '10px 14px',
+            borderRadius: 10,
+            fontSize: 13,
+            zIndex: 100,
+            textAlign: 'center',
+          }}
+        >
+          {error}
+        </div>
+      )}
+    </>
   );
 }

--- a/apps/web/src/lib/caregivers/messages.ts
+++ b/apps/web/src/lib/caregivers/messages.ts
@@ -1,0 +1,219 @@
+import type { TFunction } from 'i18next';
+
+import type {
+  CaregiverProfileView,
+  CaregiversListMessages,
+  InviteFormMessages,
+  PendingInvitationStage,
+  PendingInvitationView,
+} from '@kinhale/ui/caregivers';
+// `CaregiverRole` est défini dans le module `home` (déjà exporté
+// largement). Voir `caregivers/index.ts` pour la note sur la dé-dup.
+import type { CaregiverRole } from '@kinhale/ui/home';
+import type { ProjectedCaregiver } from '@kinhale/sync';
+
+import type { InvitationSummary } from '../invitations/client';
+
+/**
+ * Hue déterministe (0-360) calculée depuis l'identifiant de l'aidant
+ * pour produire un avatar coloré stable d'une session à l'autre. Pas
+ * de hash cryptographique nécessaire (palette esthétique).
+ */
+function hueFromId(id: string): number {
+  let acc = 0;
+  for (let i = 0; i < id.length; i += 1) {
+    acc = (acc * 31 + id.charCodeAt(i)) >>> 0;
+  }
+  return acc % 360;
+}
+
+/**
+ * Initiales depuis un nom complet : 1ʳᵉ lettre des deux premiers mots,
+ * ou 2 premières lettres si un seul mot. Toujours en MAJUSCULES.
+ */
+function initialsFor(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return '?';
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) {
+    return (parts[0] ?? '').slice(0, 2).toUpperCase();
+  }
+  return ((parts[0]?.[0] ?? '') + (parts[1]?.[0] ?? '')).toUpperCase();
+}
+
+/**
+ * Mappe le rôle interne (`admin` / `contributor` / `restricted_contributor`)
+ * vers le type `CaregiverRole` utilisé par la couche présentationnelle.
+ */
+function mapInternalRole(role: string): CaregiverRole {
+  if (role === 'admin') return 'admin';
+  if (role === 'restricted_contributor' || role === 'restricted') return 'restricted';
+  return 'contributor';
+}
+
+export interface BuildContext {
+  /** ID du device courant — utilisé pour la pastille « Vous ». */
+  currentDeviceId: string | null;
+  /** Locale BCP-47 pour formater les dates (« 24 avril »). */
+  locale: string;
+  /** Référence temporelle (par défaut now()). */
+  now?: Date;
+}
+
+export function projectedCaregiverToView(
+  c: ProjectedCaregiver,
+  ctx: BuildContext,
+): CaregiverProfileView {
+  const role = mapInternalRole(c.role);
+  return {
+    id: c.caregiverId,
+    name: c.displayName,
+    initials: initialsFor(c.displayName),
+    relation: '',
+    role,
+    presence: 'offline',
+    hue: hueFromId(c.caregiverId),
+    ...(ctx.currentDeviceId !== null && c.caregiverId === ctx.currentDeviceId
+      ? { isYou: true }
+      : {}),
+  };
+}
+
+function stageOf(inv: InvitationSummary): PendingInvitationStage {
+  if (inv.hasRecipientPublicKey !== true) return 'awaitingRecipient';
+  if (inv.hasSealedGroupKey !== true) return 'awaitingSeal';
+  return 'sealedWaiting';
+}
+
+function formatShortDate(ms: number, locale: string): string {
+  return new Intl.DateTimeFormat(locale, {
+    day: 'numeric',
+    month: 'short',
+  }).format(new Date(ms));
+}
+
+export function invitationToPendingView(
+  inv: InvitationSummary,
+  ctx: BuildContext,
+): PendingInvitationView {
+  const role = mapInternalRole(inv.targetRole);
+  return {
+    token: inv.token,
+    name: inv.displayName,
+    initials: initialsFor(inv.displayName),
+    role,
+    stage: stageOf(inv),
+    sentLabel: formatShortDate(inv.createdAtMs, ctx.locale),
+    hue: hueFromId(inv.token),
+  };
+}
+
+export function buildCaregiversListMessages(
+  t: TFunction<'common'>,
+  count: number,
+): CaregiversListMessages {
+  return {
+    childName: t('home.dashboard.childName'),
+    title: t('caregivers.title'),
+    subtitle: count === 0 ? t('caregivers.subtitle_zero') : t('caregivers.subtitle', { count }),
+    inviteCta: t('caregivers.inviteCta'),
+    inviteShort: t('caregivers.inviteShort'),
+    sectionActive: t('caregivers.sectionActive'),
+    sectionPending: t('caregivers.sectionPending'),
+    youTag: t('caregivers.youTag'),
+    onlineNow: t('caregivers.onlineNow'),
+    roleLabel: {
+      admin: t('caregivers.role.admin'),
+      contributor: t('caregivers.role.contributor'),
+      restricted: t('caregivers.role.restricted'),
+    },
+    roleDescription: {
+      admin: t('caregivers.roleDescription.admin'),
+      contributor: t('caregivers.roleDescription.contributor'),
+      restricted: t('caregivers.roleDescription.restricted'),
+    },
+    resendCta: t('caregivers.resendCta'),
+    withdrawCta: t('caregivers.withdrawCta'),
+    stageAwaitingRecipient: t('caregivers.stage.awaitingRecipient', { date: '' }),
+    stageAwaitingSeal: t('caregivers.stage.awaitingSeal', { date: '' }),
+    stageSealedWaiting: t('caregivers.stage.sealedWaiting'),
+    permissionsTitle: t('caregivers.permissionsTitle'),
+    permission1: t('caregivers.permission1'),
+    permission2: t('caregivers.permission2'),
+    permission3: t('caregivers.permission3'),
+    permission4: t('caregivers.permission4'),
+    permission5: t('caregivers.permission5'),
+    permYes: t('caregivers.permYes'),
+    permNo: t('caregivers.permNo'),
+    notMedical: t('caregivers.notMedical'),
+  };
+}
+
+/**
+ * Phrase localisée pour chaque stade — l'app utilise la date d'envoi
+ * de l'invitation pour personnaliser le libellé.
+ */
+export function buildStageLabel(
+  t: TFunction<'common'>,
+  stage: PendingInvitationStage,
+  sentLabel: string,
+): string {
+  switch (stage) {
+    case 'awaitingRecipient':
+      return t('caregivers.stage.awaitingRecipient', { date: sentLabel });
+    case 'awaitingSeal':
+      return t('caregivers.stage.awaitingSeal', { date: sentLabel });
+    case 'sealedWaiting':
+      return t('caregivers.stage.sealedWaiting');
+  }
+}
+
+export function buildPendingPrimaryCta(
+  t: TFunction<'common'>,
+): (view: PendingInvitationView) => string | null {
+  return (view) => {
+    if (view.stage === 'awaitingSeal') {
+      return t('caregivers.primaryCta.awaitingSeal');
+    }
+    return null;
+  };
+}
+
+export function buildInviteFormMessages(t: TFunction<'common'>): InviteFormMessages {
+  return {
+    title: t('caregivers.invite.title'),
+    subtitle: t('caregivers.invite.subtitle'),
+    nameLabel: t('caregivers.invite.nameLabel'),
+    namePlaceholder: t('caregivers.invite.namePlaceholder'),
+    emailLabel: t('caregivers.invite.emailLabel'),
+    emailPlaceholder: t('caregivers.invite.emailPlaceholder'),
+    chooseRoleLabel: t('caregivers.invite.chooseRoleLabel'),
+    roleLabel: {
+      admin: t('caregivers.role.admin'),
+      contributor: t('caregivers.role.contributor'),
+      restricted: t('caregivers.role.restricted'),
+    },
+    roleDescription: {
+      admin: t('caregivers.roleDescription.admin'),
+      contributor: t('caregivers.roleDescription.contributor'),
+      restricted: t('caregivers.roleDescription.restricted'),
+    },
+    cancelCta: t('caregivers.invite.cancelCta'),
+    sendCta: t('caregivers.invite.sendCta'),
+  };
+}
+
+/**
+ * Mappe le `CaregiverRole` présentationnel (`'admin' | 'contributor' |
+ * 'restricted'`) vers le rôle interne accepté par
+ * `createInvitation` (`'contributor' | 'restricted_contributor'`).
+ *
+ * `admin` n'est PAS un rôle d'invitation — la promotion en admin se
+ * fait après acceptation, via un événement séparé. Côté formulaire on
+ * masque le choix `admin` à l'utilisateur (`availableRoles`).
+ */
+export function inviteRoleToInternal(
+  role: CaregiverRole,
+): 'contributor' | 'restricted_contributor' {
+  return role === 'restricted' ? 'restricted_contributor' : 'contributor';
+}

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -825,5 +825,73 @@
     "emptyTitle": "No doses logged yet",
     "emptySub": "Logged doses will appear here, day by day.",
     "notMedical": "Tracking tool · not medical advice."
+  },
+  "caregivers": {
+    "title": "Caregivers",
+    "subtitle_one": "{{count}} person has access",
+    "subtitle_other": "{{count}} people have access",
+    "subtitle_zero": "No caregivers yet",
+    "inviteCta": "Invite caregiver",
+    "inviteShort": "Invite",
+    "sectionActive": "Active",
+    "sectionPending": "Pending invitations",
+    "youTag": "You",
+    "onlineNow": "Online",
+    "lastSeen_minutes_one": "Seen {{count}} min ago",
+    "lastSeen_minutes_other": "Seen {{count}} min ago",
+    "lastSeen_hours_one": "Seen {{count}} h ago",
+    "lastSeen_hours_other": "Seen {{count}} h ago",
+    "lastSeen_days_one": "Seen {{count}} d ago",
+    "lastSeen_days_other": "Seen {{count}} d ago",
+    "role": {
+      "admin": "Admin",
+      "contributor": "Co-parent",
+      "restricted": "Daycare · grandparent"
+    },
+    "roleDescription": {
+      "admin": "Full access · add, edit, invite",
+      "contributor": "Logs doses · sees everything",
+      "restricted": "Sees today's plan · can log"
+    },
+    "relation": {
+      "parent": "Parent",
+      "grandparent": "Grandparent",
+      "daycare": "Daycare",
+      "school": "School",
+      "friend": "Friend",
+      "other": "Other"
+    },
+    "stage": {
+      "awaitingRecipient": "Sent on {{date}} · awaiting recipient",
+      "awaitingSeal": "Sent on {{date}} · awaiting your action",
+      "sealedWaiting": "Finalized · awaiting acceptance"
+    },
+    "primaryCta": {
+      "awaitingSeal": "Finalize",
+      "awaitingRecipient": "",
+      "sealedWaiting": ""
+    },
+    "resendCta": "Resend",
+    "withdrawCta": "Withdraw",
+    "permissionsTitle": "Permissions at a glance",
+    "permission1": "See today's plan",
+    "permission2": "Log doses",
+    "permission3": "Manage inhalers",
+    "permission4": "Invite others",
+    "permission5": "Export data",
+    "permYes": "✓",
+    "permNo": "—",
+    "notMedical": "Tracking tool · not a substitute for medical advice.",
+    "invite": {
+      "title": "Invite a caregiver",
+      "subtitle": "We'll send a magic link. No password to share.",
+      "nameLabel": "First name",
+      "namePlaceholder": "Grandma Claire",
+      "emailLabel": "Email address",
+      "emailPlaceholder": "grandma@family.ca",
+      "chooseRoleLabel": "Choose a role",
+      "cancelCta": "Cancel",
+      "sendCta": "Send invitation"
+    }
   }
 }

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -825,5 +825,73 @@
     "emptyTitle": "Aucune prise enregistrée",
     "emptySub": "Les prises consignées apparaîtront ici, jour par jour.",
     "notMedical": "Outil de suivi · ne remplace pas un avis médical."
+  },
+  "caregivers": {
+    "title": "Aidants",
+    "subtitle_one": "{{count}} personne a accès au profil",
+    "subtitle_other": "{{count}} personnes ont accès au profil",
+    "subtitle_zero": "Aucun aidant invité",
+    "inviteCta": "Inviter un aidant",
+    "inviteShort": "Inviter",
+    "sectionActive": "Actifs",
+    "sectionPending": "Invitations en attente",
+    "youTag": "Vous",
+    "onlineNow": "En ligne",
+    "lastSeen_minutes_one": "Vu·e il y a {{count}} min",
+    "lastSeen_minutes_other": "Vu·e il y a {{count}} min",
+    "lastSeen_hours_one": "Vu·e il y a {{count}} h",
+    "lastSeen_hours_other": "Vu·e il y a {{count}} h",
+    "lastSeen_days_one": "Vu·e il y a {{count}} j",
+    "lastSeen_days_other": "Vu·e il y a {{count}} j",
+    "role": {
+      "admin": "Admin",
+      "contributor": "Co-parent",
+      "restricted": "Garderie · grand-parent"
+    },
+    "roleDescription": {
+      "admin": "Accès complet · ajoute, modifie, invite",
+      "contributor": "Consigne les prises · voit tout",
+      "restricted": "Voit le plan d'aujourd'hui · peut consigner"
+    },
+    "relation": {
+      "parent": "Parent",
+      "grandparent": "Grand-parent",
+      "daycare": "Garderie",
+      "school": "École",
+      "friend": "Ami·e",
+      "other": "Autre"
+    },
+    "stage": {
+      "awaitingRecipient": "Envoyée le {{date}} · en attente de l'invité·e",
+      "awaitingSeal": "Envoyée le {{date}} · à finaliser",
+      "sealedWaiting": "Finalisée · en attente d'acceptation"
+    },
+    "primaryCta": {
+      "awaitingSeal": "Finaliser",
+      "awaitingRecipient": "",
+      "sealedWaiting": ""
+    },
+    "resendCta": "Renvoyer",
+    "withdrawCta": "Retirer",
+    "permissionsTitle": "Aperçu des permissions",
+    "permission1": "Voir le plan du jour",
+    "permission2": "Consigner les prises",
+    "permission3": "Modifier les pompes",
+    "permission4": "Inviter d'autres aidants",
+    "permission5": "Exporter les données",
+    "permYes": "✓",
+    "permNo": "—",
+    "notMedical": "Outil de suivi · ne remplace pas un avis médical.",
+    "invite": {
+      "title": "Inviter un aidant",
+      "subtitle": "On enverra un lien magique. Pas de mot de passe à partager.",
+      "nameLabel": "Prénom",
+      "namePlaceholder": "Mamie Claire",
+      "emailLabel": "Adresse courriel",
+      "emailPlaceholder": "mamie@famille.ca",
+      "chooseRoleLabel": "Choisir le rôle",
+      "cancelCta": "Annuler",
+      "sendCta": "Envoyer l'invitation"
+    }
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,6 +15,7 @@
     "./onboarding": "./src/components/onboarding/index.ts",
     "./pumps": "./src/components/pumps/index.ts",
     "./history": "./src/components/history/index.ts",
+    "./caregivers": "./src/components/caregivers/index.ts",
     "./icons": "./src/icons/index.ts"
   },
   "scripts": {

--- a/packages/ui/src/components/caregivers/Avatar.tsx
+++ b/packages/ui/src/components/caregivers/Avatar.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { Stack, Text } from 'tamagui';
+
+export interface AvatarProps {
+  /** Initiales (1-2 caractères). Centré dans l'avatar. */
+  initials: string;
+  /** Hue (0-360) pour générer un fond déterministe via `oklch(85% 0.06 hue)`. */
+  hue: number;
+  /** Taille du cercle en px. Le ratio texte/cercle reste constant. */
+  size?: number;
+  /** Pastille verte « online » en bas-droite. */
+  online?: boolean;
+  /** Cercle pointillé ambré pour les invitations en attente. */
+  pending?: boolean;
+}
+
+export function Avatar({
+  initials,
+  hue,
+  size = 40,
+  online = false,
+  pending = false,
+}: AvatarProps): React.JSX.Element {
+  const halfSize = size / 2;
+  const dotSize = Math.round(size * 0.28);
+  return (
+    <Stack position="relative" flexShrink={0} width={size} height={size}>
+      <Stack
+        width={size}
+        height={size}
+        borderRadius={halfSize}
+        alignItems="center"
+        justifyContent="center"
+        opacity={pending ? 0.6 : 1}
+        borderWidth={pending ? 1.5 : 0}
+        borderStyle={pending ? 'dashed' : 'solid'}
+        style={{
+          background: `oklch(85% 0.06 ${hue})`,
+          ...(pending
+            ? {
+                borderColor: 'color-mix(in oklch, var(--amber) 60%, transparent)',
+              }
+            : {}),
+        }}
+      >
+        <Text
+          fontSize={Math.round(size * 0.36)}
+          fontWeight="600"
+          letterSpacing={0.4}
+          style={{ color: `oklch(35% 0.10 ${hue})` }}
+        >
+          {initials}
+        </Text>
+      </Stack>
+      {online && (
+        <Stack
+          position="absolute"
+          bottom={0}
+          right={0}
+          width={dotSize}
+          height={dotSize}
+          borderRadius={dotSize / 2}
+          backgroundColor="$ok"
+          borderWidth={2}
+          borderColor="$background"
+        />
+      )}
+    </Stack>
+  );
+}

--- a/packages/ui/src/components/caregivers/CaregiverRow.tsx
+++ b/packages/ui/src/components/caregivers/CaregiverRow.tsx
@@ -1,0 +1,112 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { Avatar } from './Avatar';
+import { MoreIcon } from './icons';
+import { RolePill } from './RolePill';
+import type { CaregiverProfileView } from './types';
+
+export interface CaregiverRowProps {
+  caregiver: CaregiverProfileView;
+  /** Libellé pastille « Vous ». */
+  youLabel: string;
+  /** Libellé « En ligne ». */
+  onlineLabel: string;
+  /** Libellé du rôle déjà localisé. */
+  roleLabel: string;
+  mode?: 'mobile' | 'web';
+  /** Si fourni, la rangée devient cliquable (hover + onPress). */
+  onPress?: ((id: string) => void) | undefined;
+}
+
+export function CaregiverRow({
+  caregiver,
+  youLabel,
+  onlineLabel,
+  roleLabel,
+  mode = 'mobile',
+  onPress,
+}: CaregiverRowProps): React.JSX.Element {
+  return (
+    <XStack
+      alignItems="center"
+      gap={14}
+      paddingHorizontal={mode === 'web' ? 16 : 14}
+      paddingVertical={mode === 'web' ? 14 : 12}
+      borderBottomWidth={0.5}
+      borderBottomColor="$borderColor"
+      cursor={onPress ? 'pointer' : 'default'}
+      tag={onPress ? 'button' : 'div'}
+      borderWidth={0}
+      backgroundColor="transparent"
+      {...(onPress ? { onPress: () => onPress(caregiver.id) } : {})}
+      {...(onPress ? { hoverStyle: { backgroundColor: '$surface2' } } : {})}
+      accessibilityRole={onPress ? 'button' : undefined}
+    >
+      <Avatar
+        initials={caregiver.initials}
+        hue={caregiver.hue}
+        size={mode === 'web' ? 44 : 40}
+        online={caregiver.presence === 'online'}
+      />
+      <YStack flex={1} minWidth={0}>
+        <XStack alignItems="center" gap={8} flexWrap="wrap">
+          <Text fontSize={14.5} fontWeight="600" color="$color">
+            {caregiver.name}
+          </Text>
+          {caregiver.isYou === true && (
+            <Stack
+              paddingHorizontal={8}
+              paddingVertical={1}
+              backgroundColor="$surface2"
+              borderRadius={99}
+            >
+              <Text
+                fontSize={10}
+                fontWeight="600"
+                color="$colorMuted"
+                textTransform="uppercase"
+                letterSpacing={0.6}
+              >
+                {youLabel}
+              </Text>
+            </Stack>
+          )}
+        </XStack>
+        <Text fontSize={12} color="$colorMore" marginTop={2}>
+          {caregiver.relation}
+          {caregiver.presence === 'online' ? (
+            <>
+              {' · '}
+              <Text color="$ok" fontWeight="500">
+                {onlineLabel}
+              </Text>
+            </>
+          ) : caregiver.lastSeenLabel !== undefined && caregiver.lastSeenLabel !== '' ? (
+            <> · {caregiver.lastSeenLabel}</>
+          ) : null}
+        </Text>
+        {mode === 'web' && caregiver.email !== undefined && caregiver.email !== '' && (
+          <Text fontFamily="$mono" fontSize={11.5} color="$colorFaint" marginTop={2}>
+            {caregiver.email}
+          </Text>
+        )}
+      </YStack>
+      <RolePill role={caregiver.role} label={roleLabel} compact={mode === 'mobile'} />
+      <Stack
+        tag="button"
+        cursor="pointer"
+        padding={6}
+        borderWidth={0}
+        backgroundColor="transparent"
+        borderRadius={8}
+        accessibilityRole="button"
+        accessibilityLabel={`${caregiver.name} — actions`}
+      >
+        <Text color="$colorMore" display="flex" alignItems="center" justifyContent="center">
+          <MoreIcon size={16} color="currentColor" />
+        </Text>
+      </Stack>
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/caregivers/CaregiversListMobile.tsx
+++ b/packages/ui/src/components/caregivers/CaregiversListMobile.tsx
@@ -1,0 +1,208 @@
+import * as React from 'react';
+import { Stack, Text, Theme, XStack, YStack } from 'tamagui';
+
+import { CaregiverRow } from './CaregiverRow';
+import { PendingRow } from './PendingRow';
+import { PermsTable } from './PermsTable';
+import { PlusIcon } from './icons';
+import type {
+  CaregiverProfileView,
+  CaregiversListHandlers,
+  CaregiversListMessages,
+  PendingInvitationView,
+} from './types';
+
+export interface CaregiversListMobileProps {
+  messages: CaregiversListMessages;
+  caregivers: ReadonlyArray<CaregiverProfileView>;
+  pending: ReadonlyArray<PendingInvitationView>;
+  /**
+   * Mappage stade → libellé localisé (ex. « Envoyée le 24 avril · en
+   * attente de l'invité·e »). L'app appelante construit ce libellé pour
+   * éviter de dupliquer le formatage de date dans le composant.
+   */
+  pendingStageLabels: Record<string, string>;
+  /** Mappage stade → CTA principal contextualisé (peut renvoyer null). */
+  pendingPrimaryCta?: ((view: PendingInvitationView) => string | null) | undefined;
+  handlers?: CaregiversListHandlers | undefined;
+  theme?: 'kinhale_light' | 'kinhale_dark';
+}
+
+export function CaregiversListMobile({
+  messages,
+  caregivers,
+  pending,
+  pendingStageLabels,
+  pendingPrimaryCta,
+  handlers,
+  theme = 'kinhale_light',
+}: CaregiversListMobileProps): React.JSX.Element {
+  return (
+    <Theme name={theme}>
+      <YStack height="100%" backgroundColor="$background">
+        <XStack
+          tag="header"
+          paddingHorizontal={20}
+          paddingTop={8}
+          paddingBottom={16}
+          alignItems="center"
+          justifyContent="space-between"
+          borderBottomWidth={0.5}
+          borderBottomColor="$borderColor"
+        >
+          <YStack>
+            <Text
+              tag="h1"
+              margin={0}
+              fontFamily="$heading"
+              fontSize={24}
+              fontWeight="500"
+              letterSpacing={-0.48}
+              color="$color"
+            >
+              {messages.title}
+            </Text>
+            <Text fontSize={12} color="$colorMore" marginTop={2}>
+              {messages.subtitle}
+            </Text>
+          </YStack>
+          <XStack
+            tag="button"
+            cursor="pointer"
+            backgroundColor="$maint"
+            paddingHorizontal={14}
+            paddingVertical={8}
+            borderRadius={99}
+            borderWidth={0}
+            alignItems="center"
+            gap={6}
+            accessibilityRole="button"
+            accessibilityLabel={messages.inviteCta}
+            testID="caregivers-invite-cta"
+            {...(handlers?.onPressInvite ? { onPress: handlers.onPressInvite } : {})}
+            style={{
+              boxShadow: '0 4px 12px color-mix(in oklch, var(--maint) 28%, transparent)',
+            }}
+          >
+            <Text color="white" display="flex" alignItems="center" justifyContent="center">
+              <PlusIcon size={13} color="white" />
+            </Text>
+            <Text fontSize={12.5} fontWeight="600" color="white">
+              {messages.inviteShort}
+            </Text>
+          </XStack>
+        </XStack>
+
+        <Stack flex={1} style={{ overflow: 'auto' }}>
+          {/* Active section */}
+          <Text
+            tag="h2"
+            margin={0}
+            fontSize={11}
+            color="$colorMore"
+            textTransform="uppercase"
+            letterSpacing={0.88}
+            fontWeight="600"
+            paddingHorizontal={20}
+            paddingTop={14}
+            paddingBottom={8}
+          >
+            {messages.sectionActive}
+          </Text>
+          <YStack
+            backgroundColor="$surface"
+            borderTopWidth={0.5}
+            borderTopColor="$borderColor"
+            borderBottomWidth={0.5}
+            borderBottomColor="$borderColor"
+          >
+            {caregivers.map((c) => (
+              <CaregiverRow
+                key={c.id}
+                caregiver={c}
+                youLabel={messages.youTag}
+                onlineLabel={messages.onlineNow}
+                roleLabel={messages.roleLabel[c.role]}
+                mode="mobile"
+                {...(handlers?.onPressCaregiver ? { onPress: handlers.onPressCaregiver } : {})}
+              />
+            ))}
+          </YStack>
+
+          {/* Pending section */}
+          {pending.length > 0 && (
+            <>
+              <Text
+                tag="h2"
+                margin={0}
+                fontSize={11}
+                color="$colorMore"
+                textTransform="uppercase"
+                letterSpacing={0.88}
+                fontWeight="600"
+                paddingHorizontal={20}
+                paddingTop={14}
+                paddingBottom={8}
+                testID={
+                  pending.some((p) => p.stage === 'awaitingSeal')
+                    ? 'pending-seal-section'
+                    : undefined
+                }
+              >
+                {messages.sectionPending}
+              </Text>
+              <YStack
+                borderTopWidth={0.5}
+                borderTopColor="$borderColor"
+                borderBottomWidth={0.5}
+                borderBottomColor="$borderColor"
+              >
+                {pending.map((p) => {
+                  const primaryCta = pendingPrimaryCta?.(p) ?? null;
+                  const isAwaitingSeal = p.stage === 'awaitingSeal';
+                  return (
+                    <PendingRow
+                      key={p.token}
+                      invitation={p}
+                      roleLabel={messages.roleLabel[p.role]}
+                      stageLabel={pendingStageLabels[p.stage] ?? ''}
+                      resendCta={messages.resendCta}
+                      withdrawCta={messages.withdrawCta}
+                      {...(primaryCta !== null ? { primaryCta } : {})}
+                      mode="mobile"
+                      {...(isAwaitingSeal
+                        ? {
+                            rowTestID: `pending-seal-card-${p.token}`,
+                            primaryTestID: `seal-button-${p.token}`,
+                          }
+                        : {})}
+                      {...(handlers?.onPressResend ? { onResend: handlers.onPressResend } : {})}
+                      {...(handlers?.onPressWithdraw
+                        ? { onWithdraw: handlers.onPressWithdraw }
+                        : {})}
+                      {...(handlers?.onPressSeal ? { onPrimary: handlers.onPressSeal } : {})}
+                    />
+                  );
+                })}
+              </YStack>
+            </>
+          )}
+
+          <Stack paddingHorizontal={16} paddingVertical={20}>
+            <PermsTable messages={messages} />
+          </Stack>
+
+          <Text
+            fontSize={11}
+            color="$colorFaint"
+            textAlign="center"
+            paddingBottom={32}
+            fontStyle="italic"
+          >
+            {messages.notMedical}
+          </Text>
+        </Stack>
+      </YStack>
+    </Theme>
+  );
+}

--- a/packages/ui/src/components/caregivers/CaregiversListWeb.tsx
+++ b/packages/ui/src/components/caregivers/CaregiversListWeb.tsx
@@ -1,0 +1,269 @@
+import * as React from 'react';
+import { Stack, Text, Theme, XStack, YStack } from 'tamagui';
+
+import { CaregiverRow } from './CaregiverRow';
+import { CaregiversSidebar } from './CaregiversSidebar';
+import { InviteForm } from './InviteForm';
+import { PendingRow } from './PendingRow';
+import { PermsTable } from './PermsTable';
+import { PlusIcon } from './icons';
+import type {
+  CaregiverProfileView,
+  CaregiversListHandlers,
+  CaregiversListMessages,
+  CaregiversNavItem,
+  InviteFormHandlers,
+  InviteFormMessages,
+  InviteFormState,
+  PendingInvitationView,
+} from './types';
+
+export interface CaregiversListWebProps {
+  messages: CaregiversListMessages;
+  inviteMessages: InviteFormMessages;
+  caregivers: ReadonlyArray<CaregiverProfileView>;
+  pending: ReadonlyArray<PendingInvitationView>;
+  pendingStageLabels: Record<string, string>;
+  pendingPrimaryCta?: ((view: PendingInvitationView) => string | null) | undefined;
+  navItems: ReadonlyArray<CaregiversNavItem>;
+  /** État formulaire d'invitation contrôlé par l'app appelante. */
+  inviteState: InviteFormState;
+  onInviteChange: (patch: Partial<InviteFormState>) => void;
+  inviteSubmitDisabled?: boolean;
+  inviteHandlers?: InviteFormHandlers | undefined;
+  handlers?: CaregiversListHandlers | undefined;
+  theme?: 'kinhale_light' | 'kinhale_dark';
+}
+
+export function CaregiversListWeb({
+  messages,
+  inviteMessages,
+  caregivers,
+  pending,
+  pendingStageLabels,
+  pendingPrimaryCta,
+  navItems,
+  inviteState,
+  onInviteChange,
+  inviteSubmitDisabled = false,
+  inviteHandlers,
+  handlers,
+  theme = 'kinhale_light',
+}: CaregiversListWebProps): React.JSX.Element {
+  return (
+    <Theme name={theme}>
+      <Stack
+        position="absolute"
+        top={0}
+        right={0}
+        bottom={0}
+        left={0}
+        backgroundColor="$background"
+        overflow="hidden"
+        style={{ display: 'grid', gridTemplateColumns: '224px 1fr' }}
+      >
+        <CaregiversSidebar navItems={navItems} />
+
+        <YStack tag="main" minHeight={0} style={{ overflow: 'auto' }}>
+          {/* Header sticky */}
+          <XStack
+            paddingHorizontal={32}
+            paddingVertical={20}
+            alignItems="flex-end"
+            justifyContent="space-between"
+            borderBottomWidth={0.5}
+            borderBottomColor="$borderColor"
+            zIndex={5}
+            style={{
+              position: 'sticky',
+              top: 0,
+              background: 'color-mix(in oklch, var(--background) 90%, transparent)',
+              backdropFilter: 'blur(12px)',
+              WebkitBackdropFilter: 'blur(12px)',
+            }}
+          >
+            <YStack>
+              <Text
+                fontSize={11}
+                color="$colorMore"
+                textTransform="uppercase"
+                letterSpacing={1.1}
+                fontWeight="600"
+              >
+                {messages.childName}
+              </Text>
+              <Text
+                tag="h1"
+                margin={0}
+                fontFamily="$heading"
+                fontSize={28}
+                fontWeight="500"
+                letterSpacing={-0.56}
+                color="$color"
+                marginTop={2}
+              >
+                {messages.title}
+              </Text>
+              <Text fontSize={13} color="$colorMore" marginTop={4}>
+                {messages.subtitle}
+              </Text>
+            </YStack>
+
+            {handlers?.onPressInvite && (
+              <XStack
+                tag="button"
+                cursor="pointer"
+                backgroundColor="$maint"
+                borderWidth={0}
+                paddingHorizontal={16}
+                paddingVertical={9}
+                borderRadius={10}
+                alignItems="center"
+                gap={8}
+                accessibilityRole="button"
+                accessibilityLabel={messages.inviteCta}
+                testID="caregivers-invite-cta"
+                onPress={handlers.onPressInvite}
+                style={{
+                  boxShadow: '0 4px 12px color-mix(in oklch, var(--maint) 28%, transparent)',
+                }}
+              >
+                <Text color="white" display="flex" alignItems="center" justifyContent="center">
+                  <PlusIcon size={13} color="white" />
+                </Text>
+                <Text fontSize={13} fontWeight="600" color="white">
+                  {messages.inviteCta}
+                </Text>
+              </XStack>
+            )}
+          </XStack>
+
+          {/* Content : grid 1.3fr / 1fr */}
+          <Stack
+            paddingHorizontal={32}
+            paddingTop={24}
+            paddingBottom={48}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'minmax(0, 1.3fr) minmax(0, 1fr)',
+              gap: 24,
+            }}
+          >
+            {/* Left col : list + pending + perms */}
+            <YStack gap={18} minWidth={0}>
+              <YStack>
+                <Text
+                  tag="h2"
+                  margin={0}
+                  fontSize={11}
+                  color="$colorMore"
+                  textTransform="uppercase"
+                  letterSpacing={0.88}
+                  fontWeight="600"
+                  marginBottom={8}
+                >
+                  {messages.sectionActive}
+                </Text>
+                <YStack
+                  backgroundColor="$surface"
+                  borderRadius={16}
+                  borderWidth={0.5}
+                  borderColor="$borderColor"
+                  overflow="hidden"
+                >
+                  {caregivers.map((c) => (
+                    <CaregiverRow
+                      key={c.id}
+                      caregiver={c}
+                      youLabel={messages.youTag}
+                      onlineLabel={messages.onlineNow}
+                      roleLabel={messages.roleLabel[c.role]}
+                      mode="web"
+                      {...(handlers?.onPressCaregiver
+                        ? { onPress: handlers.onPressCaregiver }
+                        : {})}
+                    />
+                  ))}
+                </YStack>
+              </YStack>
+
+              {pending.length > 0 && (
+                <YStack>
+                  <Text
+                    tag="h2"
+                    margin={0}
+                    fontSize={11}
+                    color="$colorMore"
+                    textTransform="uppercase"
+                    letterSpacing={0.88}
+                    fontWeight="600"
+                    marginBottom={8}
+                    testID={
+                      pending.some((p) => p.stage === 'awaitingSeal')
+                        ? 'pending-seal-section'
+                        : undefined
+                    }
+                  >
+                    {messages.sectionPending}
+                  </Text>
+                  <YStack
+                    borderRadius={16}
+                    borderWidth={0.5}
+                    borderColor="$borderColor"
+                    overflow="hidden"
+                  >
+                    {pending.map((p) => {
+                      const primaryCta = pendingPrimaryCta?.(p) ?? null;
+                      const isAwaitingSeal = p.stage === 'awaitingSeal';
+                      return (
+                        <PendingRow
+                          key={p.token}
+                          invitation={p}
+                          roleLabel={messages.roleLabel[p.role]}
+                          stageLabel={pendingStageLabels[p.stage] ?? ''}
+                          resendCta={messages.resendCta}
+                          withdrawCta={messages.withdrawCta}
+                          {...(primaryCta !== null ? { primaryCta } : {})}
+                          mode="web"
+                          {...(isAwaitingSeal
+                            ? {
+                                rowTestID: `pending-seal-card-${p.token}`,
+                                primaryTestID: `seal-button-${p.token}`,
+                              }
+                            : {})}
+                          {...(handlers?.onPressResend ? { onResend: handlers.onPressResend } : {})}
+                          {...(handlers?.onPressWithdraw
+                            ? { onWithdraw: handlers.onPressWithdraw }
+                            : {})}
+                          {...(handlers?.onPressSeal ? { onPrimary: handlers.onPressSeal } : {})}
+                        />
+                      );
+                    })}
+                  </YStack>
+                </YStack>
+              )}
+
+              <PermsTable messages={messages} />
+
+              <Text fontSize={11} color="$colorFaint" textAlign="center" fontStyle="italic">
+                {messages.notMedical}
+              </Text>
+            </YStack>
+
+            {/* Right col : invite form */}
+            <YStack minWidth={0}>
+              <InviteForm
+                messages={inviteMessages}
+                state={inviteState}
+                onChange={onInviteChange}
+                submitDisabled={inviteSubmitDisabled}
+                mode="web"
+                {...(inviteHandlers ? { handlers: inviteHandlers } : {})}
+              />
+            </YStack>
+          </Stack>
+        </YStack>
+      </Stack>
+    </Theme>
+  );
+}

--- a/packages/ui/src/components/caregivers/CaregiversSidebar.tsx
+++ b/packages/ui/src/components/caregivers/CaregiversSidebar.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { BrandIcon } from '../auth/icons';
+import type { CaregiversNavItem } from './types';
+
+export interface CaregiversSidebarProps {
+  navItems: ReadonlyArray<CaregiversNavItem>;
+  brandLabel?: string;
+}
+
+/**
+ * Sidebar 224 px de la page Aidants. Pattern identique aux autres
+ * sidebars du dashboard (PumpsSidebar, HistorySidebar) — duplication
+ * volontaire pour rester strictement présentationnel.
+ */
+export function CaregiversSidebar({
+  navItems,
+  brandLabel = 'Kinhale',
+}: CaregiversSidebarProps): React.JSX.Element {
+  return (
+    <YStack
+      tag="aside"
+      borderRightWidth={0.5}
+      borderRightColor="$borderColor"
+      paddingHorizontal={14}
+      paddingVertical={20}
+      gap={4}
+      backgroundColor="$surface"
+      style={{ overflow: 'auto' }}
+    >
+      <XStack alignItems="center" gap={10} paddingHorizontal={8} paddingTop={4} paddingBottom={18}>
+        <Stack
+          width={28}
+          height={28}
+          borderRadius={8}
+          backgroundColor="$maint"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <BrandIcon size={15} color="#ffffff" />
+        </Stack>
+        <Text
+          fontFamily="$heading"
+          fontSize={17}
+          fontWeight="600"
+          letterSpacing={-0.17}
+          color="$color"
+        >
+          {brandLabel}
+        </Text>
+      </XStack>
+
+      {navItems.map((item) => (
+        <XStack
+          key={item.key}
+          tag="button"
+          paddingHorizontal={10}
+          paddingVertical={9}
+          borderRadius={8}
+          backgroundColor={item.active ? '$surface2' : 'transparent'}
+          cursor="pointer"
+          alignItems="center"
+          gap={10}
+          borderWidth={0}
+          hoverStyle={{ backgroundColor: '$surface2' }}
+          {...(item.onPress ? { onPress: item.onPress } : {})}
+          accessibilityRole="link"
+          accessibilityLabel={item.label}
+        >
+          <Stack
+            width={6}
+            height={6}
+            borderRadius={3}
+            backgroundColor={item.active ? '$maint' : '$borderColorStrong'}
+          />
+          <Text
+            fontSize={13.5}
+            fontWeight={item.active ? '600' : '500'}
+            color={item.active ? '$color' : '$colorMuted'}
+            fontFamily="$body"
+          >
+            {item.label}
+          </Text>
+        </XStack>
+      ))}
+    </YStack>
+  );
+}

--- a/packages/ui/src/components/caregivers/InviteForm.tsx
+++ b/packages/ui/src/components/caregivers/InviteForm.tsx
@@ -1,0 +1,259 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { EnvelopeIcon } from './icons';
+import type {
+  CaregiverRole,
+  InviteFormHandlers,
+  InviteFormMessages,
+  InviteFormState,
+} from './types';
+
+const inputBaseStyle: React.CSSProperties = {
+  appearance: 'none',
+  width: '100%',
+  padding: '10px 12px',
+  borderRadius: 10,
+  border: '1px solid var(--borderColorStrong)',
+  background: 'var(--background)',
+  color: 'var(--color)',
+  fontSize: 14,
+  fontFamily: 'inherit',
+  outline: 'none',
+  boxSizing: 'border-box',
+};
+
+const ROLES: ReadonlyArray<CaregiverRole> = ['admin', 'contributor', 'restricted'];
+
+const ROLE_HUE: Record<CaregiverRole, number> = {
+  admin: 235,
+  contributor: 200,
+  restricted: 145,
+};
+
+export interface InviteFormProps {
+  messages: InviteFormMessages;
+  state: InviteFormState;
+  onChange: (patch: Partial<InviteFormState>) => void;
+  /** Si fourni, désactive le bouton Envoyer (ex. offline guard, validation). */
+  submitDisabled?: boolean;
+  /** Mode visuel : `web` => card 18 r ; `mobile` => 16 r réduit. */
+  mode?: 'mobile' | 'web';
+  handlers?: InviteFormHandlers | undefined;
+  /** Permet de masquer certains rôles (ex. seul un admin peut promouvoir admin). */
+  availableRoles?: ReadonlyArray<CaregiverRole>;
+}
+
+export function InviteForm({
+  messages,
+  state,
+  onChange,
+  submitDisabled = false,
+  mode = 'web',
+  handlers,
+  availableRoles = ROLES,
+}: InviteFormProps): React.JSX.Element {
+  const visibleRoles = ROLES.filter((r) => availableRoles.includes(r));
+
+  return (
+    <YStack
+      backgroundColor="$surface"
+      borderRadius={mode === 'web' ? 18 : 16}
+      borderWidth={0.5}
+      borderColor="$borderColor"
+      padding={mode === 'web' ? 24 : 18}
+      gap={16}
+    >
+      <YStack>
+        <Text
+          tag="h2"
+          margin={0}
+          fontFamily="$heading"
+          fontSize={mode === 'web' ? 18 : 16}
+          fontWeight="500"
+          letterSpacing={-0.18}
+          color="$color"
+        >
+          {messages.title}
+        </Text>
+        <Text fontSize={12.5} color="$colorMore" marginTop={4} lineHeight={18}>
+          {messages.subtitle}
+        </Text>
+      </YStack>
+
+      <Stack
+        style={{
+          display: 'grid',
+          gridTemplateColumns: mode === 'web' ? '1fr 1fr' : '1fr',
+          gap: 12,
+        }}
+      >
+        <YStack gap={6}>
+          <Text
+            tag="label"
+            fontSize={11}
+            color="$colorMore"
+            textTransform="uppercase"
+            letterSpacing={0.66}
+            fontWeight="600"
+            htmlFor="invite-name"
+          >
+            {messages.nameLabel}
+          </Text>
+          <input
+            id="invite-name"
+            type="text"
+            value={state.name}
+            placeholder={messages.namePlaceholder}
+            onChange={(e) => onChange({ name: e.target.value })}
+            style={inputBaseStyle}
+          />
+        </YStack>
+        <YStack gap={6}>
+          <Text
+            tag="label"
+            fontSize={11}
+            color="$colorMore"
+            textTransform="uppercase"
+            letterSpacing={0.66}
+            fontWeight="600"
+            htmlFor="invite-email"
+          >
+            {messages.emailLabel}
+          </Text>
+          <input
+            id="invite-email"
+            type="email"
+            value={state.email}
+            placeholder={messages.emailPlaceholder}
+            onChange={(e) => onChange({ email: e.target.value })}
+            style={inputBaseStyle}
+          />
+        </YStack>
+      </Stack>
+
+      <YStack>
+        <Text
+          fontSize={11}
+          color="$colorMore"
+          textTransform="uppercase"
+          letterSpacing={0.66}
+          fontWeight="600"
+          marginBottom={8}
+        >
+          {messages.chooseRoleLabel}
+        </Text>
+        <YStack gap={8}>
+          {visibleRoles.map((r) => {
+            const sel = state.role === r;
+            const hue = ROLE_HUE[r];
+            const accent = `oklch(40% 0.12 ${hue})`;
+            return (
+              <Stack
+                key={r}
+                tag="button"
+                cursor="pointer"
+                paddingHorizontal={14}
+                paddingVertical={12}
+                borderRadius={12}
+                borderWidth={1.5}
+                alignItems="stretch"
+                onPress={() => onChange({ role: r })}
+                accessibilityRole="radio"
+                accessibilityState={{ checked: sel }}
+                accessibilityLabel={messages.roleLabel[r]}
+                style={{
+                  borderColor: sel ? accent : 'var(--borderColorStrong)',
+                  background: sel
+                    ? `color-mix(in oklch, ${accent} 8%, var(--surface))`
+                    : 'var(--background)',
+                }}
+              >
+                <XStack alignItems="center" gap={12}>
+                  <Stack
+                    width={18}
+                    height={18}
+                    borderRadius={9}
+                    borderWidth={1.5}
+                    alignItems="center"
+                    justifyContent="center"
+                    flexShrink={0}
+                    style={{
+                      borderColor: sel ? accent : 'var(--borderColorStrong)',
+                      background: sel ? accent : 'transparent',
+                    }}
+                  >
+                    {sel && (
+                      <Stack width={7} height={7} borderRadius={4} backgroundColor="$background" />
+                    )}
+                  </Stack>
+                  <YStack flex={1}>
+                    <Text fontSize={13.5} fontWeight="600" color="$color" textAlign="left">
+                      {messages.roleLabel[r]}
+                    </Text>
+                    <Text fontSize={11.5} color="$colorMore" marginTop={2} textAlign="left">
+                      {messages.roleDescription[r]}
+                    </Text>
+                  </YStack>
+                </XStack>
+              </Stack>
+            );
+          })}
+        </YStack>
+      </YStack>
+
+      <XStack gap={10} justifyContent="flex-end" marginTop={4}>
+        {handlers?.onCancel && (
+          <Stack
+            tag="button"
+            cursor="pointer"
+            paddingHorizontal={16}
+            paddingVertical={10}
+            borderRadius={10}
+            borderWidth={0.5}
+            borderColor="$borderColorStrong"
+            backgroundColor="$surface"
+            accessibilityRole="button"
+            accessibilityLabel={messages.cancelCta}
+            onPress={handlers.onCancel}
+          >
+            <Text fontSize={13.5} fontWeight="500" color="$colorMuted">
+              {messages.cancelCta}
+            </Text>
+          </Stack>
+        )}
+        <Stack
+          tag="button"
+          cursor={submitDisabled ? 'not-allowed' : 'pointer'}
+          paddingHorizontal={18}
+          paddingVertical={10}
+          borderRadius={10}
+          borderWidth={0}
+          backgroundColor="$maint"
+          opacity={submitDisabled ? 0.5 : 1}
+          flexDirection="row"
+          alignItems="center"
+          gap={8}
+          disabled={submitDisabled}
+          accessibilityRole="button"
+          accessibilityLabel={messages.sendCta}
+          {...(submitDisabled || handlers?.onSubmit === undefined
+            ? {}
+            : { onPress: () => handlers.onSubmit?.(state) })}
+          style={{
+            boxShadow: submitDisabled
+              ? 'none'
+              : '0 4px 12px color-mix(in oklch, var(--maint) 28%, transparent)',
+          }}
+        >
+          <Text color="white" display="flex" alignItems="center" justifyContent="center">
+            <EnvelopeIcon size={13} color="white" />
+          </Text>
+          <Text fontSize={13.5} fontWeight="600" color="white">
+            {messages.sendCta}
+          </Text>
+        </Stack>
+      </XStack>
+    </YStack>
+  );
+}

--- a/packages/ui/src/components/caregivers/PendingRow.tsx
+++ b/packages/ui/src/components/caregivers/PendingRow.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { Avatar } from './Avatar';
+import { EnvelopeIcon } from './icons';
+import { RolePill } from './RolePill';
+import type { PendingInvitationView } from './types';
+
+export interface PendingRowProps {
+  invitation: PendingInvitationView;
+  /** Libellé localisé du rôle. */
+  roleLabel: string;
+  /** Phrase localisée décrivant le stade (« Envoyée le X · en attente de … »). */
+  stageLabel: string;
+  resendCta: string;
+  withdrawCta: string;
+  /** CTA principal contextuel : sceller, accepter, etc. (optionnel). */
+  primaryCta?: string | undefined;
+  mode?: 'mobile' | 'web';
+  /** testID optionnel posé sur la ligne (utile pour les tests Jest). */
+  rowTestID?: string | undefined;
+  /** testID optionnel posé sur le bouton primaire (ex. « Finaliser »). */
+  primaryTestID?: string | undefined;
+  onResend?: ((token: string) => void) | undefined;
+  onWithdraw?: ((token: string) => void) | undefined;
+  onPrimary?: ((token: string) => void) | undefined;
+}
+
+export function PendingRow({
+  invitation,
+  roleLabel,
+  stageLabel,
+  resendCta,
+  withdrawCta,
+  primaryCta,
+  mode = 'mobile',
+  rowTestID,
+  primaryTestID,
+  onResend,
+  onWithdraw,
+  onPrimary,
+}: PendingRowProps): React.JSX.Element {
+  return (
+    <XStack
+      alignItems="center"
+      gap={14}
+      paddingHorizontal={mode === 'web' ? 16 : 14}
+      paddingVertical={mode === 'web' ? 14 : 12}
+      borderBottomWidth={0.5}
+      borderBottomColor="$borderColor"
+      {...(rowTestID !== undefined ? { testID: rowTestID } : {})}
+      style={{
+        background: 'color-mix(in oklch, var(--amber) 4%, var(--surface))',
+      }}
+    >
+      <Avatar initials={invitation.initials} hue={invitation.hue} size={40} pending />
+      <YStack flex={1} minWidth={0}>
+        <XStack alignItems="center" gap={8} flexWrap="wrap">
+          <Text fontSize={14.5} fontWeight="500" color="$colorMuted">
+            {invitation.name}
+          </Text>
+          <RolePill role={invitation.role} label={roleLabel} compact />
+        </XStack>
+        <XStack alignItems="center" gap={5} marginTop={2}>
+          <Text color="$amberInk" display="flex" alignItems="center" justifyContent="center">
+            <EnvelopeIcon size={11} color="currentColor" />
+          </Text>
+          <Text fontSize={11.5} color="$amberInk">
+            {invitation.email !== undefined && invitation.email !== ''
+              ? `${invitation.email} · ${stageLabel}`
+              : stageLabel}
+          </Text>
+        </XStack>
+      </YStack>
+      {primaryCta !== undefined && primaryCta !== '' && onPrimary && (
+        <Stack
+          tag="button"
+          cursor="pointer"
+          backgroundColor="$maint"
+          paddingHorizontal={12}
+          paddingVertical={6}
+          borderRadius={99}
+          borderWidth={0}
+          accessibilityRole="button"
+          accessibilityLabel={primaryCta}
+          {...(primaryTestID !== undefined ? { testID: primaryTestID } : {})}
+          onPress={() => onPrimary(invitation.token)}
+        >
+          <Text fontSize={12} fontWeight="600" color="white">
+            {primaryCta}
+          </Text>
+        </Stack>
+      )}
+      <Stack
+        tag="button"
+        cursor="pointer"
+        backgroundColor="$surface"
+        borderWidth={0.5}
+        borderColor="$borderColorStrong"
+        paddingHorizontal={12}
+        paddingVertical={6}
+        borderRadius={99}
+        accessibilityRole="button"
+        accessibilityLabel={resendCta}
+        {...(onResend ? { onPress: () => onResend(invitation.token) } : {})}
+      >
+        <Text fontSize={12} fontWeight="500" color="$colorMuted">
+          {resendCta}
+        </Text>
+      </Stack>
+      <Stack
+        tag="button"
+        cursor="pointer"
+        backgroundColor="transparent"
+        borderWidth={0}
+        paddingHorizontal={8}
+        paddingVertical={6}
+        accessibilityRole="button"
+        accessibilityLabel={withdrawCta}
+        {...(onWithdraw ? { onPress: () => onWithdraw(invitation.token) } : {})}
+      >
+        <Text fontSize={12} fontWeight="500" color="$colorMore">
+          {withdrawCta}
+        </Text>
+      </Stack>
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/caregivers/PermsTable.tsx
+++ b/packages/ui/src/components/caregivers/PermsTable.tsx
@@ -1,0 +1,135 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { ShieldIcon } from './icons';
+import type { CaregiverRole, CaregiversListMessages } from './types';
+
+const ROLE_HUE: Record<CaregiverRole, number> = {
+  admin: 235,
+  contributor: 200,
+  restricted: 145,
+};
+
+export interface PermsTableProps {
+  messages: Pick<
+    CaregiversListMessages,
+    | 'permissionsTitle'
+    | 'permission1'
+    | 'permission2'
+    | 'permission3'
+    | 'permission4'
+    | 'permission5'
+    | 'permYes'
+    | 'permNo'
+    | 'roleLabel'
+  >;
+}
+
+const MATRIX: ReadonlyArray<{
+  key: keyof Pick<
+    CaregiversListMessages,
+    'permission1' | 'permission2' | 'permission3' | 'permission4' | 'permission5'
+  >;
+  admin: boolean;
+  contributor: boolean;
+  restricted: boolean;
+}> = [
+  { key: 'permission1', admin: true, contributor: true, restricted: true },
+  { key: 'permission2', admin: true, contributor: true, restricted: true },
+  { key: 'permission3', admin: true, contributor: true, restricted: false },
+  { key: 'permission4', admin: true, contributor: false, restricted: false },
+  { key: 'permission5', admin: true, contributor: true, restricted: false },
+];
+
+const ROLES: ReadonlyArray<CaregiverRole> = ['admin', 'contributor', 'restricted'];
+
+export function PermsTable({ messages }: PermsTableProps): React.JSX.Element {
+  return (
+    <YStack
+      backgroundColor="$surface"
+      borderRadius={16}
+      borderWidth={0.5}
+      borderColor="$borderColor"
+      overflow="hidden"
+    >
+      <XStack
+        alignItems="center"
+        gap={8}
+        paddingHorizontal={16}
+        paddingVertical={14}
+        borderBottomWidth={0.5}
+        borderBottomColor="$borderColor"
+      >
+        <Text color="$colorMuted" display="flex" alignItems="center" justifyContent="center">
+          <ShieldIcon size={13} color="currentColor" />
+        </Text>
+        <Text fontSize={13} fontWeight="600" color="$color">
+          {messages.permissionsTitle}
+        </Text>
+      </XStack>
+      <Stack
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 70px 70px 70px',
+        }}
+      >
+        <Stack paddingHorizontal={16} paddingVertical={10} />
+        {ROLES.map((r) => (
+          <Stack
+            key={r}
+            paddingHorizontal={6}
+            paddingVertical={10}
+            alignItems="center"
+            justifyContent="center"
+          >
+            <Text
+              fontSize={10}
+              fontWeight="700"
+              textTransform="uppercase"
+              letterSpacing={0.6}
+              style={{ color: `oklch(40% 0.12 ${ROLE_HUE[r]})` }}
+            >
+              {messages.roleLabel[r].split(' ')[0]}
+            </Text>
+          </Stack>
+        ))}
+        {MATRIX.map((row) => (
+          <React.Fragment key={row.key}>
+            <Stack
+              paddingHorizontal={16}
+              paddingVertical={10}
+              borderTopWidth={0.5}
+              borderTopColor="$borderColor"
+            >
+              <Text fontSize={12} color="$colorMuted">
+                {messages[row.key]}
+              </Text>
+            </Stack>
+            {ROLES.map((r) => {
+              const ok = row[r];
+              return (
+                <Stack
+                  key={r}
+                  paddingHorizontal={6}
+                  paddingVertical={10}
+                  alignItems="center"
+                  justifyContent="center"
+                  borderTopWidth={0.5}
+                  borderTopColor="$borderColor"
+                >
+                  <Text
+                    fontSize={12}
+                    fontWeight={ok ? '700' : '400'}
+                    color={ok ? '$ok' : '$colorFaint'}
+                  >
+                    {ok ? messages.permYes : messages.permNo}
+                  </Text>
+                </Stack>
+              );
+            })}
+          </React.Fragment>
+        ))}
+      </Stack>
+    </YStack>
+  );
+}

--- a/packages/ui/src/components/caregivers/RolePill.tsx
+++ b/packages/ui/src/components/caregivers/RolePill.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { Text, XStack } from 'tamagui';
+
+import { ShieldIcon } from './icons';
+import type { CaregiverRole } from './types';
+
+const ROLE_HUE_DEG: Record<CaregiverRole, number> = {
+  admin: 235, // maint slate-blue
+  contributor: 200, // teal
+  restricted: 145, // green
+};
+
+export interface RolePillProps {
+  role: CaregiverRole;
+  label: string;
+  /** Padding réduit pour les listes mobiles. */
+  compact?: boolean;
+}
+
+export function RolePill({ role, label, compact = false }: RolePillProps): React.JSX.Element {
+  const hue = ROLE_HUE_DEG[role];
+  // Couleurs dérivées du hue via `oklch` — résolues en runtime via style
+  // natif, car Tamagui ne supporte pas l'interpolation d'oklch côté props.
+  const fg = `oklch(40% 0.12 ${hue})`;
+  const bg = `oklch(95% 0.04 ${hue})`;
+  const border = `oklch(85% 0.06 ${hue})`;
+  return (
+    <XStack
+      alignItems="center"
+      gap={5}
+      paddingHorizontal={compact ? 8 : 10}
+      paddingVertical={compact ? 2 : 3}
+      borderRadius={99}
+      borderWidth={0.5}
+      style={{ background: bg, borderColor: border }}
+    >
+      <Text style={{ color: fg }} display="flex" alignItems="center" justifyContent="center">
+        <ShieldIcon size={10} color="currentColor" />
+      </Text>
+      <Text fontSize={11} fontWeight="600" style={{ color: fg }}>
+        {label}
+      </Text>
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/caregivers/icons.tsx
+++ b/packages/ui/src/components/caregivers/icons.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+
+interface IconProps {
+  size?: number;
+  color?: string;
+}
+
+const baseStroke = {
+  fill: 'none' as const,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+};
+
+export function PlusIcon({ size = 14, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.8"
+    >
+      <path d="M7 2v10M2 7h10" />
+    </svg>
+  );
+}
+
+export function ShieldIcon({ size = 14, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.5"
+    >
+      <path d="M7 1.5L2 3v3.5c0 3 2.5 5.5 5 6 2.5-.5 5-3 5-6V3L7 1.5z" />
+    </svg>
+  );
+}
+
+export function MoreIcon({ size = 16, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg width={size} height={size} viewBox="0 0 16 16" fill={color}>
+      <circle cx="3.5" cy="8" r="1.4" />
+      <circle cx="8" cy="8" r="1.4" />
+      <circle cx="12.5" cy="8" r="1.4" />
+    </svg>
+  );
+}
+
+export function EnvelopeIcon({ size = 14, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.5"
+    >
+      <rect x="2" y="3" width="10" height="8" rx="1.5" />
+      <path d="M2.5 4l4.5 3.5L11.5 4" />
+    </svg>
+  );
+}

--- a/packages/ui/src/components/caregivers/index.ts
+++ b/packages/ui/src/components/caregivers/index.ts
@@ -1,0 +1,45 @@
+export { Avatar } from './Avatar';
+export type { AvatarProps } from './Avatar';
+
+export { CaregiverRow } from './CaregiverRow';
+export type { CaregiverRowProps } from './CaregiverRow';
+
+export { CaregiversListMobile } from './CaregiversListMobile';
+export type { CaregiversListMobileProps } from './CaregiversListMobile';
+
+export { CaregiversListWeb } from './CaregiversListWeb';
+export type { CaregiversListWebProps } from './CaregiversListWeb';
+
+export { CaregiversSidebar } from './CaregiversSidebar';
+export type { CaregiversSidebarProps } from './CaregiversSidebar';
+
+export { InviteForm } from './InviteForm';
+export type { InviteFormProps } from './InviteForm';
+
+export { PendingRow } from './PendingRow';
+export type { PendingRowProps } from './PendingRow';
+
+export { PermsTable } from './PermsTable';
+export type { PermsTableProps } from './PermsTable';
+
+export { RolePill } from './RolePill';
+export type { RolePillProps } from './RolePill';
+
+// `CaregiverRole` est délibérément non re-exporté ici : le module
+// `home` exporte déjà ce type (même union `'admin' | 'contributor' |
+// 'restricted'`) et la dé-duplication via `export *` côté `src/index.ts`
+// causerait une ambiguïté TS. Les consommateurs font
+// `import type { CaregiverRole } from '@kinhale/ui/home'` ou
+// `from '@kinhale/ui/caregivers/types'` selon leur point d'entrée.
+export type {
+  CaregiverPresence,
+  CaregiverProfileView,
+  CaregiversListHandlers,
+  CaregiversListMessages,
+  CaregiversNavItem,
+  InviteFormHandlers,
+  InviteFormMessages,
+  InviteFormState,
+  PendingInvitationStage,
+  PendingInvitationView,
+} from './types';

--- a/packages/ui/src/components/caregivers/types.ts
+++ b/packages/ui/src/components/caregivers/types.ts
@@ -1,0 +1,139 @@
+// Types présentationnels pour les écrans Aidants (clinical-calm v2).
+// Les composants sont purement présentationnels : ils reçoivent des
+// props localisées et déjà mappées depuis `projectCaregivers` côté app.
+
+/**
+ * Rôle du foyer affiché dans les pastilles `RolePill` et la matrice de
+ * permissions. Mappé côté app depuis le rôle interne (`admin`,
+ * `contributor`, `restricted_contributor`).
+ */
+export type CaregiverRole = 'admin' | 'contributor' | 'restricted';
+
+/**
+ * Statut visuel d'un aidant dans la liste « actifs ». La couche app
+ * dérive ce champ depuis le statut Automerge + l'éventuel suivi de
+ * connexion.
+ */
+export type CaregiverPresence = 'online' | 'offline';
+
+export interface CaregiverProfileView {
+  id: string;
+  /** Nom complet ou pseudonyme du foyer. */
+  name: string;
+  /** Initiales calculées côté app, ex. « ST ». */
+  initials: string;
+  /** Lien familial déjà localisé (« Parent », « Garderie »…). */
+  relation: string;
+  role: CaregiverRole;
+  email?: string | undefined;
+  presence: CaregiverPresence;
+  /** Libellé localisé « Vu·e il y a 12 min ». Optionnel si présence==='online'. */
+  lastSeenLabel?: string | undefined;
+  /** Vrai pour l'aidant courant — ajoute la pastille « Vous ». */
+  isYou?: boolean;
+  /**
+   * Hue (0-360) calculé côté app pour produire un avatar déterministe
+   * basé sur `oklch(85% 0.06 hue)`. La pastille reste cohérente d'une
+   * session à l'autre pour le même `id`.
+   */
+  hue: number;
+}
+
+export type PendingInvitationStage =
+  | 'awaitingRecipient' // pending_acceptance — l'invité n'a pas encore ouvert le lien
+  | 'awaitingSeal' // pending_sealing — pubkey reçue, l'admin doit sceller
+  | 'sealedWaiting'; // sealed_waiting — sealé, l'invité doit accepter
+
+export interface PendingInvitationView {
+  /** Token court d'invitation (utilisé pour resend / revoke). */
+  token: string;
+  /** Nom affiché par l'admin lors de la création. */
+  name: string;
+  initials: string;
+  email?: string | undefined;
+  role: CaregiverRole;
+  stage: PendingInvitationStage;
+  /** Date d'envoi déjà formatée (ex. « 24 avril »). */
+  sentLabel: string;
+  hue: number;
+}
+
+// ── Sidebar (réutilisée) ────────────────────────────────────────────────
+
+export interface CaregiversNavItem {
+  key: string;
+  label: string;
+  active?: boolean;
+  onPress?: (() => void) | undefined;
+}
+
+// ── Messages ────────────────────────────────────────────────────────────
+
+export interface CaregiversListMessages {
+  childName: string;
+  title: string;
+  /** Sous-titre formaté avec le nombre, ex. « 5 personnes ont accès au profil ». */
+  subtitle: string;
+  inviteCta: string;
+  inviteShort: string;
+  sectionActive: string;
+  sectionPending: string;
+  youTag: string;
+  onlineNow: string;
+  /** Rôles localisés. */
+  roleLabel: Record<CaregiverRole, string>;
+  roleDescription: Record<CaregiverRole, string>;
+  /** Boutons sur les rangées en attente. */
+  resendCta: string;
+  withdrawCta: string;
+  /** Phrases pour chaque stade d'invitation. */
+  stageAwaitingRecipient: string;
+  stageAwaitingSeal: string;
+  stageSealedWaiting: string;
+  /** Permissions panel. */
+  permissionsTitle: string;
+  permission1: string;
+  permission2: string;
+  permission3: string;
+  permission4: string;
+  permission5: string;
+  permYes: string;
+  permNo: string;
+  notMedical: string;
+}
+
+export interface CaregiversListHandlers {
+  onPressInvite?: (() => void) | undefined;
+  onPressCaregiver?: ((id: string) => void) | undefined;
+  onPressResend?: ((token: string) => void) | undefined;
+  onPressWithdraw?: ((token: string) => void) | undefined;
+  /** Action principale sur un pending : « finaliser » (sceller). */
+  onPressSeal?: ((token: string) => void) | undefined;
+}
+
+// ── Invite form ──────────────────────────────────────────────────────────
+
+export interface InviteFormState {
+  name: string;
+  email: string;
+  role: CaregiverRole;
+}
+
+export interface InviteFormMessages {
+  title: string;
+  subtitle: string;
+  nameLabel: string;
+  namePlaceholder: string;
+  emailLabel: string;
+  emailPlaceholder: string;
+  chooseRoleLabel: string;
+  roleLabel: Record<CaregiverRole, string>;
+  roleDescription: Record<CaregiverRole, string>;
+  cancelCta: string;
+  sendCta: string;
+}
+
+export interface InviteFormHandlers {
+  onCancel?: (() => void) | undefined;
+  onSubmit?: ((state: InviteFormState) => void) | undefined;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,3 +5,4 @@ export * from './components/home';
 export * from './components/onboarding';
 export * from './components/pumps';
 export * from './components/history';
+export * from './components/caregivers';


### PR DESCRIPTION
## Summary

Refonte des deux pages liées à la **gestion des aidants du foyer** pour matcher la maquette clinical-calm.

### Layout web
- Sidebar 224 px + header sticky avec eyebrow LÉA + h1 « Aidants » + bouton **« + Inviter un aidant »**
- Grid 2 colonnes : **liste aidants + invitations en attente + matrice de permissions** à gauche, **formulaire d'invitation** à droite

### Layout mobile
- Header h1 + bouton **« + Inviter »** pill, sections empilées

### CaregiverRow
- Avatar coloré déterministe (oklch hue dérivé du `caregiverId`) + dot vert si en ligne
- Pastille « Vous » pour l'aidant courant
- Pastille **rôle** (Admin / Co-parent / Garderie · grand-parent) avec icône bouclier et 3 hues distincts

### PendingRow — 3 stades RM21 / KIN-096
- `awaitingRecipient` : l'invité n'a pas encore ouvert le lien
- `awaitingSeal` : pubkey reçue, l'admin doit sceller (CTA **« Finaliser »**)
- `sealedWaiting` : sealé, en attente d'acceptation
- Avatar pointillé ambre + libellé contextualisé

### PermsTable
Matrice 5 lignes × 3 rôles avec ✓ / — coloré.

### InviteForm
- Prénom + email sur 2 colonnes (web) / 1 (mobile)
- 3 rôles en cards radio avec description
- CTA **« Envoyer l'invitation »** avec icône enveloppe

## Architecture

- 9 composants exposés via `@kinhale/ui/caregivers` (CaregiversListWeb/Mobile, CaregiverRow, PendingRow, PermsTable, InviteForm, Avatar, RolePill, CaregiversSidebar)
- `CaregiverProfileView` (renommé pour éviter le conflit avec `home.CaregiverView`)
- Helpers `apps/web/src/lib/caregivers/messages.ts`
- Refactor des routes `/caregivers/page.tsx` et `/caregivers/invite/page.tsx`
- **Toute la logique X25519 sealing préservée intacte** (KIN-096) — handleSeal / handleRevoke / refresh / QR generation
- Le flux QR code + PIN + expiry + copy lien est conservé sur la page invite

## Conformité

- ✅ **WCAG 2.1 AA** : `<h1>` + `<h2>` natifs, `accessibilityRole="radio"` + `accessibilityState` sur les radios rôles, `accessibilityLabel` partout
- ✅ **TypeScript strict** : aucun `any`, exactOptionalPropertyTypes
- ✅ **i18n FR + EN** : section `caregivers.*` complète, aucune chaîne hardcodée
- ✅ **Tokens design system** : `\$maint`, `\$amberSoft`, `\$rescueSoft`, `\$ok`, `\$borderColor` ; couleurs de rôle en oklch (3 hues distincts)
- ✅ **Tests préservés** : 209 web + 95 mobile
- ✅ **testIDs `pending-seal-section` et `seal-button-{token}` conservés** pour la regression KIN-096

## Test plan

- [ ] `pnpm typecheck` ✓ (10/10 packages)
- [ ] `pnpm lint` ✓ (10/10 packages)
- [ ] `pnpm format:check` ✓
- [ ] `pnpm test` ✓ (209 web + 95 mobile)
- [ ] Vérification visuelle desktop : `/caregivers` affiche sidebar + liste + invitations en attente + matrice de permissions + formulaire à droite
- [ ] Mobile : layout vertical avec sections empilées
- [ ] Cliquer sur **« + Inviter »** → navigue vers `/caregivers/invite`
- [ ] **Pré-remplissage** : si on clique « Renvoyer » sur un pending, on arrive sur `/caregivers/invite?resend=…`
- [ ] **Création d'invitation** : nom + rôle + envoyer → QR code + PIN + bouton « Copier le lien »
- [ ] **Garde-fou hors-ligne** : message d'avertissement + bouton désactivé
- [ ] **Sealing X25519** (KIN-096) : section « Invitations en attente » avec aidant en attente de finalisation, bouton « Finaliser » → `sealedBoxEncrypt` + `sealInvitation`
- [ ] **Retirer** une invitation pending → `revokeInvitation` + refresh
- [ ] FR ↔ EN : changer la langue traduit toutes les chaînes (rôles, stades, permissions, formulaire)

## Hors scope (futurs tickets)

- État de présence en ligne/hors ligne en temps réel (WS presence)
- Promotion Admin / transfert de rôle après acceptation
- Page de détail d'un aidant (drill-in) — la maquette ne la définit pas

🤖 Generated with [Claude Code](https://claude.com/claude-code)