### PR TITLE
feat(ui,web,i18n): hub Réglages clinical-calm (KIN-114)

### DIFF
--- a/apps/web/src/app/caregivers/page.tsx
+++ b/apps/web/src/app/caregivers/page.tsx
@@ -177,7 +177,7 @@ export default function CaregiversPage(): React.JSX.Element | null {
       {
         key: 'settings',
         label: t('pumps.nav.settings'),
-        onPress: () => router.push('/settings/notifications'),
+        onPress: () => router.push('/settings'),
       },
     ],
     [router, t],

--- a/apps/web/src/app/journal/page.tsx
+++ b/apps/web/src/app/journal/page.tsx
@@ -111,7 +111,7 @@ export default function JournalPage(): React.JSX.Element | null {
       {
         key: 'settings',
         label: t('pumps.nav.settings'),
-        onPress: () => router.push('/settings/notifications'),
+        onPress: () => router.push('/settings'),
       },
     ],
     [router, t],

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -80,7 +80,7 @@ export default function HomePage(): React.JSX.Element | null {
       {
         key: 'settings',
         label: t('home.dashboard.nav.settings'),
-        onPress: () => router.push('/settings/notifications'),
+        onPress: () => router.push('/settings'),
       },
     ],
     [router, t],

--- a/apps/web/src/app/pumps/page.tsx
+++ b/apps/web/src/app/pumps/page.tsx
@@ -82,7 +82,7 @@ export default function PumpsListPage(): React.JSX.Element | null {
       {
         key: 'settings',
         label: t('pumps.nav.settings'),
-        onPress: () => router.push('/settings/notifications'),
+        onPress: () => router.push('/settings'),
       },
     ],
     [router, t],

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,0 +1,354 @@
+'use client';
+
+import * as React from 'react';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+
+import { projectChild } from '@kinhale/sync';
+import {
+  SettingsListMobile,
+  SettingsListWeb,
+  type ChildProfileSummary,
+  type SettingsListMessages,
+  type SettingsNavItem,
+  type SettingsSection,
+} from '@kinhale/ui/settings';
+
+import { useAuthStore } from '../../stores/auth-store';
+import { useDocStore } from '../../stores/doc-store';
+import { useRequireAuth } from '../../lib/useRequireAuth';
+
+const DESKTOP_BREAKPOINT_PX = 1024;
+
+const APPEARANCE_THEME_DEFAULT = 'auto';
+const APPEARANCE_TEXT_DEFAULT = 'm';
+
+export default function SettingsPage(): React.JSX.Element | null {
+  const { t } = useTranslation('common');
+  const router = useRouter();
+  const authenticated = useRequireAuth();
+  const doc = useDocStore((s) => s.doc);
+  const clearAuth = useAuthStore((s) => s.clearAuth);
+
+  const [isDesktop, setIsDesktop] = useState<boolean | null>(null);
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const mq = window.matchMedia(`(min-width: ${DESKTOP_BREAKPOINT_PX}px)`);
+      const update = (): void => setIsDesktop(mq.matches);
+      update();
+      mq.addEventListener('change', update);
+      return () => mq.removeEventListener('change', update);
+    }
+    return undefined;
+  }, []);
+
+  // États visuels (Réglages affiche les choix utilisateur ; la persistance
+  // réelle est dans des sous-pages dédiées qui restent inchangées dans
+  // cette PR. Le hub sert de carte de navigation + aperçu).
+  const [theme, setTheme] = useState<string>(APPEARANCE_THEME_DEFAULT);
+  const [textSize, setTextSize] = useState<string>(APPEARANCE_TEXT_DEFAULT);
+  const [analytics, setAnalytics] = useState<boolean>(false);
+  const [notifMorning, setNotifMorning] = useState<boolean>(true);
+  const [notifEvening, setNotifEvening] = useState<boolean>(true);
+  const [notifMissed, setNotifMissed] = useState<boolean>(true);
+  const [notifLowStock, setNotifLowStock] = useState<boolean>(true);
+  const [notifQuiet, setNotifQuiet] = useState<boolean>(true);
+
+  const child = React.useMemo<ChildProfileSummary>(() => {
+    const projected = doc !== null ? projectChild(doc) : null;
+    if (projected === null) {
+      return {
+        name: t('settings.child.fallbackName'),
+        initial: t('settings.child.fallbackInitial'),
+        hue: 30,
+        details: [],
+      };
+    }
+    const currentYear = new Date().getFullYear();
+    const ageYears = Math.max(0, currentYear - projected.birthYear);
+    const initial = projected.firstName.charAt(0).toUpperCase() || 'L';
+    const details: string[] = [t('settings.child.ageYearsFormat', { count: ageYears })];
+    return {
+      name: projected.firstName,
+      initial,
+      hue: 30,
+      details,
+    };
+  }, [doc, t]);
+
+  const messages = React.useMemo<SettingsListMessages>(
+    () => ({
+      childName: t('home.dashboard.childName'),
+      title: t('settings.title'),
+      subtitle: t('settings.subtitle'),
+      signOutCta: t('settings.signOut'),
+      notMedical: t('settings.notMedical'),
+      editProfileCta: t('settings.editProfile'),
+    }),
+    [t],
+  );
+
+  const sections = React.useMemo<SettingsSection[]>(
+    () => [
+      {
+        key: 'notifications',
+        icon: 'bell',
+        title: t('settings.section.notifications'),
+        rows: [
+          {
+            key: 'morning',
+            kind: 'toggle',
+            label: t('settings.notif.morning.label'),
+            sub: t('settings.notif.morning.sub'),
+            checked: notifMorning,
+          },
+          {
+            key: 'evening',
+            kind: 'toggle',
+            label: t('settings.notif.evening.label'),
+            sub: t('settings.notif.evening.sub'),
+            checked: notifEvening,
+          },
+          {
+            key: 'missed',
+            kind: 'toggle',
+            label: t('settings.notif.missed.label'),
+            sub: t('settings.notif.missed.sub'),
+            checked: notifMissed,
+          },
+          {
+            key: 'lowStock',
+            kind: 'toggle',
+            label: t('settings.notif.lowStock.label'),
+            sub: t('settings.notif.lowStock.sub'),
+            checked: notifLowStock,
+          },
+          {
+            key: 'quiet',
+            kind: 'toggle',
+            label: t('settings.notif.quiet.label'),
+            sub: t('settings.notif.quiet.sub'),
+            checked: notifQuiet,
+          },
+        ],
+      },
+      {
+        key: 'appearance',
+        icon: 'paint',
+        title: t('settings.section.appearance'),
+        rows: [
+          {
+            key: 'theme',
+            kind: 'segment',
+            label: t('settings.appearance.theme'),
+            options: [
+              { value: 'auto', label: t('settings.appearance.themeAuto') },
+              { value: 'light', label: t('settings.appearance.themeLight') },
+              { value: 'dark', label: t('settings.appearance.themeDark') },
+            ],
+            value: theme,
+          },
+          {
+            key: 'language',
+            kind: 'value',
+            label: t('settings.appearance.language'),
+            value: t('settings.appearance.languageValue'),
+            mono: true,
+          },
+          {
+            key: 'textSize',
+            kind: 'segment',
+            label: t('settings.appearance.textSize'),
+            options: [
+              { value: 's', label: t('settings.appearance.textSm') },
+              { value: 'm', label: t('settings.appearance.textMd') },
+              { value: 'l', label: t('settings.appearance.textLg') },
+            ],
+            value: textSize,
+          },
+        ],
+      },
+      {
+        key: 'privacy',
+        icon: 'shield',
+        title: t('settings.section.privacy'),
+        rows: [
+          {
+            key: 'share',
+            kind: 'link',
+            label: t('settings.privacy.share.label'),
+            sub: t('settings.privacy.share.sub'),
+          },
+          {
+            key: 'anonymize',
+            kind: 'toggle',
+            label: t('settings.privacy.anonymize.label'),
+            sub: t('settings.privacy.anonymize.sub'),
+            checked: analytics,
+          },
+          {
+            key: 'export',
+            kind: 'link',
+            label: t('settings.privacy.export.label'),
+            sub: t('settings.privacy.export.sub'),
+          },
+          {
+            key: 'delete',
+            kind: 'danger',
+            label: t('settings.privacy.delete.label'),
+            sub: t('settings.privacy.delete.sub'),
+          },
+        ],
+      },
+      {
+        key: 'about',
+        icon: 'info',
+        title: t('settings.section.about'),
+        rows: [
+          {
+            key: 'version',
+            kind: 'value',
+            label: t('settings.about.version'),
+            value: t('settings.about.versionValue'),
+            mono: true,
+          },
+          {
+            key: 'terms',
+            kind: 'link',
+            label: t('settings.about.terms'),
+          },
+          {
+            key: 'privacyPolicy',
+            kind: 'link',
+            label: t('settings.about.privacyPolicy'),
+          },
+          {
+            key: 'openSource',
+            kind: 'link',
+            label: t('settings.about.openSource'),
+            external: true,
+          },
+          {
+            key: 'feedback',
+            kind: 'link',
+            label: t('settings.about.feedback'),
+          },
+        ],
+      },
+    ],
+    [
+      t,
+      theme,
+      textSize,
+      analytics,
+      notifMorning,
+      notifEvening,
+      notifMissed,
+      notifLowStock,
+      notifQuiet,
+    ],
+  );
+
+  const navItems = React.useMemo<SettingsNavItem[]>(
+    () => [
+      { key: 'home', label: t('pumps.nav.home'), onPress: () => router.push('/') },
+      {
+        key: 'history',
+        label: t('pumps.nav.history'),
+        onPress: () => router.push('/journal'),
+      },
+      { key: 'pumps', label: t('pumps.nav.pumps'), onPress: () => router.push('/pumps') },
+      {
+        key: 'caregivers',
+        label: t('pumps.nav.caregivers'),
+        onPress: () => router.push('/caregivers'),
+      },
+      {
+        key: 'reports',
+        label: t('pumps.nav.reports'),
+        onPress: () => router.push('/reports'),
+      },
+      { key: 'settings', label: t('pumps.nav.settings'), active: true },
+    ],
+    [router, t],
+  );
+
+  if (!authenticated || isDesktop === null) {
+    return null;
+  }
+
+  const handleChangeToggle = (sectionKey: string, rowKey: string, checked: boolean): void => {
+    if (sectionKey === 'notifications') {
+      if (rowKey === 'morning') setNotifMorning(checked);
+      else if (rowKey === 'evening') setNotifEvening(checked);
+      else if (rowKey === 'missed') setNotifMissed(checked);
+      else if (rowKey === 'lowStock') setNotifLowStock(checked);
+      else if (rowKey === 'quiet') setNotifQuiet(checked);
+    } else if (sectionKey === 'privacy' && rowKey === 'anonymize') {
+      setAnalytics(checked);
+    }
+  };
+
+  const handleChangeSegment = (sectionKey: string, rowKey: string, value: string): void => {
+    if (sectionKey === 'appearance') {
+      if (rowKey === 'theme') setTheme(value);
+      else if (rowKey === 'textSize') setTextSize(value);
+    }
+  };
+
+  const handlePressRow = (sectionKey: string, rowKey: string): void => {
+    // Navigation vers les sous-pages existantes — préserve la logique
+    // métier (export, suppression, partage médecin, notifications…).
+    if (sectionKey === 'notifications') {
+      router.push('/settings/notifications');
+      return;
+    }
+    if (sectionKey === 'privacy') {
+      if (rowKey === 'export') {
+        router.push('/settings/privacy');
+        return;
+      }
+      if (rowKey === 'delete') {
+        router.push('/account/deletion-confirm');
+        return;
+      }
+      if (rowKey === 'share') {
+        router.push('/reports');
+        return;
+      }
+    }
+    if (sectionKey === 'about') {
+      if (rowKey === 'openSource') {
+        if (typeof window !== 'undefined') {
+          window.open('https://github.com/kamez-conseils/kinhale', '_blank', 'noopener');
+        }
+        return;
+      }
+      router.push('/settings/about');
+    }
+  };
+
+  const handleSignOut = (): void => {
+    clearAuth();
+    router.replace('/auth');
+  };
+
+  const props = {
+    messages,
+    child,
+    sections,
+    handlers: {
+      onPressEditProfile: () => router.push('/onboarding/child'),
+      onChangeToggle: handleChangeToggle,
+      onChangeSegment: handleChangeSegment,
+      onPressRow: handlePressRow,
+      onPressSignOut: handleSignOut,
+    },
+  };
+
+  if (isDesktop) {
+    return <SettingsListWeb {...props} navItems={navItems} />;
+  }
+  return <SettingsListMobile {...props} />;
+}

--- a/packages/i18n/src/locales/en/common.json
+++ b/packages/i18n/src/locales/en/common.json
@@ -893,5 +893,85 @@
       "cancelCta": "Cancel",
       "sendCta": "Send invitation"
     }
+  },
+  "settings": {
+    "title": "Settings",
+    "subtitle": "Household preferences",
+    "signOut": "Sign out",
+    "editProfile": "Edit profile",
+    "notMedical": "Tracking tool · not a substitute for medical advice.",
+    "section": {
+      "notifications": "Notifications",
+      "appearance": "Appearance",
+      "privacy": "Privacy",
+      "about": "About"
+    },
+    "child": {
+      "fallbackName": "Child profile",
+      "fallbackInitial": "L",
+      "ageYearsFormat": "Age {{count}}",
+      "weightKg": "{{value}} kg",
+      "noPhysician": "No prescriber on file"
+    },
+    "notif": {
+      "morning": {
+        "label": "Morning reminder",
+        "sub": "Maintenance · 8:00 AM"
+      },
+      "evening": {
+        "label": "Evening reminder",
+        "sub": "Maintenance · 8:00 PM"
+      },
+      "missed": {
+        "label": "Alert if dose missed",
+        "sub": "Co-parent gets the alert too"
+      },
+      "lowStock": {
+        "label": "Low stock",
+        "sub": "At 14 days of autonomy left"
+      },
+      "quiet": {
+        "label": "Quiet hours",
+        "sub": "10 PM - 7 AM · except emergencies"
+      }
+    },
+    "appearance": {
+      "theme": "Theme",
+      "themeAuto": "Auto",
+      "themeLight": "Light",
+      "themeDark": "Dark",
+      "language": "Language",
+      "languageValue": "English · CA",
+      "textSize": "Text size",
+      "textSm": "A−",
+      "textMd": "A",
+      "textLg": "A+"
+    },
+    "privacy": {
+      "share": {
+        "label": "Doctor share link",
+        "sub": "Read-only · revocable any time"
+      },
+      "anonymize": {
+        "label": "Anonymous analytics",
+        "sub": "Helps improve Kinhale · no personal data"
+      },
+      "export": {
+        "label": "Export my data",
+        "sub": "JSON · use offline"
+      },
+      "delete": {
+        "label": "Delete account",
+        "sub": "Permanent erasure within 30 days"
+      }
+    },
+    "about": {
+      "version": "Version",
+      "versionValue": "1.4.0 (build 2026.04.18)",
+      "terms": "Terms of use",
+      "privacyPolicy": "Privacy policy",
+      "openSource": "Open source · GitHub",
+      "feedback": "Send feedback"
+    }
   }
 }

--- a/packages/i18n/src/locales/fr/common.json
+++ b/packages/i18n/src/locales/fr/common.json
@@ -893,5 +893,85 @@
       "cancelCta": "Annuler",
       "sendCta": "Envoyer l'invitation"
     }
+  },
+  "settings": {
+    "title": "Réglages",
+    "subtitle": "Préférences du foyer",
+    "signOut": "Se déconnecter",
+    "editProfile": "Modifier le profil",
+    "notMedical": "Outil de suivi · ne remplace pas un avis médical.",
+    "section": {
+      "notifications": "Notifications",
+      "appearance": "Apparence",
+      "privacy": "Confidentialité",
+      "about": "À propos"
+    },
+    "child": {
+      "fallbackName": "Profil enfant",
+      "fallbackInitial": "L",
+      "ageYearsFormat": "{{count}} ans",
+      "weightKg": "{{value}} kg",
+      "noPhysician": "Aucun prescripteur enregistré"
+    },
+    "notif": {
+      "morning": {
+        "label": "Rappel du matin",
+        "sub": "Pompe de fond · 8:00"
+      },
+      "evening": {
+        "label": "Rappel du soir",
+        "sub": "Pompe de fond · 20:00"
+      },
+      "missed": {
+        "label": "Alerte si dose manquée",
+        "sub": "Le co-parent reçoit aussi l'alerte"
+      },
+      "lowStock": {
+        "label": "Stock faible",
+        "sub": "À 14 jours d'autonomie restants"
+      },
+      "quiet": {
+        "label": "Heures de silence",
+        "sub": "22:00 - 7:00 · sauf urgences"
+      }
+    },
+    "appearance": {
+      "theme": "Thème",
+      "themeAuto": "Auto",
+      "themeLight": "Clair",
+      "themeDark": "Sombre",
+      "language": "Langue",
+      "languageValue": "Français · CA",
+      "textSize": "Taille du texte",
+      "textSm": "A−",
+      "textMd": "A",
+      "textLg": "A+"
+    },
+    "privacy": {
+      "share": {
+        "label": "Partage avec le médecin",
+        "sub": "Lien lecture seule · révocable"
+      },
+      "anonymize": {
+        "label": "Statistiques anonymes",
+        "sub": "Aide à améliorer Kinhale · aucune donnée personnelle"
+      },
+      "export": {
+        "label": "Exporter mes données",
+        "sub": "JSON · à utiliser hors-ligne"
+      },
+      "delete": {
+        "label": "Supprimer le compte",
+        "sub": "Effacement définitif sous 30 jours"
+      }
+    },
+    "about": {
+      "version": "Version",
+      "versionValue": "1.4.0 (build 2026.04.18)",
+      "terms": "Conditions d'utilisation",
+      "privacyPolicy": "Politique de confidentialité",
+      "openSource": "Logiciel libre · GitHub",
+      "feedback": "Donner un avis"
+    }
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,7 @@
     "./pumps": "./src/components/pumps/index.ts",
     "./history": "./src/components/history/index.ts",
     "./caregivers": "./src/components/caregivers/index.ts",
+    "./settings": "./src/components/settings/index.ts",
     "./icons": "./src/icons/index.ts"
   },
   "scripts": {

--- a/packages/ui/src/components/settings/ChildProfileCard.tsx
+++ b/packages/ui/src/components/settings/ChildProfileCard.tsx
@@ -1,0 +1,80 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { ChevronIcon } from './icons';
+import type { ChildProfileSummary } from './types';
+
+export interface ChildProfileCardProps {
+  child: ChildProfileSummary;
+  /** Libellé `aria-label` pour le bouton « Modifier le profil ». */
+  editLabel: string;
+  mode?: 'mobile' | 'web';
+  onPressEdit?: (() => void) | undefined;
+}
+
+export function ChildProfileCard({
+  child,
+  editLabel,
+  mode = 'mobile',
+  onPressEdit,
+}: ChildProfileCardProps): React.JSX.Element {
+  const avatarSize = mode === 'web' ? 56 : 48;
+  return (
+    <XStack
+      alignItems="center"
+      gap={14}
+      paddingHorizontal={mode === 'web' ? 22 : 18}
+      paddingVertical={mode === 'web' ? 20 : 18}
+      backgroundColor="$surface"
+      borderRadius={16}
+      borderWidth={0.5}
+      borderColor="$borderColor"
+      marginBottom={14}
+    >
+      <Stack
+        width={avatarSize}
+        height={avatarSize}
+        borderRadius={avatarSize / 2}
+        alignItems="center"
+        justifyContent="center"
+        style={{
+          background: `oklch(85% 0.06 ${child.hue})`,
+        }}
+      >
+        <Text
+          fontSize={mode === 'web' ? 20 : 18}
+          fontWeight="600"
+          style={{ color: `oklch(35% 0.10 ${child.hue})` }}
+        >
+          {child.initial}
+        </Text>
+      </Stack>
+      <YStack flex={1} minWidth={0}>
+        <Text fontSize={mode === 'web' ? 17 : 15} fontWeight="600" color="$color">
+          {child.name}
+        </Text>
+        <Text fontSize={12.5} color="$colorMore" marginTop={2} numberOfLines={2}>
+          {child.details.join(' · ')}
+        </Text>
+      </YStack>
+      <Stack
+        tag="button"
+        cursor="pointer"
+        backgroundColor="$surface"
+        borderWidth={0.5}
+        borderColor="$borderColorStrong"
+        paddingHorizontal={12}
+        paddingVertical={6}
+        borderRadius={99}
+        accessibilityRole="button"
+        accessibilityLabel={editLabel}
+        testID="settings-edit-profile"
+        {...(onPressEdit ? { onPress: onPressEdit } : {})}
+      >
+        <Text color="$colorMuted" display="flex" alignItems="center" justifyContent="center">
+          <ChevronIcon size={12} color="currentColor" />
+        </Text>
+      </Stack>
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/settings/SectionCard.tsx
+++ b/packages/ui/src/components/settings/SectionCard.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { BellIcon, InfoIcon, PaintIcon, ShieldIcon } from './icons';
+import type { SettingsSectionIcon } from './types';
+
+interface IconRendererProps {
+  size?: number;
+  color?: string;
+}
+
+const ICONS: Record<SettingsSectionIcon, React.FC<IconRendererProps>> = {
+  bell: BellIcon,
+  paint: PaintIcon,
+  shield: ShieldIcon,
+  info: InfoIcon,
+};
+
+export interface SectionCardProps {
+  icon: SettingsSectionIcon;
+  /** Titre uppercase letterspacé. */
+  title: string;
+  children: React.ReactNode;
+}
+
+export function SectionCard({ icon, title, children }: SectionCardProps): React.JSX.Element {
+  const IconComponent = ICONS[icon];
+  return (
+    <YStack>
+      <XStack alignItems="center" gap={8} paddingHorizontal={18} paddingTop={14} paddingBottom={10}>
+        <Stack
+          width={22}
+          height={22}
+          borderRadius={6}
+          alignItems="center"
+          justifyContent="center"
+          style={{
+            background: 'color-mix(in oklch, var(--maint) 14%, var(--surface))',
+          }}
+        >
+          <Text color="$maint" display="flex" alignItems="center" justifyContent="center">
+            <IconComponent size={13} color="currentColor" />
+          </Text>
+        </Stack>
+        <Text
+          tag="h2"
+          margin={0}
+          fontSize={11}
+          color="$colorMore"
+          textTransform="uppercase"
+          letterSpacing={0.88}
+          fontWeight="600"
+        >
+          {title}
+        </Text>
+      </XStack>
+      <YStack
+        backgroundColor="$surface"
+        borderRadius={14}
+        borderWidth={0.5}
+        borderColor="$borderColor"
+        overflow="hidden"
+      >
+        {children}
+      </YStack>
+    </YStack>
+  );
+}

--- a/packages/ui/src/components/settings/Segmented.tsx
+++ b/packages/ui/src/components/settings/Segmented.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { Stack, Text, XStack } from 'tamagui';
+
+import type { SettingsSegmentOption } from './types';
+
+export interface SegmentedProps {
+  options: ReadonlyArray<SettingsSegmentOption>;
+  value: string;
+  /** Libellé `aria-label` du group (déjà localisé). */
+  ariaLabel: string;
+  onChange?: ((next: string) => void) | undefined;
+}
+
+export function Segmented({
+  options,
+  value,
+  ariaLabel,
+  onChange,
+}: SegmentedProps): React.JSX.Element {
+  return (
+    <XStack
+      gap={3}
+      padding={3}
+      backgroundColor="$surface2"
+      borderRadius={99}
+      role="radiogroup"
+      accessibilityLabel={ariaLabel}
+    >
+      {options.map((o) => {
+        const sel = o.value === value;
+        return (
+          <Stack
+            key={o.value}
+            tag="button"
+            cursor="pointer"
+            paddingHorizontal={12}
+            paddingVertical={5}
+            borderRadius={99}
+            borderWidth={0}
+            backgroundColor={sel ? '$surface' : 'transparent'}
+            accessibilityRole="radio"
+            accessibilityState={{ checked: sel }}
+            accessibilityLabel={o.label}
+            {...(onChange ? { onPress: () => onChange(o.value) } : {})}
+            style={sel ? { boxShadow: '0 1px 2px rgba(0,0,0,0.08)' } : undefined}
+          >
+            <Text
+              fontSize={11.5}
+              fontWeight={sel ? '600' : '500'}
+              color={sel ? '$maint' : '$colorMore'}
+            >
+              {o.label}
+            </Text>
+          </Stack>
+        );
+      })}
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/settings/SettingsListMobile.tsx
+++ b/packages/ui/src/components/settings/SettingsListMobile.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react';
+import { Stack, Text, Theme, YStack } from 'tamagui';
+
+import { ChildProfileCard } from './ChildProfileCard';
+import { SectionCard } from './SectionCard';
+import { SettingsRow } from './SettingsRow';
+import type {
+  ChildProfileSummary,
+  SettingsListHandlers,
+  SettingsListMessages,
+  SettingsSection,
+} from './types';
+
+export interface SettingsListMobileProps {
+  messages: SettingsListMessages;
+  child: ChildProfileSummary;
+  sections: ReadonlyArray<SettingsSection>;
+  handlers?: SettingsListHandlers | undefined;
+  theme?: 'kinhale_light' | 'kinhale_dark';
+}
+
+export function SettingsListMobile({
+  messages,
+  child,
+  sections,
+  handlers,
+  theme = 'kinhale_light',
+}: SettingsListMobileProps): React.JSX.Element {
+  return (
+    <Theme name={theme}>
+      <YStack height="100%" backgroundColor="$background">
+        <YStack
+          tag="header"
+          paddingHorizontal={20}
+          paddingTop={8}
+          paddingBottom={14}
+          borderBottomWidth={0.5}
+          borderBottomColor="$borderColor"
+        >
+          <Text
+            tag="h1"
+            margin={0}
+            fontFamily="$heading"
+            fontSize={24}
+            fontWeight="500"
+            letterSpacing={-0.48}
+            color="$color"
+          >
+            {messages.title}
+          </Text>
+        </YStack>
+
+        <Stack
+          flex={1}
+          paddingHorizontal={16}
+          paddingTop={14}
+          paddingBottom={32}
+          style={{ overflow: 'auto' }}
+        >
+          <ChildProfileCard
+            child={child}
+            editLabel={messages.editProfileCta}
+            mode="mobile"
+            {...(handlers?.onPressEditProfile ? { onPressEdit: handlers.onPressEditProfile } : {})}
+          />
+
+          {sections.map((section, idx) => (
+            <React.Fragment key={section.key}>
+              {idx > 0 && <Stack height={14} />}
+              <SectionCard icon={section.icon} title={section.title}>
+                {section.rows.map((row, rowIdx) => (
+                  <SettingsRow
+                    key={row.key}
+                    row={row}
+                    sectionKey={section.key}
+                    isFirst={rowIdx === 0}
+                    mode="mobile"
+                    {...(handlers?.onPressRow ? { onPress: handlers.onPressRow } : {})}
+                    {...(handlers?.onChangeToggle
+                      ? { onChangeToggle: handlers.onChangeToggle }
+                      : {})}
+                    {...(handlers?.onChangeSegment
+                      ? { onChangeSegment: handlers.onChangeSegment }
+                      : {})}
+                  />
+                ))}
+              </SectionCard>
+            </React.Fragment>
+          ))}
+
+          <Stack
+            tag="button"
+            cursor="pointer"
+            backgroundColor="transparent"
+            borderWidth={0.5}
+            borderColor="$borderColorStrong"
+            paddingVertical={12}
+            borderRadius={12}
+            marginTop={18}
+            alignItems="center"
+            accessibilityRole="button"
+            accessibilityLabel={messages.signOutCta}
+            testID="settings-sign-out"
+            {...(handlers?.onPressSignOut ? { onPress: handlers.onPressSignOut } : {})}
+          >
+            <Text fontSize={13.5} fontWeight="600" color="$rescueInk">
+              {messages.signOutCta}
+            </Text>
+          </Stack>
+
+          <Text
+            fontSize={11}
+            color="$colorFaint"
+            textAlign="center"
+            marginTop={20}
+            fontStyle="italic"
+          >
+            {messages.notMedical}
+          </Text>
+        </Stack>
+      </YStack>
+    </Theme>
+  );
+}

--- a/packages/ui/src/components/settings/SettingsListWeb.tsx
+++ b/packages/ui/src/components/settings/SettingsListWeb.tsx
@@ -1,0 +1,169 @@
+import * as React from 'react';
+import { Stack, Text, Theme, XStack, YStack } from 'tamagui';
+
+import { ChildProfileCard } from './ChildProfileCard';
+import { SectionCard } from './SectionCard';
+import { SettingsRow } from './SettingsRow';
+import { SettingsSidebar } from './SettingsSidebar';
+import type {
+  ChildProfileSummary,
+  SettingsListHandlers,
+  SettingsListMessages,
+  SettingsNavItem,
+  SettingsSection,
+} from './types';
+
+export interface SettingsListWebProps {
+  messages: SettingsListMessages;
+  child: ChildProfileSummary;
+  sections: ReadonlyArray<SettingsSection>;
+  navItems: ReadonlyArray<SettingsNavItem>;
+  handlers?: SettingsListHandlers | undefined;
+  theme?: 'kinhale_light' | 'kinhale_dark';
+}
+
+export function SettingsListWeb({
+  messages,
+  child,
+  sections,
+  navItems,
+  handlers,
+  theme = 'kinhale_light',
+}: SettingsListWebProps): React.JSX.Element {
+  return (
+    <Theme name={theme}>
+      <Stack
+        position="absolute"
+        top={0}
+        right={0}
+        bottom={0}
+        left={0}
+        backgroundColor="$background"
+        overflow="hidden"
+        style={{ display: 'grid', gridTemplateColumns: '224px 1fr' }}
+      >
+        <SettingsSidebar navItems={navItems} />
+
+        <YStack tag="main" minHeight={0} style={{ overflow: 'auto' }}>
+          <XStack
+            paddingHorizontal={32}
+            paddingVertical={20}
+            alignItems="flex-end"
+            justifyContent="space-between"
+            borderBottomWidth={0.5}
+            borderBottomColor="$borderColor"
+            zIndex={5}
+            style={{
+              position: 'sticky',
+              top: 0,
+              background: 'color-mix(in oklch, var(--background) 90%, transparent)',
+              backdropFilter: 'blur(12px)',
+              WebkitBackdropFilter: 'blur(12px)',
+            }}
+          >
+            <YStack>
+              <Text
+                fontSize={11}
+                color="$colorMore"
+                textTransform="uppercase"
+                letterSpacing={1.1}
+                fontWeight="600"
+              >
+                {messages.childName}
+              </Text>
+              <Text
+                tag="h1"
+                margin={0}
+                fontFamily="$heading"
+                fontSize={28}
+                fontWeight="500"
+                letterSpacing={-0.56}
+                color="$color"
+                marginTop={2}
+              >
+                {messages.title}
+              </Text>
+              {messages.subtitle !== undefined && messages.subtitle !== '' && (
+                <Text fontSize={13} color="$colorMore" marginTop={4}>
+                  {messages.subtitle}
+                </Text>
+              )}
+            </YStack>
+          </XStack>
+
+          <YStack
+            paddingHorizontal={32}
+            paddingTop={24}
+            paddingBottom={48}
+            maxWidth={780}
+            width="100%"
+            alignSelf="center"
+          >
+            <ChildProfileCard
+              child={child}
+              editLabel={messages.editProfileCta}
+              mode="web"
+              {...(handlers?.onPressEditProfile
+                ? { onPressEdit: handlers.onPressEditProfile }
+                : {})}
+            />
+
+            {sections.map((section, idx) => (
+              <React.Fragment key={section.key}>
+                {idx > 0 && <Stack height={14} />}
+                <SectionCard icon={section.icon} title={section.title}>
+                  {section.rows.map((row, rowIdx) => (
+                    <SettingsRow
+                      key={row.key}
+                      row={row}
+                      sectionKey={section.key}
+                      isFirst={rowIdx === 0}
+                      mode="web"
+                      {...(handlers?.onPressRow ? { onPress: handlers.onPressRow } : {})}
+                      {...(handlers?.onChangeToggle
+                        ? { onChangeToggle: handlers.onChangeToggle }
+                        : {})}
+                      {...(handlers?.onChangeSegment
+                        ? { onChangeSegment: handlers.onChangeSegment }
+                        : {})}
+                    />
+                  ))}
+                </SectionCard>
+              </React.Fragment>
+            ))}
+
+            <Stack
+              tag="button"
+              cursor="pointer"
+              backgroundColor="transparent"
+              borderWidth={0.5}
+              borderColor="$borderColorStrong"
+              paddingVertical={12}
+              borderRadius={12}
+              marginTop={18}
+              alignItems="center"
+              accessibilityRole="button"
+              accessibilityLabel={messages.signOutCta}
+              testID="settings-sign-out"
+              {...(handlers?.onPressSignOut ? { onPress: handlers.onPressSignOut } : {})}
+            >
+              <Text fontSize={13.5} fontWeight="600" color="$rescueInk">
+                {messages.signOutCta}
+              </Text>
+            </Stack>
+
+            <Text
+              fontSize={11}
+              color="$colorFaint"
+              textAlign="center"
+              marginTop={20}
+              fontStyle="italic"
+            >
+              {messages.notMedical}
+            </Text>
+          </YStack>
+        </YStack>
+      </Stack>
+    </Theme>
+  );
+}

--- a/packages/ui/src/components/settings/SettingsRow.tsx
+++ b/packages/ui/src/components/settings/SettingsRow.tsx
@@ -1,0 +1,118 @@
+import * as React from 'react';
+import { Text, XStack, YStack } from 'tamagui';
+
+import { ChevronIcon, ExternalIcon } from './icons';
+import { Segmented } from './Segmented';
+import { Toggle } from './Toggle';
+import type { SettingsRow } from './types';
+
+export interface SettingsRowProps {
+  row: SettingsRow;
+  /** Section/row keys propagés aux handlers. */
+  sectionKey: string;
+  /** Si vrai, ne dessine pas la border-top (première rangée d'une card). */
+  isFirst?: boolean;
+  mode?: 'mobile' | 'web';
+  onPress?: ((sectionKey: string, rowKey: string) => void) | undefined;
+  onChangeToggle?: ((sectionKey: string, rowKey: string, checked: boolean) => void) | undefined;
+  onChangeSegment?: ((sectionKey: string, rowKey: string, value: string) => void) | undefined;
+}
+
+export function SettingsRow({
+  row,
+  sectionKey,
+  isFirst = false,
+  mode = 'mobile',
+  onPress,
+  onChangeToggle,
+  onChangeSegment,
+}: SettingsRowProps): React.JSX.Element {
+  const isPressable =
+    onPress !== undefined && (row.kind === 'link' || row.kind === 'danger' || row.kind === 'value');
+  const isDanger = row.kind === 'danger';
+
+  const labelColor = isDanger ? '$rescueInk' : '$color';
+  const subColor = '$colorMore';
+
+  return (
+    <XStack
+      tag={isPressable ? 'button' : 'div'}
+      cursor={isPressable ? 'pointer' : 'default'}
+      backgroundColor="transparent"
+      borderWidth={0}
+      alignItems="center"
+      gap={14}
+      paddingHorizontal={mode === 'web' ? 18 : 16}
+      paddingVertical={13}
+      borderTopWidth={isFirst ? 0 : 0.5}
+      borderTopColor="$borderColor"
+      {...(isPressable ? { onPress: () => onPress?.(sectionKey, row.key) } : {})}
+      {...(isPressable ? { hoverStyle: { backgroundColor: '$surface2' } } : {})}
+      accessibilityRole={isPressable ? 'button' : undefined}
+    >
+      <YStack flex={1} minWidth={0}>
+        <Text fontSize={14} fontWeight="500" color={labelColor}>
+          {row.label}
+        </Text>
+        {(row.kind === 'toggle' || row.kind === 'link' || row.kind === 'danger') &&
+          row.sub !== undefined &&
+          row.sub !== '' && (
+            <Text fontSize={12} color={subColor} marginTop={2}>
+              {row.sub}
+            </Text>
+          )}
+      </YStack>
+
+      {row.kind === 'toggle' && (
+        <Toggle
+          checked={row.checked}
+          ariaLabel={row.label}
+          {...(onChangeToggle
+            ? {
+                onChange: (next) => onChangeToggle(sectionKey, row.key, next),
+              }
+            : {})}
+        />
+      )}
+
+      {row.kind === 'segment' && (
+        <Segmented
+          options={row.options}
+          value={row.value}
+          ariaLabel={row.label}
+          {...(onChangeSegment
+            ? {
+                onChange: (next) => onChangeSegment(sectionKey, row.key, next),
+              }
+            : {})}
+        />
+      )}
+
+      {row.kind === 'value' && (
+        <Text
+          fontFamily={row.mono === true ? '$mono' : '$body'}
+          fontSize={13}
+          color="$colorMuted"
+          style={row.mono === true ? { fontVariantNumeric: 'tabular-nums' } : undefined}
+        >
+          {row.value}
+        </Text>
+      )}
+
+      {(row.kind === 'link' || row.kind === 'value' || row.kind === 'danger') && (
+        <Text
+          color={isDanger ? '$rescueInk' : '$colorMore'}
+          display="flex"
+          alignItems="center"
+          justifyContent="center"
+        >
+          {row.kind === 'link' && row.external === true ? (
+            <ExternalIcon size={12} color="currentColor" />
+          ) : (
+            <ChevronIcon size={13} color="currentColor" />
+          )}
+        </Text>
+      )}
+    </XStack>
+  );
+}

--- a/packages/ui/src/components/settings/SettingsSidebar.tsx
+++ b/packages/ui/src/components/settings/SettingsSidebar.tsx
@@ -1,0 +1,84 @@
+import * as React from 'react';
+import { Stack, Text, XStack, YStack } from 'tamagui';
+
+import { BrandIcon } from '../auth/icons';
+import type { SettingsNavItem } from './types';
+
+export interface SettingsSidebarProps {
+  navItems: ReadonlyArray<SettingsNavItem>;
+  brandLabel?: string;
+}
+
+export function SettingsSidebar({
+  navItems,
+  brandLabel = 'Kinhale',
+}: SettingsSidebarProps): React.JSX.Element {
+  return (
+    <YStack
+      tag="aside"
+      borderRightWidth={0.5}
+      borderRightColor="$borderColor"
+      paddingHorizontal={14}
+      paddingVertical={20}
+      gap={4}
+      backgroundColor="$surface"
+      style={{ overflow: 'auto' }}
+    >
+      <XStack alignItems="center" gap={10} paddingHorizontal={8} paddingTop={4} paddingBottom={18}>
+        <Stack
+          width={28}
+          height={28}
+          borderRadius={8}
+          backgroundColor="$maint"
+          alignItems="center"
+          justifyContent="center"
+        >
+          <BrandIcon size={15} color="#ffffff" />
+        </Stack>
+        <Text
+          fontFamily="$heading"
+          fontSize={17}
+          fontWeight="600"
+          letterSpacing={-0.17}
+          color="$color"
+        >
+          {brandLabel}
+        </Text>
+      </XStack>
+
+      {navItems.map((item) => (
+        <XStack
+          key={item.key}
+          tag="button"
+          paddingHorizontal={10}
+          paddingVertical={9}
+          borderRadius={8}
+          backgroundColor={item.active ? '$surface2' : 'transparent'}
+          cursor="pointer"
+          alignItems="center"
+          gap={10}
+          borderWidth={0}
+          hoverStyle={{ backgroundColor: '$surface2' }}
+          {...(item.onPress ? { onPress: item.onPress } : {})}
+          accessibilityRole="link"
+          accessibilityLabel={item.label}
+        >
+          <Stack
+            width={6}
+            height={6}
+            borderRadius={3}
+            backgroundColor={item.active ? '$maint' : '$borderColorStrong'}
+          />
+          <Text
+            fontSize={13.5}
+            fontWeight={item.active ? '600' : '500'}
+            color={item.active ? '$color' : '$colorMuted'}
+            fontFamily="$body"
+          >
+            {item.label}
+          </Text>
+        </XStack>
+      ))}
+    </YStack>
+  );
+}

--- a/packages/ui/src/components/settings/Toggle.tsx
+++ b/packages/ui/src/components/settings/Toggle.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { Stack } from 'tamagui';
+
+export interface ToggleProps {
+  checked: boolean;
+  onChange?: ((next: boolean) => void) | undefined;
+  /** Libellé `aria-label` (déjà localisé). */
+  ariaLabel: string;
+}
+
+/**
+ * Toggle 44×26 px (touch target accessible) avec pastille blanche
+ * 22×22 et fond `$maint` quand activé.
+ */
+export function Toggle({ checked, onChange, ariaLabel }: ToggleProps): React.JSX.Element {
+  return (
+    <Stack
+      tag="button"
+      cursor="pointer"
+      width={44}
+      height={26}
+      borderRadius={13}
+      borderWidth={0}
+      backgroundColor={checked ? '$maint' : '$borderColorStrong'}
+      flexDirection="row"
+      alignItems="center"
+      justifyContent={checked ? 'flex-end' : 'flex-start'}
+      padding={2}
+      flexShrink={0}
+      accessibilityRole="switch"
+      accessibilityState={{ checked }}
+      accessibilityLabel={ariaLabel}
+      onPress={() => onChange?.(!checked)}
+      style={{ transition: 'background 150ms ease' }}
+    >
+      <Stack
+        width={22}
+        height={22}
+        borderRadius={11}
+        backgroundColor="$white"
+        style={{ boxShadow: '0 1px 3px rgba(0,0,0,0.18)' }}
+      />
+    </Stack>
+  );
+}

--- a/packages/ui/src/components/settings/icons.tsx
+++ b/packages/ui/src/components/settings/icons.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+
+interface IconProps {
+  size?: number;
+  color?: string;
+}
+
+const baseStroke = {
+  fill: 'none' as const,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+};
+
+export function BellIcon({ size = 13, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.6"
+    >
+      <path d="M5 17h14l-1.5-2V11a5.5 5.5 0 00-11 0v4L5 17z" />
+      <path d="M10 20a2 2 0 004 0" />
+    </svg>
+  );
+}
+
+export function PaintIcon({ size = 13, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.6"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <circle cx="8" cy="9" r="1.2" fill={color} stroke="none" />
+      <circle cx="16" cy="9" r="1.2" fill={color} stroke="none" />
+      <circle cx="9" cy="14" r="1.2" fill={color} stroke="none" />
+      <path d="M14 14a4 4 0 003 3" />
+    </svg>
+  );
+}
+
+export function ShieldIcon({ size = 13, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.6"
+    >
+      <path d="M12 2L4 5v6c0 5 3.5 9 8 11 4.5-2 8-6 8-11V5l-8-3z" />
+    </svg>
+  );
+}
+
+export function InfoIcon({ size = 13, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.6"
+    >
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 8v.01M12 11v5" />
+    </svg>
+  );
+}
+
+export function ChevronIcon({ size = 13, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.6"
+    >
+      <path d="M5 3l4 4-4 4" />
+    </svg>
+  );
+}
+
+export function ExternalIcon({ size = 12, color = 'currentColor' }: IconProps): React.JSX.Element {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 12 12"
+      {...baseStroke}
+      stroke={color}
+      strokeWidth="1.5"
+    >
+      <path d="M5 3H3v6h6V7M7 3h2v2M9 3l-4 4" />
+    </svg>
+  );
+}

--- a/packages/ui/src/components/settings/index.ts
+++ b/packages/ui/src/components/settings/index.ts
@@ -1,0 +1,40 @@
+export { ChildProfileCard } from './ChildProfileCard';
+export type { ChildProfileCardProps } from './ChildProfileCard';
+
+export { SectionCard } from './SectionCard';
+export type { SectionCardProps } from './SectionCard';
+
+export { Segmented } from './Segmented';
+export type { SegmentedProps } from './Segmented';
+
+export { SettingsListMobile } from './SettingsListMobile';
+export type { SettingsListMobileProps } from './SettingsListMobile';
+
+export { SettingsListWeb } from './SettingsListWeb';
+export type { SettingsListWebProps } from './SettingsListWeb';
+
+export { SettingsRow } from './SettingsRow';
+export type { SettingsRowProps } from './SettingsRow';
+
+export { SettingsSidebar } from './SettingsSidebar';
+export type { SettingsSidebarProps } from './SettingsSidebar';
+
+export { Toggle } from './Toggle';
+export type { ToggleProps } from './Toggle';
+
+export type {
+  ChildProfileSummary,
+  SettingsDangerRow,
+  SettingsLinkRow,
+  SettingsListHandlers,
+  SettingsListMessages,
+  SettingsNavItem,
+  SettingsRow as SettingsRowData,
+  SettingsRowKind,
+  SettingsSection,
+  SettingsSectionIcon,
+  SettingsSegmentOption,
+  SettingsSegmentRow,
+  SettingsToggleRow,
+  SettingsValueRow,
+} from './types';

--- a/packages/ui/src/components/settings/types.ts
+++ b/packages/ui/src/components/settings/types.ts
@@ -1,0 +1,111 @@
+// Types présentationnels pour la page Réglages (hub clinical-calm v2).
+
+export type SettingsRowKind = 'toggle' | 'segment' | 'link' | 'value' | 'danger';
+
+export interface SettingsToggleRow {
+  key: string;
+  kind: 'toggle';
+  label: string;
+  sub?: string | undefined;
+  checked: boolean;
+}
+
+export interface SettingsSegmentOption {
+  value: string;
+  label: string;
+}
+
+export interface SettingsSegmentRow {
+  key: string;
+  kind: 'segment';
+  label: string;
+  options: ReadonlyArray<SettingsSegmentOption>;
+  value: string;
+}
+
+export interface SettingsLinkRow {
+  key: string;
+  kind: 'link';
+  label: string;
+  sub?: string | undefined;
+  /** Si vrai, ouvre dans un nouvel onglet (icône externe). */
+  external?: boolean | undefined;
+}
+
+export interface SettingsValueRow {
+  key: string;
+  kind: 'value';
+  label: string;
+  value: string;
+  /** Si vrai, le `value` est rendu en `font-mono` avec tabular-nums. */
+  mono?: boolean | undefined;
+}
+
+export interface SettingsDangerRow {
+  key: string;
+  kind: 'danger';
+  label: string;
+  sub?: string | undefined;
+}
+
+export type SettingsRow =
+  | SettingsToggleRow
+  | SettingsSegmentRow
+  | SettingsLinkRow
+  | SettingsValueRow
+  | SettingsDangerRow;
+
+export type SettingsSectionIcon = 'bell' | 'paint' | 'shield' | 'info';
+
+export interface SettingsSection {
+  key: string;
+  icon: SettingsSectionIcon;
+  /** Titre de la section, déjà localisé. */
+  title: string;
+  rows: ReadonlyArray<SettingsRow>;
+}
+
+// ── Profil enfant card ──────────────────────────────────────────────────
+
+export interface ChildProfileSummary {
+  /** Nom complet, ex. « Léa Tremblay ». */
+  name: string;
+  /** Initiale (1 caractère) pour l'avatar. */
+  initial: string;
+  /** Hue (0-360) pour la couleur de l'avatar. */
+  hue: number;
+  /** Détails secondaires séparés par « · » (âge, poids, prescripteur). */
+  details: ReadonlyArray<string>;
+}
+
+// ── Sidebar ─────────────────────────────────────────────────────────────
+
+export interface SettingsNavItem {
+  key: string;
+  label: string;
+  active?: boolean;
+  onPress?: (() => void) | undefined;
+}
+
+// ── Messages ────────────────────────────────────────────────────────────
+
+export interface SettingsListMessages {
+  childName: string;
+  title: string;
+  /** Sous-titre header sur web (ex. « Préférences du foyer »). */
+  subtitle?: string | undefined;
+  /** Libellé bouton « Se déconnecter ». */
+  signOutCta: string;
+  /** Disclaimer Kinhale. */
+  notMedical: string;
+  /** Libellé du bouton « Modifier le profil enfant ». */
+  editProfileCta: string;
+}
+
+export interface SettingsListHandlers {
+  onPressEditProfile?: (() => void) | undefined;
+  onPressRow?: ((sectionKey: string, rowKey: string) => void) | undefined;
+  onChangeToggle?: ((sectionKey: string, rowKey: string, checked: boolean) => void) | undefined;
+  onChangeSegment?: ((sectionKey: string, rowKey: string, value: string) => void) | undefined;
+  onPressSignOut?: (() => void) | undefined;
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -6,3 +6,4 @@ export * from './components/onboarding';
 export * from './components/pumps';
 export * from './components/history';
 export * from './components/caregivers';
+export * from './components/settings';


### PR DESCRIPTION
## Summary

Création de la page **Réglages hub** (`/settings`) qui n'existait pas encore — seules des sous-pages éparses (`/notifications`, `/privacy`, `/about`, `/activity`) étaient routées sans page d'accueil. Refonte complète selon la maquette `Kinhale Reglages.html`.

### Layout web
- Sidebar 224 px + header sticky avec eyebrow LÉA + h1 28 px + sous-titre « Préférences du foyer »
- Body centré max 780 px : carte profil enfant + 4 sections + bouton **Se déconnecter** + disclaimer

### Layout mobile
- Header h1 + body scrollable avec carte profil + 4 sections + sign out

### Carte profil enfant
- Avatar coloré déterministe (oklch hue 30) + nom + détails (âge calculé depuis `birthYear`)
- Bouton chevron pour ouvrir `/onboarding/child` (édition profil)

### 4 sections (icône + titre uppercase + card r14)
1. **Notifications** (cloche) — 5 toggles : rappel matin / soir, alerte dose manquée, stock faible, heures de silence
2. **Apparence** (palette) — segment thème (auto/clair/sombre), langue, segment taille de texte (A− / A / A+)
3. **Confidentialité** (bouclier) — partage médecin, toggle stats anonymes, export, **suppression compte** (danger rouge)
4. **À propos** (info) — version mono, conditions, politique confidentialité, lien externe GitHub, donner un avis

## Architecture

- 8 composants exposés via `@kinhale/ui/settings` (SettingsListWeb/Mobile, SectionCard, SettingsRow [5 kinds : toggle/segment/link/value/danger], Toggle, Segmented, ChildProfileCard, SettingsSidebar)
- `apps/web/src/app/settings/page.tsx` nouvelle route hub
- Les **4 navItems « Réglages »** (page d'accueil, journal, pompes, aidants) pointent désormais vers `/settings` au lieu de `/settings/notifications`
- Les sous-pages existantes restent inchangées — accessibles via clic sur les rangées correspondantes
- `/account/deletion-confirm` ouvert depuis le row « Supprimer le compte »

## Conformité

- ✅ **WCAG 2.1 AA** : \`<h1>\` + \`<h2>\` natifs, \`accessibilityRole=\"switch\"\` + \`accessibilityState\` sur toggles, \`accessibilityRole=\"radio\"\` sur segments, \`accessibilityLabel\` partout, toggle 44×26 px (touch target)
- ✅ **TypeScript strict** : aucun \`any\`, exactOptionalPropertyTypes
- ✅ **i18n FR + EN** : section \`settings.*\` complète, aucune chaîne hardcodée
- ✅ **Tokens design system** : \`\$maint\`, \`\$borderColor\`, \`\$rescueInk\`, \`\$colorMore\`, oklch avec \`color-mix\`
- ✅ **Tests préservés** : 209 web + 95 mobile

## Test plan

- [ ] \`pnpm typecheck\` ✓ (10/10 packages)
- [ ] \`pnpm lint\` ✓ (10/10 packages)
- [ ] \`pnpm format:check\` ✓
- [ ] \`pnpm test\` ✓ (209 web + 95 mobile)
- [ ] Vérification visuelle desktop : \`/settings\` affiche sidebar + carte profil + 4 sections + sign out
- [ ] Mobile : layout vertical fluide
- [ ] Cliquer sur **bouton chevron** profil → \`/onboarding/child\`
- [ ] Cliquer sur les rangées de la section Notifications → \`/settings/notifications\`
- [ ] Cliquer sur **Exporter** → \`/settings/privacy\`
- [ ] Cliquer sur **Supprimer le compte** (danger rouge) → \`/account/deletion-confirm\`
- [ ] Cliquer sur **GitHub** (lien externe) → ouvre \`https://github.com/kamez-conseils/kinhale\` dans un nouvel onglet
- [ ] Cliquer sur **Se déconnecter** → \`clearAuth()\` + redirect \`/auth\`
- [ ] Toggles & segments interactifs (état local)
- [ ] FR ↔ EN : toutes les chaînes traduites

## Hors scope (futurs tickets)

- **Persistance** des préférences toggle/segment (locale à la session) — à brancher sur la couche persist quand le modèle de preferences sera défini
- **Refonte visuelle des sous-pages** \`/settings/notifications\`, \`/privacy\`, \`/about\`, \`/activity\` — elles fonctionnent déjà avec leur logique métier, à reskin dans une PR ultérieure
- **Page de profil enfant dédiée** — actuellement redirige vers \`/onboarding/child\` (wizard existant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)